### PR TITLE
Add serve helper function.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/golang/protobuf v1.4.2
+	github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd
 	github.com/hashicorp/go-plugin v1.3.0
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible


### PR DESCRIPTION
Add a helper that will stand up the go-plugin server for us.

I made it require a name for the provider because I think having that
information will be useful to us down the road for things like logging.

It takes a `func() tfprotov5.ProviderServer`, which it will use to
instantiate a tfprotov5.ProviderServer, which it will then serve.
Factories only this time.

Finally, I made it use the variadic options pattern so we can add more
options later and offer a clearer indication of what's required when. I
added two sample implementations of providing your own logger to
go-plugin and of using the test mode of go-plugin that allows for
reattaching to running provider processes.