### PR TITLE
correct type in UpgradeResourceStateResponse

### DIFF
--- a/tfprotov5/resource.go
+++ b/tfprotov5/resource.go
@@ -31,7 +31,7 @@ type UpgradeResourceStateRequest struct {
 }
 
 type UpgradeResourceStateResponse struct {
-	UpgradedState *RawState
+	UpgradedState *DynamicValue
 	Diagnostics   []*Diagnostic
 }
 


### PR DESCRIPTION
We thought it was a `RawState`, but it turned out to be a `DynamicValue`.