### PR TITLE
Use go list to get module version in issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ labels: bug
 Inspect your go.mod as below to find the version, and paste the result between
 the ``` marks below.
 
-go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-go")'
+go list -m github.com/hashicorp/terraform-plugin-go
 
 If you are not running the latest version of terraform-plugin-go, please try
 upgrading because your bug may have already been fixed.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ labels: bug
 Inspect your go.mod as below to find the version, and paste the result between
 the ``` marks below.
 
-go list -m github.com/hashicorp/terraform-plugin-go
+go list -m github.com/hashicorp/terraform-plugin-go/...
 
 If you are not running the latest version of terraform-plugin-go, please try
 upgrading because your bug may have already been fixed.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ labels: enhancement
 <!--
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 
-go list -m github.com/hashicorp/terraform-plugin-go
+go list -m github.com/hashicorp/terraform-plugin-go/...
 
 If you are not running the latest version of terraform-plugin-go, please try
 upgrading because your feature may have already been implemented.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest a new feature or other enhancement.
 labels: enhancement
 ---
 
-### SDK version
+### terraform-plugin-go version
 <!--
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ labels: enhancement
 <!--
 Inspect your go.mod as below to find the version, and paste the result between the ``` marks below.
 
-go mod edit -json | jq '.Require[] | select(.Path=="github.com/hashicorp/terraform-plugin-go")'
+go list -m github.com/hashicorp/terraform-plugin-go
 
 If you are not running the latest version of terraform-plugin-go, please try
 upgrading because your feature may have already been implemented.


### PR DESCRIPTION
Instead of relying on the user having `jq` installed, use a more
idiomatic method to retrieve the module's version in our issue template,
relying only on the `go` command.