### PR TITLE
Use Dockerhub Mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,13 +25,13 @@ commands:
 jobs:
   "docker-go114 build":
     docker:
-      - image: circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
     steps:
       - get_dependencies
       - run: go build ./...
   "docker-go114 test":
     docker:
-      - image: circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
         environment:
           TF_ACC_TERRAFORM_VERSION: "0.12.26"
     parameters:
@@ -53,19 +53,19 @@ jobs:
           path: << parameters.test_results >>
   "docker-go114 vet":
     docker:
-      - image: circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
     steps:
       - get_dependencies
       - run: go vet ./...
   "docker-go114 gofmt":
     docker:
-      - image: circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
     steps:
       - get_dependencies
       - run: ./scripts/gofmtcheck.sh
   "docker-go114 golangci-lint":
     docker:
-      - image: circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
     steps:
       - get_dependencies
       - get_golangci_lint


### PR DESCRIPTION
Dockerhub is going to rate limit unauthenticated pulls.

Use internal mirror for CI and Dockerfiles built in CI.