### PR TITLE
Discourage the use of our marshaling types.

### DIFF
--- a/tfprotov5/dynamic_value.go
+++ b/tfprotov5/dynamic_value.go
@@ -26,7 +26,9 @@ var ErrUnknownDynamicValueType = errors.New("DynamicValue had no JSON or msgpack
 // that is compatible with the Type of the Value. Usually it should just be the
 // Type of the Value, but it can also be the DynamicPseudoType.
 func NewDynamicValue(t tftypes.Type, v tftypes.Value) (DynamicValue, error) {
-	b, err := v.MarshalMsgPack(t)
+	b, err := v.MarshalMsgPack(t) //nolint:staticcheck
+	//
+	// Deprecated: this is not meant to be called by third-party code.
 	if err != nil {
 		return DynamicValue{}, err
 	}

--- a/tfprotov5/dynamic_value_json.go
+++ b/tfprotov5/dynamic_value_json.go
@@ -126,7 +126,7 @@ func jsonUnmarshalDynamicPseudoType(buf []byte, typ tftypes.Type, p tftypes.Attr
 		}
 		switch key {
 		case "type":
-			t, err = tftypes.ParseJSONType(rawVal)
+			t, err = tftypes.ParseJSONType(rawVal) //nolint:staticcheck
 			if err != nil {
 				return tftypes.Value{}, p.NewErrorf("error decoding type information: %w", err)
 			}

--- a/tfprotov5/dynamic_value_msgpack.go
+++ b/tfprotov5/dynamic_value_msgpack.go
@@ -306,7 +306,7 @@ func msgpackUnmarshalDynamic(dec *msgpack.Decoder, path tftypes.AttributePath) (
 	if err != nil {
 		return tftypes.Value{}, path.NewErrorf("error decoding bytes: %w", err)
 	}
-	typ, err := tftypes.ParseJSONType(typeJSON)
+	typ, err := tftypes.ParseJSONType(typeJSON) //nolint:staticcheck
 	if err != nil {
 		return tftypes.Value{}, path.NewErrorf("error parsing type information: %w", err)
 	}

--- a/tfprotov5/internal/fromproto/schema.go
+++ b/tfprotov5/internal/fromproto/schema.go
@@ -52,7 +52,7 @@ func SchemaAttribute(in *tfplugin5.Schema_Attribute) (*tfprotov5.SchemaAttribute
 		DescriptionKind: StringKind(in.DescriptionKind),
 		Deprecated:      in.Deprecated,
 	}
-	typ, err := tftypes.ParseJSONType(in.Type)
+	typ, err := tftypes.ParseJSONType(in.Type) //nolint:staticcheck
 	if err != nil {
 		return resp, err
 	}

--- a/tfprotov5/internal/toproto/dynamic_value.go
+++ b/tfprotov5/internal/toproto/dynamic_value.go
@@ -21,7 +21,7 @@ func CtyType(in tftypes.Type) ([]byte, error) {
 		in.Is(tftypes.List{}), in.Is(tftypes.Map{}),
 		in.Is(tftypes.Set{}), in.Is(tftypes.Object{}),
 		in.Is(tftypes.Tuple{}), in.Is(tftypes.DynamicPseudoType):
-		return in.MarshalJSON()
+		return in.MarshalJSON() //nolint:staticcheck
 	}
 	return nil, fmt.Errorf("unknown type %s", in)
 }

--- a/tfprotov5/tftypes/list.go
+++ b/tfprotov5/tftypes/list.go
@@ -31,6 +31,8 @@ func (l List) private() {}
 
 // MarshalJSON returns a JSON representation of the full type signature of `l`,
 // including its ElementType.
+//
+// Deprecated: this is not meant to be called by third-party code.
 func (l List) MarshalJSON() ([]byte, error) {
 	elementType, err := l.ElementType.MarshalJSON()
 	if err != nil {

--- a/tfprotov5/tftypes/map.go
+++ b/tfprotov5/tftypes/map.go
@@ -30,6 +30,8 @@ func (m Map) private() {}
 
 // MarshalJSON returns a JSON representation of the full type signature of `m`,
 // including its AttributeType.
+//
+// Deprecated: this is not meant to be called by third-party code.
 func (m Map) MarshalJSON() ([]byte, error) {
 	attributeType, err := m.AttributeType.MarshalJSON()
 	if err != nil {

--- a/tfprotov5/tftypes/object.go
+++ b/tfprotov5/tftypes/object.go
@@ -45,6 +45,8 @@ func (o Object) private() {}
 
 // MarshalJSON returns a JSON representation of the full type signature of `o`,
 // including the AttributeTypes.
+//
+// Deprecated: this is not meant to be called by third-party code.
 func (o Object) MarshalJSON() ([]byte, error) {
 	attrs, err := json.Marshal(o.AttributeTypes)
 	if err != nil {

--- a/tfprotov5/tftypes/set.go
+++ b/tfprotov5/tftypes/set.go
@@ -31,6 +31,8 @@ func (s Set) private() {}
 
 // MarshalJSON returns a JSON representation of the full type signature of `s`,
 // including its ElementType.
+//
+// Deprecated: this is not meant to be called by third-party code.
 func (s Set) MarshalJSON() ([]byte, error) {
 	elementType, err := s.ElementType.MarshalJSON()
 	if err != nil {

--- a/tfprotov5/tftypes/tuple.go
+++ b/tfprotov5/tftypes/tuple.go
@@ -42,6 +42,8 @@ func (tu Tuple) private() {}
 
 // MarshalJSON returns a JSON representation of the full type signature of
 // `tu`, including the ElementTypes.
+//
+// Deprecated: this is not meant to be called by third-party code.
 func (tu Tuple) MarshalJSON() ([]byte, error) {
 	elements, err := json.Marshal(tu.ElementTypes)
 	if err != nil {

--- a/tfprotov5/tftypes/type.go
+++ b/tfprotov5/tftypes/type.go
@@ -22,6 +22,8 @@ type Type interface {
 	// It is modeled based on Terraform's requirements for type signature
 	// JSON representations, and may change over time to match Terraform's
 	// formatting.
+	//
+	// Deprecated: this is not meant to be called by third-party code.
 	MarshalJSON() ([]byte, error)
 
 	// private is meant to keep this interface from being implemented by
@@ -36,6 +38,8 @@ type jsonType struct {
 // ParseJSONType returns a Type from its JSON representation. The JSON
 // representation should come from Terraform or from MarshalJSON as the format
 // is not part of this package's API guarantees.
+//
+// Deprecated: this is not meant to be called by third-party code.
 func ParseJSONType(buf []byte) (Type, error) {
 	var t jsonType
 	err := json.Unmarshal(buf, &t)

--- a/tfprotov5/tftypes/value.go
+++ b/tfprotov5/tftypes/value.go
@@ -256,6 +256,8 @@ func (val Value) IsNull() bool {
 
 // MarshalMsgPack returns a msgpack representation of the Value. This is used
 // for constructing tfprotov5.DynamicValues.
+//
+// Deprecated: this is not meant to be called by third parties. Don't use it.
 func (val Value) MarshalMsgPack(t Type) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := msgpack.NewEncoder(&buf)


### PR DESCRIPTION
Deprecate our Marshal* and Unmarshal* functions to discourage
third-party callers from relying on them. This is a temporary solution;
we should refactor to make these not exported, if we can.