### PR TITLE
Flesh out the As method.

### DIFF
--- a/tfprotov5/tftypes/value.go
+++ b/tfprotov5/tftypes/value.go
@@ -58,30 +58,35 @@ func (val Value) As(dst interface{}) error {
 			return fmt.Errorf("can't unmarshal %s into %T, expected string", val.typ, dst)
 		}
 		*target = v
+		return nil
 	case *big.Float:
 		v, ok := val.value.(*big.Float)
 		if !ok {
 			return fmt.Errorf("can't unmarshal %s into %T, expected *big.Float", val.typ, dst)
 		}
 		target.Set(v)
+		return nil
 	case *bool:
 		v, ok := val.value.(bool)
 		if !ok {
 			return fmt.Errorf("can't unmarshal %s into %T, expected boolean", val.typ, dst)
 		}
 		*target = v
+		return nil
 	case *map[string]Value:
 		v, ok := val.value.(map[string]Value)
 		if !ok {
 			return fmt.Errorf("can't unmarshal %s into %T, expected map[string]tftypes.Value", val.typ, dst)
 		}
 		*target = v
+		return nil
 	case *[]Value:
 		v, ok := val.value.([]Value)
 		if !ok {
 			return fmt.Errorf("can't unmarshal %s into %T expected []tftypes.Value", val.typ, dst)
 		}
 		*target = v
+		return nil
 	}
 	return fmt.Errorf("can't unmarshal into %T, needs UnmarshalTerraform5Type method", dst)
 }


### PR DESCRIPTION
The As method on tftypes.Values was essentially useless, because As is
the only way to get to the underlying Go types beneath a Value, but As
takes a Value as its argument, and As is the only thing you can call on
a Value. So there was nothing you could actually do inside your
Unmarshaler method because As only supported Unmarshalers. So As would
call your Unmarshaler which could only call As which could only call
your Unmarshaler and so on and so forth.

This implements some basic Go type support for the canonical Go
representations of all the tftypes Types, so we can get to them in our
Unmarshaler methods or just use them with As directly.