### PR TITLE
Rough out the basic type system.

### DIFF
--- a/tfprotov5/internal/toproto/attribute_path.go
+++ b/tfprotov5/internal/toproto/attribute_path.go
@@ -1,0 +1,58 @@
+package toproto
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
+)
+
+func AttributePath(in tfprotov5.AttributePath) tfplugin5.AttributePath {
+	return tfplugin5.AttributePath{
+		Steps: AttributePath_Steps(in.Steps),
+	}
+}
+
+func AttributePaths(in []*tfprotov5.AttributePath) []*tfplugin5.AttributePath {
+	resp := make([]*tfplugin5.AttributePath, 0, len(in))
+	for _, a := range in {
+		if a == nil {
+			resp = append(resp, nil)
+			continue
+		}
+		attr := AttributePath(*a)
+		resp = append(resp, &attr)
+	}
+	return resp
+}
+
+func AttributePath_Step(step tfprotov5.AttributePathStep) tfplugin5.AttributePath_Step {
+	var resp tfplugin5.AttributePath_Step
+	if step.AttributeName != "" {
+		resp.Selector = &tfplugin5.AttributePath_Step_AttributeName{
+			AttributeName: step.AttributeName,
+		}
+	}
+	if step.ElementKeyString != "" {
+		resp.Selector = &tfplugin5.AttributePath_Step_ElementKeyString{
+			ElementKeyString: step.ElementKeyString,
+		}
+	}
+	if step.ElementKeyInt != 0 {
+		resp.Selector = &tfplugin5.AttributePath_Step_ElementKeyInt{
+			ElementKeyInt: step.ElementKeyInt,
+		}
+	}
+	return resp
+}
+
+func AttributePath_Steps(in []*tfprotov5.AttributePathStep) []*tfplugin5.AttributePath_Step {
+	resp := make([]*tfplugin5.AttributePath_Step, 0, len(in))
+	for _, step := range in {
+		if step == nil {
+			resp = append(resp, nil)
+			continue
+		}
+		s := AttributePath_Step(*step)
+		resp = append(resp, &s)
+	}
+	return resp
+}

--- a/tfprotov5/internal/toproto/cty.go
+++ b/tfprotov5/internal/toproto/cty.go
@@ -1,0 +1,16 @@
+package toproto
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes"
+)
+
+func Cty(in tftypes.RawValue) tfplugin5.DynamicValue {
+	// TODO: figure out how to marshal tftypes.RawValue into DynamicValue
+	return tfplugin5.DynamicValue{}
+}
+
+func CtyType(in tftypes.Type) []byte {
+	// TODO: figure out how to marshal tftypes.Type into []byte
+	return nil
+}

--- a/tfprotov5/internal/toproto/data_source.go
+++ b/tfprotov5/internal/toproto/data_source.go
@@ -1,0 +1,49 @@
+package toproto
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
+)
+
+func ValidateDataSourceConfig_Request(in tfprotov5.ValidateDataSourceConfigRequest) tfplugin5.ValidateDataSourceConfig_Request {
+	resp := tfplugin5.ValidateDataSourceConfig_Request{
+		TypeName: in.TypeName,
+	}
+	if in.Config != nil {
+		config := Cty(*in.Config)
+		resp.Config = &config
+	}
+	return resp
+}
+
+func ValidateDataSourceConfig_Response(in tfprotov5.ValidateDataSourceConfigResponse) tfplugin5.ValidateDataSourceConfig_Response {
+	return tfplugin5.ValidateDataSourceConfig_Response{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+}
+
+func ReadDataSource_Request(in tfprotov5.ReadDataSourceRequest) tfplugin5.ReadDataSource_Request {
+	resp := tfplugin5.ReadDataSource_Request{
+		TypeName: in.TypeName,
+	}
+	if in.Config != nil {
+		config := Cty(*in.Config)
+		resp.Config = &config
+	}
+	if in.ProviderMeta != nil {
+		meta := Cty(*in.ProviderMeta)
+		resp.ProviderMeta = &meta
+	}
+	return resp
+}
+
+func ReadDataSource_Response(in tfprotov5.ReadDataSourceResponse) tfplugin5.ReadDataSource_Response {
+	resp := tfplugin5.ReadDataSource_Response{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+	if in.State != nil {
+		state := Cty(*in.State)
+		resp.State = &state
+	}
+	return resp
+}

--- a/tfprotov5/internal/toproto/diagnostic.go
+++ b/tfprotov5/internal/toproto/diagnostic.go
@@ -1,0 +1,36 @@
+package toproto
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
+)
+
+func Diagnostic(in tfprotov5.Diagnostic) tfplugin5.Diagnostic {
+	diag := tfplugin5.Diagnostic{
+		Severity: Diagnostic_Severity(in.Severity),
+		Summary:  in.Summary,
+		Detail:   in.Detail,
+	}
+	if in.Attribute != nil {
+		attr := AttributePath(*in.Attribute)
+		diag.Attribute = &attr
+	}
+	return diag
+}
+
+func Diagnostic_Severity(in tfprotov5.DiagnosticSeverity) tfplugin5.Diagnostic_Severity {
+	return tfplugin5.Diagnostic_Severity(in)
+}
+
+func Diagnostics(in []*tfprotov5.Diagnostic) []*tfplugin5.Diagnostic {
+	diagnostics := make([]*tfplugin5.Diagnostic, 0, len(in))
+	for _, diag := range in {
+		if diag == nil {
+			diagnostics = append(diagnostics, nil)
+			continue
+		}
+		d := Diagnostic(*diag)
+		diagnostics = append(diagnostics, &d)
+	}
+	return diagnostics
+}

--- a/tfprotov5/internal/toproto/provider.go
+++ b/tfprotov5/internal/toproto/provider.go
@@ -1,0 +1,89 @@
+package toproto
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
+)
+
+func GetProviderSchema_Request(in tfprotov5.GetProviderSchemaRequest) tfplugin5.GetProviderSchema_Request {
+	return tfplugin5.GetProviderSchema_Request{}
+}
+
+func GetProviderSchema_Response(in tfprotov5.GetProviderSchemaResponse) tfplugin5.GetProviderSchema_Response {
+	var resp tfplugin5.GetProviderSchema_Response
+	if in.Provider != nil {
+		schema := Schema(*in.Provider)
+		resp.Provider = &schema
+	}
+	if in.ProviderMeta != nil {
+		schema := Schema(*in.ProviderMeta)
+		resp.ProviderMeta = &schema
+	}
+	resp.ResourceSchemas = make(map[string]*tfplugin5.Schema, len(in.ResourceSchemas))
+	for k, v := range in.ResourceSchemas {
+		if v == nil {
+			resp.ResourceSchemas[k] = nil
+			continue
+		}
+		schema := Schema(*v)
+		resp.ResourceSchemas[k] = &schema
+	}
+	resp.DataSourceSchemas = make(map[string]*tfplugin5.Schema, len(in.DataSourceSchemas))
+	for k, v := range in.DataSourceSchemas {
+		if v == nil {
+			resp.DataSourceSchemas[k] = nil
+			continue
+		}
+		schema := Schema(*v)
+		resp.DataSourceSchemas[k] = &schema
+	}
+	resp.Diagnostics = Diagnostics(in.Diagnostics)
+	return resp
+}
+
+func PrepareProviderConfig_Request(in tfprotov5.PrepareProviderConfigRequest) tfplugin5.PrepareProviderConfig_Request {
+	resp := tfplugin5.PrepareProviderConfig_Request{}
+	if in.Config != nil {
+		config := Cty(*in.Config)
+		resp.Config = &config
+	}
+	return resp
+}
+
+func PrepareProviderConfig_Response(in tfprotov5.PrepareProviderConfigResponse) tfplugin5.PrepareProviderConfig_Response {
+	resp := tfplugin5.PrepareProviderConfig_Response{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+	if in.PreparedConfig != nil {
+		config := Cty(*in.PreparedConfig)
+		resp.PreparedConfig = &config
+	}
+	return resp
+}
+
+func Configure_Request(in tfprotov5.ConfigureProviderRequest) tfplugin5.Configure_Request {
+	resp := tfplugin5.Configure_Request{
+		TerraformVersion: in.TerraformVersion,
+	}
+	if in.Config != nil {
+		config := Cty(*in.Config)
+		resp.Config = &config
+	}
+	return resp
+}
+
+func Configure_Response(in tfprotov5.ConfigureProviderResponse) tfplugin5.Configure_Response {
+	return tfplugin5.Configure_Response{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+}
+
+func Stop_Request(in tfprotov5.StopProviderRequest) tfplugin5.Stop_Request {
+	return tfplugin5.Stop_Request{}
+}
+
+func Stop_Response(in tfprotov5.StopProviderResponse) tfplugin5.Stop_Response {
+	return tfplugin5.Stop_Response{
+		Error: in.Error,
+	}
+}

--- a/tfprotov5/internal/toproto/resource.go
+++ b/tfprotov5/internal/toproto/resource.go
@@ -1,0 +1,181 @@
+package toproto
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
+)
+
+func ValidateResourceTypeConfig_Request(in tfprotov5.ValidateResourceTypeConfigRequest) tfplugin5.ValidateResourceTypeConfig_Request {
+	resp := tfplugin5.ValidateResourceTypeConfig_Request{
+		TypeName: in.TypeName,
+	}
+	if in.Config != nil {
+		config := Cty(*in.Config)
+		resp.Config = &config
+	}
+	return resp
+}
+
+func ValidateResourceTypeConfig_Response(in tfprotov5.ValidateResourceTypeConfigResponse) tfplugin5.ValidateResourceTypeConfig_Response {
+	return tfplugin5.ValidateResourceTypeConfig_Response{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+}
+
+func UpgradeResourceState_Request(in tfprotov5.UpgradeResourceStateRequest) tfplugin5.UpgradeResourceState_Request {
+	resp := tfplugin5.UpgradeResourceState_Request{
+		TypeName: in.TypeName,
+		Version:  in.Version,
+	}
+	if in.RawState != nil {
+		state := RawState(*in.RawState)
+		resp.RawState = &state
+	}
+	return resp
+}
+
+func UpgradeResourceState_Response(in tfprotov5.UpgradeResourceStateResponse) tfplugin5.UpgradeResourceState_Response {
+	return tfplugin5.UpgradeResourceState_Response{
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+}
+
+func ReadResource_Request(in tfprotov5.ReadResourceRequest) tfplugin5.ReadResource_Request {
+	resp := tfplugin5.ReadResource_Request{
+		TypeName: in.TypeName,
+		Private:  in.Private,
+	}
+	if in.CurrentState != nil {
+		state := Cty(*in.CurrentState)
+		resp.CurrentState = &state
+	}
+	if in.ProviderMeta != nil {
+		meta := Cty(*in.ProviderMeta)
+		resp.ProviderMeta = &meta
+	}
+	return resp
+}
+
+func ReadResource_Response(in tfprotov5.ReadResourceResponse) tfplugin5.ReadResource_Response {
+	resp := tfplugin5.ReadResource_Response{
+		Diagnostics: Diagnostics(in.Diagnostics),
+		Private:     in.Private,
+	}
+	if in.NewState != nil {
+		state := Cty(*in.NewState)
+		resp.NewState = &state
+	}
+	return resp
+}
+
+func PlanResourceChange_Request(in tfprotov5.PlanResourceChangeRequest) tfplugin5.PlanResourceChange_Request {
+	resp := tfplugin5.PlanResourceChange_Request{
+		TypeName:     in.TypeName,
+		PriorPrivate: in.PriorPrivate,
+	}
+	if in.Config != nil {
+		config := Cty(*in.Config)
+		resp.Config = &config
+	}
+	if in.PriorState != nil {
+		state := Cty(*in.PriorState)
+		resp.PriorState = &state
+	}
+	if in.ProposedNewState != nil {
+		state := Cty(*in.ProposedNewState)
+		resp.ProposedNewState = &state
+	}
+	if in.ProviderMeta != nil {
+		meta := Cty(*in.ProviderMeta)
+		resp.ProviderMeta = &meta
+	}
+	return resp
+}
+
+func PlanResourceChange_Response(in tfprotov5.PlanResourceChangeResponse) tfplugin5.PlanResourceChange_Response {
+	resp := tfplugin5.PlanResourceChange_Response{
+		RequiresReplace: AttributePaths(in.RequiresReplace),
+		PlannedPrivate:  in.PlannedPrivate,
+		Diagnostics:     Diagnostics(in.Diagnostics),
+	}
+	if in.PlannedState != nil {
+		state := Cty(*in.PlannedState)
+		resp.PlannedState = &state
+	}
+	return resp
+}
+
+func ApplyResourceChange_Request(in tfprotov5.ApplyResourceChangeRequest) tfplugin5.ApplyResourceChange_Request {
+	resp := tfplugin5.ApplyResourceChange_Request{
+		TypeName:       in.TypeName,
+		PlannedPrivate: in.PlannedPrivate,
+	}
+	if in.Config != nil {
+		config := Cty(*in.Config)
+		resp.Config = &config
+	}
+	if in.PriorState != nil {
+		state := Cty(*in.PriorState)
+		resp.PriorState = &state
+	}
+	if in.PlannedState != nil {
+		state := Cty(*in.PlannedState)
+		resp.PlannedState = &state
+	}
+	if in.ProviderMeta != nil {
+		meta := Cty(*in.ProviderMeta)
+		resp.ProviderMeta = &meta
+	}
+	return resp
+}
+
+func ApplyResourceChange_Response(in tfprotov5.ApplyResourceChangeResponse) tfplugin5.ApplyResourceChange_Response {
+	resp := tfplugin5.ApplyResourceChange_Response{
+		Private:     in.Private,
+		Diagnostics: Diagnostics(in.Diagnostics),
+	}
+	if in.NewState != nil {
+		state := Cty(*in.NewState)
+		resp.NewState = &state
+	}
+	return resp
+}
+
+func ImportResourceState_Request(in tfprotov5.ImportResourceStateRequest) tfplugin5.ImportResourceState_Request {
+	return tfplugin5.ImportResourceState_Request{
+		TypeName: in.TypeName,
+		Id:       in.ID,
+	}
+}
+
+func ImportResourceState_Response(in tfprotov5.ImportResourceStateResponse) tfplugin5.ImportResourceState_Response {
+	return tfplugin5.ImportResourceState_Response{
+		ImportedResources: ImportResourceState_ImportedResources(in.ImportedResources),
+		Diagnostics:       Diagnostics(in.Diagnostics),
+	}
+}
+
+func ImportResourceState_ImportedResource(in tfprotov5.ImportedResource) tfplugin5.ImportResourceState_ImportedResource {
+	resp := tfplugin5.ImportResourceState_ImportedResource{
+		TypeName: in.TypeName,
+		Private:  in.Private,
+	}
+	if in.State != nil {
+		state := Cty(*in.State)
+		resp.State = &state
+	}
+	return resp
+}
+
+func ImportResourceState_ImportedResources(in []*tfprotov5.ImportedResource) []*tfplugin5.ImportResourceState_ImportedResource {
+	resp := make([]*tfplugin5.ImportResourceState_ImportedResource, 0, len(in))
+	for _, i := range in {
+		if i == nil {
+			resp = append(resp, nil)
+			continue
+		}
+		r := ImportResourceState_ImportedResource(*i)
+		resp = append(resp, &r)
+	}
+	return resp
+}

--- a/tfprotov5/internal/toproto/schema.go
+++ b/tfprotov5/internal/toproto/schema.go
@@ -1,0 +1,85 @@
+package toproto
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
+)
+
+func Schema(in tfprotov5.Schema) tfplugin5.Schema {
+	var resp tfplugin5.Schema
+	resp.Version = in.Version
+	if in.Block != nil {
+		block := Schema_Block(*in.Block)
+		resp.Block = &block
+	}
+	return resp
+}
+
+func Schema_Block(in tfprotov5.SchemaBlock) tfplugin5.Schema_Block {
+	return tfplugin5.Schema_Block{
+		Version:         in.Version,
+		Attributes:      Schema_Attributes(in.Attributes),
+		BlockTypes:      Schema_NestedBlocks(in.BlockTypes),
+		Description:     in.Description,
+		DescriptionKind: StringKind(in.DescriptionKind),
+		Deprecated:      in.Deprecated,
+	}
+}
+
+func Schema_Attribute(in tfprotov5.SchemaAttribute) tfplugin5.Schema_Attribute {
+	return tfplugin5.Schema_Attribute{
+		Name:            in.Name,
+		Type:            CtyType(in.Type),
+		Description:     in.Description,
+		Required:        in.Required,
+		Optional:        in.Optional,
+		Computed:        in.Computed,
+		Sensitive:       in.Sensitive,
+		DescriptionKind: StringKind(in.DescriptionKind),
+		Deprecated:      in.Deprecated,
+	}
+}
+
+func Schema_Attributes(in []*tfprotov5.SchemaAttribute) []*tfplugin5.Schema_Attribute {
+	resp := make([]*tfplugin5.Schema_Attribute, 0, len(in))
+	for _, a := range in {
+		if a == nil {
+			resp = append(resp, nil)
+			continue
+		}
+		attr := Schema_Attribute(*a)
+		resp = append(resp, &attr)
+	}
+	return resp
+}
+
+func Schema_NestedBlock(in tfprotov5.SchemaNestedBlock) tfplugin5.Schema_NestedBlock {
+	resp := tfplugin5.Schema_NestedBlock{
+		TypeName: in.TypeName,
+		Nesting:  Schema_NestedBlock_NestingMode(in.Nesting),
+		MinItems: in.MinItems,
+		MaxItems: in.MaxItems,
+	}
+	if in.Block != nil {
+		block := Schema_Block(*in.Block)
+		resp.Block = &block
+	}
+	return resp
+}
+
+func Schema_NestedBlocks(in []*tfprotov5.SchemaNestedBlock) []*tfplugin5.Schema_NestedBlock {
+	resp := make([]*tfplugin5.Schema_NestedBlock, 0, len(in))
+	for _, b := range in {
+		if b == nil {
+			resp = append(resp, nil)
+			continue
+		}
+		block := Schema_NestedBlock(*b)
+		resp = append(resp, &block)
+	}
+	return resp
+}
+
+func Schema_NestedBlock_NestingMode(in tfprotov5.SchemaNestedBlockNestingMode) tfplugin5.Schema_NestedBlock_NestingMode {
+	return tfplugin5.Schema_NestedBlock_NestingMode(in)
+}

--- a/tfprotov5/internal/toproto/state.go
+++ b/tfprotov5/internal/toproto/state.go
@@ -1,0 +1,13 @@
+package toproto
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
+)
+
+func RawState(in tfprotov5.RawState) tfplugin5.RawState {
+	return tfplugin5.RawState{
+		Json:    in.JSON,
+		Flatmap: in.Flatmap,
+	}
+}

--- a/tfprotov5/internal/toproto/string_kind.go
+++ b/tfprotov5/internal/toproto/string_kind.go
@@ -1,0 +1,10 @@
+package toproto
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
+)
+
+func StringKind(in tfprotov5.StringKind) tfplugin5.StringKind {
+	return tfplugin5.StringKind(in)
+}


### PR DESCRIPTION
This is basically just transcribing the generated gRPC types into types
that we control. I still need to do the conversion for them.

I changed GetSchema to GetProviderSchema, Stop to StopProvider, and
Configure to ConfigureProvider, as all other RPC calls name the type of
resource they're operating on. This may also provide a little forward
compatibility if we introduce other plugin types to the protocol, e.g.
backends.

I'm still not sure how to represent state. In the gRPC generated types,
it's just a *DynamicValue, which means "msgpack-encoded whatever that
gets a second round of decoding", usually. So I need to figure out what
it gets decoded into and replicate _that_, instead.

I'm going back and forth on the Private []bytes. The protocol just
requires you to echo them back, I believe, which we can do for users
without them needing to deal with these weird opaque fields that they
need to remember to return every time. But "minimal possible
abstraction" has me questioning whether it's our place to do that or
not.

Representing cty is also something I need to figure out. Once again, its
protocol definition is just a *DynamicValue, which only tells us that it
will be decoded _again_ by the application, not what it's decoded into,
which is what we want to surface. Should be easy enough to find, but it
wasn't in front of my face in the protobuf definition, so I didn't
include it in this pass.

I have no idea why SchemaAttribute.Type is a []byte in the protobuf, and
want someone to explain that to me and why it isn't, say, a string, so I
can include it as a comment in the code, because that's bizarre.

I made all the code happen in tfprotov5 instead of the root package or a
tfproto package because I want to be able to have multiple major
versions of the protocol in a single module version, so we don't have to
do weird long-running branches to support v5 and v6 simultaneously if we
ever have a v6.

I used a system of composition to do some weird type stuff here. The
ResourceServer and DataSourceServer interfaces handle all the RPC
calls for a resource or a data source, respectively. This allows us to
have helpers that just send resource calls to a resource type, so users
don't _need_ to branch all their resources out of ApplyResourceChange or
whatever. Then a ProviderServer embeds those interfaces, relying on all
their methods, and adds the provider-specific ones.

I also used this approach to create a BaseResourceServer,
BaseDataSourceServer, and BaseProviderServer that handle their unique
methods (BaseProviderServer anonymously embeds BaseResourceServer and
BaseDataSourceServer) and return a "not implemented" error message. This
is an idea I'm playing with for forward-compatible interfaces; a struct
can anonymously embed these types, and it will automatically implement
the interface, even if the interface expands underneath it. I'm not sure
if this is better than a compile-time warning, or if we can provide
reasonable default behavior for some or all of these methods, but it
seemed like an idea worth trying.