### PR TITLE
initialise stopCh before using

### DIFF
--- a/tfprotov5/server/server.go
+++ b/tfprotov5/server/server.go
@@ -135,6 +135,7 @@ func (s *server) stoppableContext(ctx context.Context) context.Context {
 func New(serve tfprotov5.ProviderServer) tfplugin5.ProviderServer {
 	return &server{
 		downstream: serve,
+		stopCh:     make(chan struct{}),
 	}
 }
 


### PR DESCRIPTION
This should fix #45.

Note the corresponding code in the SDK gRPC server, which was missed out when we ported the `stopCh` implementation to terraform-plugin-go: https://github.com/hashicorp/terraform-plugin-sdk/blob/master/helper/schema/grpc_provider.go#L29

I'm not completely happy with this yet because I don't have a consistent reproduction case; this code (`server.Stop`) is not run every time a Ctrl-C is issued during a `terraform apply`. Leaving this here so we can either agree it's a reasonable change and merge it, or decide to investigate further.