### PR TITLE
Consolidate our handling of JSON types.

### DIFF
--- a/tfprotov5/dynamic_value_msgpack.go
+++ b/tfprotov5/dynamic_value_msgpack.go
@@ -306,7 +306,7 @@ func msgpackUnmarshalDynamic(dec *msgpack.Decoder, path tftypes.AttributePath) (
 	if err != nil {
 		return tftypes.Value{}, path.NewErrorf("error decoding bytes: %w", err)
 	}
-	typ, err := parseJSONType(typeJSON)
+	typ, err := tftypes.ParseJSONType(typeJSON)
 	if err != nil {
 		return tftypes.Value{}, path.NewErrorf("error parsing type information: %w", err)
 	}

--- a/tfprotov5/internal/fromproto/schema.go
+++ b/tfprotov5/internal/fromproto/schema.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes"
 )
 
 func Schema(in *tfplugin5.Schema) (*tfprotov5.Schema, error) {
@@ -51,7 +52,7 @@ func SchemaAttribute(in *tfplugin5.Schema_Attribute) (*tfprotov5.SchemaAttribute
 		DescriptionKind: StringKind(in.DescriptionKind),
 		Deprecated:      in.Deprecated,
 	}
-	typ, err := TerraformTypesType(in.Type)
+	typ, err := tftypes.ParseJSONType(in.Type)
 	if err != nil {
 		return resp, err
 	}

--- a/tfprotov5/internal/fromproto/types.go
+++ b/tfprotov5/internal/fromproto/types.go
@@ -1,12 +1,8 @@
 package fromproto
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes"
 )
 
 func DynamicValue(in *tfplugin5.DynamicValue) *tfprotov5.DynamicValue {
@@ -14,13 +10,4 @@ func DynamicValue(in *tfplugin5.DynamicValue) *tfprotov5.DynamicValue {
 		MsgPack: in.Msgpack,
 		JSON:    in.Json,
 	}
-}
-
-func TerraformTypesType(in []byte) (tftypes.Type, error) {
-	var raw interface{}
-	err := json.Unmarshal(in, &raw)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing type, not valid JSON: %w", err)
-	}
-	return tftypes.ParseType(raw)
 }


### PR DESCRIPTION
We had two separate implementations of JSON type parsing, and that just
seems wasteful. One was similar to cty's, and used a custom JSON decoder
to parse types. One was a novel algorithm that decoded the JSON bytes
into an `interface{}` and read the resulting Go types using a switch
statement to understand the type information.

This consolidates to only use the cty-esque implementation, which is
presumably more accurate and stable.