### PR TITLE
Expose Types of tftypes.Values.

### DIFF
--- a/.changelog/58.txt
+++ b/.changelog/58.txt
@@ -1,0 +1,11 @@
+```release-note:feature
+`tftypes.Value`s now have a `Type` method, exposing their `tftypes.Type`.
+```
+
+```release-note:breaking-change
+`tftypes.Value`s no longer have an `Is` method. Use `tftypes.Value.Type().Is` instead.
+```
+
+```release-note:breaking-change
+`tftypes.String`, `tftypes.Number`, `tftypes.Bool`, and `tftypes.DynamicPseudoType` are now represented by a different Go type. Uses of `==` and `switch` on them will no longer work. The recommended way to compare any type is using `Is`.
+```

--- a/tfprotov5/dynamic_value_json.go
+++ b/tfprotov5/dynamic_value_json.go
@@ -234,7 +234,7 @@ func jsonUnmarshalList(buf []byte, elementType tftypes.Type, p tftypes.Attribute
 	}
 
 	elTyp := elementType
-	if elTyp == tftypes.DynamicPseudoType {
+	if elTyp.Is(tftypes.DynamicPseudoType) {
 		elTyp, err = tftypes.TypeFromElements(vals)
 		if err != nil {
 			return tftypes.Value{}, p.NewErrorf("invalid elements for list: %w", err)
@@ -291,7 +291,7 @@ func jsonUnmarshalSet(buf []byte, elementType tftypes.Type, p tftypes.AttributeP
 	}
 
 	elTyp := elementType
-	if elTyp == tftypes.DynamicPseudoType {
+	if elTyp.Is(tftypes.DynamicPseudoType) {
 		elTyp, err = tftypes.TypeFromElements(vals)
 		if err != nil {
 			return tftypes.Value{}, p.NewErrorf("invalid elements for list: %w", err)

--- a/tfprotov5/dynamic_value_msgpack.go
+++ b/tfprotov5/dynamic_value_msgpack.go
@@ -135,7 +135,7 @@ func msgpackUnmarshalList(dec *msgpack.Decoder, typ tftypes.Type, path tftypes.A
 	}
 
 	elTyp := typ
-	if elTyp == tftypes.DynamicPseudoType {
+	if elTyp.Is(tftypes.DynamicPseudoType) {
 		elTyp, err = tftypes.TypeFromElements(vals)
 		if err != nil {
 			return tftypes.Value{}, err

--- a/tfprotov5/tftypes/list.go
+++ b/tfprotov5/tftypes/list.go
@@ -6,6 +6,7 @@ import "fmt"
 // of the same type.
 type List struct {
 	ElementType Type
+	_           []struct{}
 }
 
 // Is returns whether `t` is a List type or not. If `t` is an instance of the

--- a/tfprotov5/tftypes/list.go
+++ b/tfprotov5/tftypes/list.go
@@ -6,7 +6,11 @@ import "fmt"
 // of the same type.
 type List struct {
 	ElementType Type
-	_           []struct{}
+
+	// used to make this type uncomparable
+	// see https://golang.org/ref/spec#Comparison_operators
+	// this enforces the use of Is, instead
+	_ []struct{}
 }
 
 // Is returns whether `t` is a List type or not. If `t` is an instance of the

--- a/tfprotov5/tftypes/map.go
+++ b/tfprotov5/tftypes/map.go
@@ -6,6 +6,7 @@ import "fmt"
 // all of the same type, each identifiable with a unique string key.
 type Map struct {
 	AttributeType Type
+	_             []struct{}
 }
 
 // Is returns whether `t` is a Map type or not. If `t` is an instance of the

--- a/tfprotov5/tftypes/map.go
+++ b/tfprotov5/tftypes/map.go
@@ -6,7 +6,11 @@ import "fmt"
 // all of the same type, each identifiable with a unique string key.
 type Map struct {
 	AttributeType Type
-	_             []struct{}
+
+	// used to make this type uncomparable
+	// see https://golang.org/ref/spec#Comparison_operators
+	// this enforces the use of Is, instead
+	_ []struct{}
 }
 
 // Is returns whether `t` is a Map type or not. If `t` is an instance of the

--- a/tfprotov5/tftypes/object.go
+++ b/tfprotov5/tftypes/object.go
@@ -9,6 +9,7 @@ import "encoding/json"
 // attribute names or types are considered to be distinct types.
 type Object struct {
 	AttributeTypes map[string]Type
+	_              []struct{}
 }
 
 // Is returns whether `t` is an Object type or not. If `t` is an instance of

--- a/tfprotov5/tftypes/object.go
+++ b/tfprotov5/tftypes/object.go
@@ -9,7 +9,11 @@ import "encoding/json"
 // attribute names or types are considered to be distinct types.
 type Object struct {
 	AttributeTypes map[string]Type
-	_              []struct{}
+
+	// used to make this type uncomparable
+	// see https://golang.org/ref/spec#Comparison_operators
+	// this enforces the use of Is, instead
+	_ []struct{}
 }
 
 // Is returns whether `t` is an Object type or not. If `t` is an instance of

--- a/tfprotov5/tftypes/primitive.go
+++ b/tfprotov5/tftypes/primitive.go
@@ -2,54 +2,57 @@ package tftypes
 
 import "fmt"
 
-const (
+var (
 	// DynamicPseudoType is a pseudo-type in Terraform's type system that
 	// is used as a wildcard type. It indicates that any Terraform type can
 	// be used.
-	DynamicPseudoType = primitive("DynamicPseudoType")
+	DynamicPseudoType = primitive{name: "DynamicPseudoType"}
 
 	// String is a primitive type in Terraform that represents a UTF-8
 	// string of bytes.
-	String = primitive("String")
+	String = primitive{name: "String"}
 
 	// Number is a primitive type in Terraform that represents a real
 	// number.
-	Number = primitive("Number")
+	Number = primitive{name: "Number"}
 
 	// Bool is a primitive type in Terraform that represents a true or
 	// false boolean value.
-	Bool = primitive("Bool")
+	Bool = primitive{name: "Bool"}
 )
 
 var (
-	_ Type = primitive("test")
+	_ Type = primitive{name: "test"}
 )
 
-type primitive string
+type primitive struct {
+	_    []struct{}
+	name string
+}
 
 func (p primitive) Is(t Type) bool {
 	v, ok := t.(primitive)
 	if !ok {
 		return false
 	}
-	return p == v
+	return p.name == v.name
 }
 
 func (p primitive) String() string {
-	return "tftypes." + string(p)
+	return "tftypes." + string(p.name)
 }
 
 func (p primitive) private() {}
 
 func (p primitive) MarshalJSON() ([]byte, error) {
-	switch p {
-	case String:
+	switch p.name {
+	case String.name:
 		return []byte(`"string"`), nil
-	case Number:
+	case Number.name:
 		return []byte(`"number"`), nil
-	case Bool:
+	case Bool.name:
 		return []byte(`"bool"`), nil
-	case DynamicPseudoType:
+	case DynamicPseudoType.name:
 		return []byte(`"dynamic"`), nil
 	}
 	return nil, fmt.Errorf("unknown primitive type %q", p)

--- a/tfprotov5/tftypes/primitive.go
+++ b/tfprotov5/tftypes/primitive.go
@@ -26,8 +26,12 @@ var (
 )
 
 type primitive struct {
-	_    []struct{}
 	name string
+
+	// used to make this type uncomparable
+	// see https://golang.org/ref/spec#Comparison_operators
+	// this enforces the use of Is, instead
+	_ []struct{}
 }
 
 func (p primitive) Is(t Type) bool {

--- a/tfprotov5/tftypes/set.go
+++ b/tfprotov5/tftypes/set.go
@@ -6,7 +6,11 @@ import "fmt"
 // elements, all of the same type.
 type Set struct {
 	ElementType Type
-	_           []struct{}
+
+	// used to make this type uncomparable
+	// see https://golang.org/ref/spec#Comparison_operators
+	// this enforces the use of Is, instead
+	_ []struct{}
 }
 
 // Is returns whether `t` is a Set type or not. If `t` is an instance of the

--- a/tfprotov5/tftypes/set.go
+++ b/tfprotov5/tftypes/set.go
@@ -6,6 +6,7 @@ import "fmt"
 // elements, all of the same type.
 type Set struct {
 	ElementType Type
+	_           []struct{}
 }
 
 // Is returns whether `t` is a Set type or not. If `t` is an instance of the

--- a/tfprotov5/tftypes/tuple.go
+++ b/tfprotov5/tftypes/tuple.go
@@ -8,7 +8,11 @@ import "encoding/json"
 // numbers or types of elements are considered to be distinct types.
 type Tuple struct {
 	ElementTypes []Type
-	_            []struct{}
+
+	// used to make this type uncomparable
+	// see https://golang.org/ref/spec#Comparison_operators
+	// this enforces the use of Is, instead
+	_ []struct{}
 }
 
 // Is returns whether `t` is a Tuple type or not. If `t` is an instance of the

--- a/tfprotov5/tftypes/tuple.go
+++ b/tfprotov5/tftypes/tuple.go
@@ -8,6 +8,7 @@ import "encoding/json"
 // numbers or types of elements are considered to be distinct types.
 type Tuple struct {
 	ElementTypes []Type
+	_            []struct{}
 }
 
 // Is returns whether `t` is a Tuple type or not. If `t` is an instance of the

--- a/tfprotov5/tftypes/value.go
+++ b/tfprotov5/tftypes/value.go
@@ -394,12 +394,9 @@ func (val Value) As(dst interface{}) error {
 	return fmt.Errorf("can't unmarshal into %T, needs FromTerraform5Value method", dst)
 }
 
-// Is calls Type.Is using the Type of the Value.
-func (val Value) Is(t Type) bool {
-	if val.typ == nil || t == nil {
-		return val.typ == nil && t == nil
-	}
-	return val.typ.Is(t)
+// Type returns the Type of the Value.
+func (val Value) Type() Type {
+	return val.typ
 }
 
 // IsKnown returns true if `val` is known. If `val` is an aggregate type, only

--- a/tfprotov5/tftypes/value_msgpack.go
+++ b/tfprotov5/tftypes/value_msgpack.go
@@ -10,7 +10,7 @@ import (
 )
 
 func marshalMsgPack(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
-	if typ.Is(DynamicPseudoType) && !val.Is(DynamicPseudoType) {
+	if typ.Is(DynamicPseudoType) && !val.Type().Is(DynamicPseudoType) {
 		return marshalMsgPackDynamicPseudoType(val, typ, p, enc)
 
 	}


### PR DESCRIPTION
Add a method to expose the tftypes.Type associated with a tftypes.Value.
This is necessary because tftypes.Value.Is is not always able to
reconstruct a type from comparison alone; for example, reconstructing
what types a map, object, list, set, or tuple uses when its
tftypes.Value is the unknown value is impossible.

But we can make it so people can't directly compare them with ==, which
we don't want them doing (we want them to use Is instead) by embedding a
`_ []struct{}` in each type, which cannot be compared and prevents the
types from being compared, raising a compile time error.

This does mean our primitive types are now structs, and therefore cannot
be constants, which is sad. In theory, someone could overwrite them and
change the output, but the amount of shenanigans one can get up to with
this is pretty limited. You could rename a type to another type:

```go
tftypes.DynamicPseudoType = tftypes.String
```

but you can't construct a new type out of whole cloth, because the
`primitive` type isn't exported and so you can't create new values for
it. So people could wreak some havoc here if they were malicious, but
this doesn't _seem_ to expose us to any new vectors of user error.