### PR TITLE
Walk, Transform, Diff, Equal, and String.

### DIFF
--- a/.changelog/60.txt
+++ b/.changelog/60.txt
@@ -1,0 +1,35 @@
+```release-note:feature
+Added tftypes.Walk and tftypes.Transform functions for the tftypes.Value type, allowing providers to traverse and mutate a tftypes.Value, respectively.
+```
+
+```release-note:feature
+Added tftypes.Diff function to return the elements and attributes that are different between two tftypes.Values.
+```
+
+```release-note:enhancement
+Added an Equal method to tftypes.Value to compare two tftypes.Values.
+```
+
+```release-note:enhancement
+Added an Equal method to tftypes.AttributePath to compares two tftypes.AttributePaths.
+```
+
+```release-note:enhancement
+Added a String method to tftypes.AttributePath to return a string representation of the tftypes.AttributePath.
+```
+
+```release-note:breaking-change
+tftypes.AttributePath.WithAttributeName, WithElementKeyString, WithElementKeyInt, and WithElementKeyValue no longer accept pointers and mutate the AttributePath. They now copy the AttributePath, and return a version of it with the new AttributePathStep appended.
+```
+
+```release-note:enhancement
+Added a String method to tftypes.Value, returning a string representation of the tftypes.Value.
+```
+
+```release-note:enhancement
+Added a Copy method to tftypes.Value, returning a clone of the tftypes.Value such that modifying the clone is guaranteed to not modify the original.
+```
+
+```release-note:enhancement
+Updated the String method of all tftypes.Type implementations to include any element or attribute types in the string as well.
+```

--- a/tfprotov5/tftypes/attribute_path.go
+++ b/tfprotov5/tftypes/attribute_path.go
@@ -297,6 +297,9 @@ func (i interfaceSliceAttributePathStepper) ApplyTerraform5AttributePathStep(ste
 	if !isElementKeyInt {
 		return nil, ErrInvalidStep
 	}
+	if eki < 0 {
+		return nil, ErrInvalidStep
+	}
 	// slices can only have items up to the max value of int
 	// but we get ElementKeyInt as an int64
 	// we keep ElementKeyInt as an int64 and cast the length of the slice

--- a/tfprotov5/tftypes/attribute_path.go
+++ b/tfprotov5/tftypes/attribute_path.go
@@ -155,7 +155,7 @@ func (a AttributePath) WithElementKeyValue(key Value) AttributePath {
 	steps := make([]AttributePathStep, len(a.Steps))
 	copy(steps, a.Steps)
 	return AttributePath{
-		Steps: append(steps, ElementKeyValue(key)),
+		Steps: append(steps, ElementKeyValue(key.Copy())),
 	}
 }
 

--- a/tfprotov5/tftypes/attribute_path.go
+++ b/tfprotov5/tftypes/attribute_path.go
@@ -48,6 +48,9 @@ func (a AttributePath) String() string {
 	return res.String()
 }
 
+// Equal returns true if two AttributePaths should be considered equal.
+// AttributePaths are considered equal if they have the same number of steps,
+// the steps are all the same types, and the steps have all the same values.
 func (a AttributePath) Equal(o AttributePath) bool {
 	if len(a.Steps) != len(o.Steps) {
 		return false

--- a/tfprotov5/tftypes/attribute_path.go
+++ b/tfprotov5/tftypes/attribute_path.go
@@ -57,17 +57,9 @@ func (a AttributePath) Equal(o AttributePath) bool {
 	}
 	for pos, aStep := range a.Steps {
 		oStep := o.Steps[pos]
-		switch aVal := aStep.(type) {
-		case AttributeName:
-			if oStep != aVal {
-				return false
-			}
-		case ElementKeyString:
-			if oStep != aVal {
-				return false
-			}
-		case ElementKeyInt:
-			if oStep != aVal {
+		switch aStep.(type) {
+		case AttributeName, ElementKeyString, ElementKeyInt:
+			if oStep != aStep {
 				return false
 			}
 		case ElementKeyValue:
@@ -75,7 +67,7 @@ func (a AttributePath) Equal(o AttributePath) bool {
 			if !ok {
 				return false
 			}
-			if !Value(aVal).Equal(Value(oVal)) {
+			if !Value(aStep.(ElementKeyValue)).Equal(Value(oVal)) {
 				return false
 			}
 		default:

--- a/tfprotov5/tftypes/attribute_path.go
+++ b/tfprotov5/tftypes/attribute_path.go
@@ -59,27 +59,15 @@ func (a AttributePath) Equal(o AttributePath) bool {
 		oStep := o.Steps[pos]
 		switch aVal := aStep.(type) {
 		case AttributeName:
-			oVal, ok := oStep.(AttributeName)
-			if !ok {
-				return false
-			}
-			if oVal != aVal {
+			if oStep != aVal {
 				return false
 			}
 		case ElementKeyString:
-			oVal, ok := oStep.(ElementKeyString)
-			if !ok {
-				return false
-			}
-			if oVal != aVal {
+			if oStep != aVal {
 				return false
 			}
 		case ElementKeyInt:
-			oVal, ok := oStep.(ElementKeyInt)
-			if !ok {
-				return false
-			}
-			if oVal != aVal {
+			if oStep != aVal {
 				return false
 			}
 		case ElementKeyValue:
@@ -87,11 +75,7 @@ func (a AttributePath) Equal(o AttributePath) bool {
 			if !ok {
 				return false
 			}
-			diffs, err := Value(aVal).Diff(Value(oVal))
-			if err != nil {
-				panic(err)
-			}
-			if len(diffs) > 0 {
+			if !Value(aVal).Equal(Value(oVal)) {
 				return false
 			}
 		default:

--- a/tfprotov5/tftypes/attribute_path.go
+++ b/tfprotov5/tftypes/attribute_path.go
@@ -95,7 +95,7 @@ func (a AttributePath) Equal(o AttributePath) bool {
 				return false
 			}
 		default:
-			panic(fmt.Sprintf("unknown step %T in ValueDiff.Equal", aStep))
+			panic(fmt.Sprintf("unknown step %T in AttributePath.Equal", aStep))
 		}
 	}
 	return true

--- a/tfprotov5/tftypes/attribute_path_test.go
+++ b/tfprotov5/tftypes/attribute_path_test.go
@@ -182,3 +182,7 @@ func TestWalkAttributePath(t *testing.T) {
 		})
 	}
 }
+
+func TestAttributePathEquals(t *testing.T) {
+	t.Error("not implemented")
+}

--- a/tfprotov5/tftypes/diff.go
+++ b/tfprotov5/tftypes/diff.go
@@ -86,6 +86,9 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 		}
 		return true, nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	// make sure everything in val1 is also in val2 and also that it all matches
 	err = Walk(val1, func(path AttributePath, value1 Value) (bool, error) {

--- a/tfprotov5/tftypes/diff.go
+++ b/tfprotov5/tftypes/diff.go
@@ -1,0 +1,270 @@
+package tftypes
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+type ValueDiff struct {
+	Path   AttributePath
+	Value1 *Value
+	Value2 *Value
+}
+
+func (v ValueDiff) String() string {
+	val1 := "{no value set}"
+	if v.Value1 != nil {
+		val1 = v.Value1.String()
+	}
+	val2 := "{no value set}"
+	if v.Value2 != nil {
+		val2 = v.Value2.String()
+	}
+	return fmt.Sprintf("%s: value1: %s, value2: %s",
+		v.Path.String(), val1, val2)
+}
+
+func (v ValueDiff) Equal(o ValueDiff) bool {
+	if !v.Path.Equal(o.Path) {
+		return false
+	}
+	if v.Value1 == nil && o.Value1 != nil {
+		return false
+	}
+	if v.Value1 != nil && o.Value1 == nil {
+		return false
+	}
+	if v.Value1 == nil && o.Value1 == nil {
+		return true
+	}
+	diffs, err := v.Value1.Diff(*o.Value1)
+	if err != nil {
+		panic(err)
+	}
+	if len(diffs) > 0 {
+		return false
+	}
+	if v.Value2 == nil && o.Value2 != nil {
+		return false
+	}
+	if v.Value2 != nil && o.Value2 == nil {
+		return false
+	}
+	if v.Value2 == nil && o.Value2 == nil {
+		return true
+	}
+	diffs, err = v.Value2.Diff(*o.Value2)
+	if err != nil {
+		panic(err)
+	}
+	if len(diffs) > 0 {
+		return false
+	}
+	return true
+}
+
+func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
+	// TODO: replace with Type() when #58 is merged
+	if !val1.typ.Is(val2.typ) {
+		return nil, errors.New("Can't diff values of different types")
+	}
+	var diffs []ValueDiff
+
+	// make sure everything in val2 is also in val1
+	err := Walk(val2, func(path AttributePath, value2 Value) (bool, error) {
+		_, _, err := WalkAttributePath(val1, path)
+		if err != nil && err != ErrInvalidStep {
+			return false, fmt.Errorf("Error walking %q: %w", path, err)
+		} else if err == ErrInvalidStep {
+			diffs = append(diffs, ValueDiff{
+				Path:   path,
+				Value1: nil,
+				Value2: &value2,
+			})
+			return false, nil
+		}
+		return true, nil
+	})
+
+	// make sure everything in val1 is also in val2 and also that it all matches
+	err = Walk(val1, func(path AttributePath, value1 Value) (bool, error) {
+		// pull out the Value at the same path in val2
+		value2I, _, err := WalkAttributePath(val2, path)
+		if err != nil && err != ErrInvalidStep {
+			return false, fmt.Errorf("Error walking %q: %w", path, err)
+		} else if err == ErrInvalidStep {
+			diffs = append(diffs, ValueDiff{
+				Path:   path,
+				Value1: &value1,
+				Value2: nil,
+			})
+			return true, nil
+		}
+
+		// convert from an interface{} to a Value
+		value2 := value2I.(Value)
+
+		// if they're both unknown, no need to continue
+		if !value1.IsKnown() && !value2.IsKnown() {
+			return false, nil
+		}
+
+		// if val1 is unknown and val2 not, we have a diff
+		// no need to continue to recurse into val1, no further to go
+		if !value1.IsKnown() && value2.IsKnown() {
+			diffs = append(diffs, ValueDiff{
+				Path:   path,
+				Value1: &value1,
+				Value2: &value2,
+			})
+			return false, nil
+		}
+
+		// if val2 is unknown and val1 not, we have a diff
+		// continue to recurse though, so we can surface the elements of val1
+		// that are now "missing" as diffs
+		if value1.IsKnown() && !value2.IsKnown() {
+			diffs = append(diffs, ValueDiff{
+				Path:   path,
+				Value1: &value1,
+				Value2: &value2,
+			})
+			return true, nil
+		}
+
+		// if they're both null, no need to continue
+		if value1.IsNull() && value2.IsNull() {
+			return false, nil
+		}
+
+		// if val1 is null and val2 not, we have a diff
+		// no need to continue to recurse into val1, no further to go
+		if value1.IsNull() && !value2.IsNull() {
+			diffs = append(diffs, ValueDiff{
+				Path:   path,
+				Value1: &value1,
+				Value2: &value2,
+			})
+			return false, nil
+		}
+
+		// if val2 is null and val1 not, we have a diff
+		// continue to recurse though, so we can surface the elements of val1
+		// that are now "missing" as diffs
+		if !value1.IsNull() && value2.IsNull() {
+			diffs = append(diffs, ValueDiff{
+				Path:   path,
+				Value1: &value1,
+				Value2: &value2,
+			})
+			return true, nil
+		}
+
+		// we know there are known, non-null values, time to compare them
+		switch {
+		case value1.Is(String):
+			var s1, s2 string
+			err := value1.As(&s1)
+			if err != nil {
+				return false, fmt.Errorf("Error converting %q: %w", path, err)
+			}
+			err = value2.As(&s2)
+			if err != nil {
+				return false, fmt.Errorf("Error converting %q: %w", path, err)
+			}
+			if s1 != s2 {
+				diffs = append(diffs, ValueDiff{
+					Path:   path,
+					Value1: &value1,
+					Value2: &value2,
+				})
+			}
+			return false, nil
+		case value1.Is(Number):
+			n1, n2 := big.NewFloat(0), big.NewFloat(0)
+			err := value1.As(&n1)
+			if err != nil {
+				return false, fmt.Errorf("Error converting %q: %w", path, err)
+			}
+			err = value2.As(&n2)
+			if err != nil {
+				return false, fmt.Errorf("Error converting %q: %w", path, err)
+			}
+			if n1.Cmp(n2) != 0 {
+				diffs = append(diffs, ValueDiff{
+					Path:   path,
+					Value1: &value1,
+					Value2: &value2,
+				})
+			}
+			return false, nil
+		case value1.Is(Bool):
+			var b1, b2 bool
+			err := value1.As(&b1)
+			if err != nil {
+				return false, fmt.Errorf("Error converting %q: %w", path, err)
+			}
+			err = value2.As(&b2)
+			if err != nil {
+				return false, fmt.Errorf("Error converting %q: %w", path, err)
+			}
+			if b1 != b2 {
+				diffs = append(diffs, ValueDiff{
+					Path:   path,
+					Value1: &value1,
+					Value2: &value2,
+				})
+			}
+			return false, nil
+		case value1.Is(List{}), value1.Is(Set{}), value1.Is(Tuple{}):
+			var s1, s2 []Value
+			err := value1.As(&s1)
+			if err != nil {
+				return false, fmt.Errorf("Error converting %q: %w", path, err)
+			}
+			err = value2.As(&s2)
+			if err != nil {
+				return false, fmt.Errorf("Error converting %q: %w", path, err)
+			}
+			// we only care about if the lengths match for lists,
+			// sets, and tuples. If any of the elements differ,
+			// the recursion of the walk will find them for us.
+			if len(s1) != len(s2) {
+				diffs = append(diffs, ValueDiff{
+					Path:   path,
+					Value1: &value1,
+					Value2: &value2,
+				})
+				return true, nil
+			}
+			return true, nil
+		case value1.Is(Map{}), value1.Is(Object{}):
+			m1 := map[string]Value{}
+			m2 := map[string]Value{}
+			err := value1.As(&m1)
+			if err != nil {
+				return false, fmt.Errorf("Error converting %q: %w", path, err)
+			}
+			err = value2.As(&m2)
+			if err != nil {
+				return false, fmt.Errorf("Error converting %q: %w", path, err)
+			}
+			// we need maps and objects to have the same exact keys
+			// as each other
+			if len(m1) != len(m2) {
+				diffs = append(diffs, ValueDiff{
+					Path:   path,
+					Value1: &value1,
+					Value2: &value2,
+				})
+				return true, nil
+			}
+			// if we have the same keys, we can just let recursion
+			// from the walk check the sub-values match
+			return true, nil
+		}
+		return false, fmt.Errorf("unexpected type %v in Diff at %s", value1.typ, path)
+	})
+	return diffs, err
+}

--- a/tfprotov5/tftypes/diff.go
+++ b/tfprotov5/tftypes/diff.go
@@ -6,9 +6,23 @@ import (
 	"math/big"
 )
 
+// ValueDiff expresses a subset of a Value that is different between two
+// Values. The Path property indicates where the subset is located within the
+// Value, and Value1 and Value2 indicate what the subset is in each of the
+// Values. If the Value does not contain a subset at that AttributePath, its
+// Value will be nil. This is distinct from a Value with a nil in it (a "null"
+// value), which is present in the Value.
 type ValueDiff struct {
-	Path   AttributePath
+	// The Path these different subsets are located at in the original
+	// Values.
+	Path AttributePath
+
+	// The subset of the first Value passed to Diff found at the
+	// AttributePath indicated by Path.
 	Value1 *Value
+
+	// The subset of the second Value passed to Diff found at the
+	// AttributePath indicated by Path.
 	Value2 *Value
 }
 
@@ -25,6 +39,9 @@ func (v ValueDiff) String() string {
 		v.Path.String(), val1, val2)
 }
 
+// Equal returns whether two ValueDiffs should be considered equal or not.
+// ValueDiffs are consisdered equal when their Path, Value1, and Value2
+// properties are considered equal.
 func (v ValueDiff) Equal(o ValueDiff) bool {
 	if !v.Path.Equal(o.Path) {
 		return false
@@ -35,14 +52,7 @@ func (v ValueDiff) Equal(o ValueDiff) bool {
 	if v.Value1 != nil && o.Value1 == nil {
 		return false
 	}
-	if v.Value1 == nil && o.Value1 == nil {
-		return true
-	}
-	diffs, err := v.Value1.Diff(*o.Value1)
-	if err != nil {
-		panic(err)
-	}
-	if len(diffs) > 0 {
+	if v.Value1 != nil && o.Value1 != nil && !v.Value1.Equal(*o.Value1) {
 		return false
 	}
 	if v.Value2 == nil && o.Value2 != nil {
@@ -51,19 +61,19 @@ func (v ValueDiff) Equal(o ValueDiff) bool {
 	if v.Value2 != nil && o.Value2 == nil {
 		return false
 	}
-	if v.Value2 == nil && o.Value2 == nil {
-		return true
-	}
-	diffs, err = v.Value2.Diff(*o.Value2)
-	if err != nil {
-		panic(err)
-	}
-	if len(diffs) > 0 {
+	if v.Value2 != nil && o.Value2 != nil && !v.Value2.Equal(*o.Value2) {
 		return false
 	}
 	return true
 }
 
+// Diff computes the differences between `val1` and `val2` and surfaces them as
+// a slice of ValueDiffs. The ValueDiffs in the struct will use `val1`'s values
+// as Value1 and `val2`'s values as Value2. An empty or nil slice means the two
+// Values can be considered equal. Values must be the same type when passed to
+// Diff; passing in Values of two different types will result in an error.
+// val1.Type().Is(val2.Type()) is a safe way to check that Values can be
+// compared with Diff.
 func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 	if !val1.Type().Is(val2.Type()) {
 		return nil, errors.New("Can't diff values of different types")

--- a/tfprotov5/tftypes/diff.go
+++ b/tfprotov5/tftypes/diff.go
@@ -65,8 +65,7 @@ func (v ValueDiff) Equal(o ValueDiff) bool {
 }
 
 func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
-	// TODO: replace with Type() when #58 is merged
-	if !val1.typ.Is(val2.typ) {
+	if !val1.Type().Is(val2.Type()) {
 		return nil, errors.New("Can't diff values of different types")
 	}
 	var diffs []ValueDiff
@@ -166,7 +165,7 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 
 		// we know there are known, non-null values, time to compare them
 		switch {
-		case value1.Is(String):
+		case value1.Type().Is(String):
 			var s1, s2 string
 			err := value1.As(&s1)
 			if err != nil {
@@ -184,7 +183,7 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 				})
 			}
 			return false, nil
-		case value1.Is(Number):
+		case value1.Type().Is(Number):
 			n1, n2 := big.NewFloat(0), big.NewFloat(0)
 			err := value1.As(&n1)
 			if err != nil {
@@ -202,7 +201,7 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 				})
 			}
 			return false, nil
-		case value1.Is(Bool):
+		case value1.Type().Is(Bool):
 			var b1, b2 bool
 			err := value1.As(&b1)
 			if err != nil {
@@ -220,7 +219,7 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 				})
 			}
 			return false, nil
-		case value1.Is(List{}), value1.Is(Set{}), value1.Is(Tuple{}):
+		case value1.Type().Is(List{}), value1.Type().Is(Set{}), value1.Type().Is(Tuple{}):
 			var s1, s2 []Value
 			err := value1.As(&s1)
 			if err != nil {
@@ -242,7 +241,7 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 				return true, nil
 			}
 			return true, nil
-		case value1.Is(Map{}), value1.Is(Object{}):
+		case value1.Type().Is(Map{}), value1.Type().Is(Object{}):
 			m1 := map[string]Value{}
 			m2 := map[string]Value{}
 			err := value1.As(&m1)
@@ -267,7 +266,7 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 			// from the walk check the sub-values match
 			return true, nil
 		}
-		return false, fmt.Errorf("unexpected type %v in Diff at %s", value1.typ, path)
+		return false, fmt.Errorf("unexpected type %v in Diff at %s", value1.Type(), path)
 	})
 	return diffs, err
 }

--- a/tfprotov5/tftypes/diff_test.go
+++ b/tfprotov5/tftypes/diff_test.go
@@ -1,9 +1,368 @@
 package tftypes
 
-import "testing"
+import (
+	"math/big"
+	"testing"
+)
+
+func valuePointer(val Value) *Value {
+	return &val
+}
 
 func TestValueDiffEqual(t *testing.T) {
-	t.Error("not implemented")
+	t.Parallel()
+	type testCase struct {
+		diff1 ValueDiff
+		diff2 ValueDiff
+		equal bool
+	}
+
+	tests := map[string]testCase{
+		"pathDiff": {
+			diff1: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(String, "test")),
+				Value2: valuePointer(NewValue(String, "test 2")),
+			},
+			diff2: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyInt(123),
+				Value1: valuePointer(NewValue(String, "test")),
+				Value2: valuePointer(NewValue(String, "test 2")),
+			},
+			equal: false,
+		},
+		"primitiveVal1Diff": {
+			diff1: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(String, "test")),
+				Value2: valuePointer(NewValue(String, "test 2")),
+			},
+			diff2: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(String, "test 3")),
+				Value2: valuePointer(NewValue(String, "test 2")),
+			},
+			equal: false,
+		},
+		"primitiveVal2Diff": {
+			diff1: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(String, "test")),
+				Value2: valuePointer(NewValue(String, "test 2")),
+			},
+			diff2: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(String, "test")),
+				Value2: valuePointer(NewValue(String, "test 3")),
+			},
+			equal: false,
+		},
+		"primitiveTypeDiff": {
+			diff1: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(String, "test")),
+				Value2: valuePointer(NewValue(String, "test 2")),
+			},
+			diff2: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(Number, big.NewFloat(123))),
+				Value2: valuePointer(NewValue(Number, big.NewFloat(1234))),
+			},
+			equal: false,
+		},
+		"complexVal1Diff": {
+			diff1: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test"),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test"),
+					NewValue(String, "test 2"),
+					NewValue(String, "test 3"),
+				})),
+			},
+			diff2: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "testing"),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test"),
+					NewValue(String, "test 2"),
+					NewValue(String, "test 3"),
+				})),
+			},
+			equal: false,
+		},
+		"complexVal2Diff": {
+			diff1: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test"),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test"),
+					NewValue(String, "test 2"),
+					NewValue(String, "test 3"),
+				})),
+			},
+			diff2: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test"),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test 1"),
+					NewValue(String, "test 2"),
+					NewValue(String, "test 3"),
+				})),
+			},
+			equal: false,
+		},
+		"complexTypeDiff": {
+			diff1: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "testing"),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "testing"),
+					NewValue(String, "foo"),
+				})),
+			},
+			diff2: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, true),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, true),
+					NewValue(Bool, false),
+				})),
+			},
+			equal: false,
+		},
+		"val1NilDiff": {
+			diff1: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: nil,
+				Value2: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, true),
+					NewValue(Bool, false),
+				})),
+			},
+			diff2: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, true),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, true),
+					NewValue(Bool, false),
+				})),
+			},
+			equal: false,
+		},
+		"val2NilDiff": {
+			diff1: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, false),
+					NewValue(Bool, true),
+				})),
+				Value2: nil,
+			},
+			diff2: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, false),
+					NewValue(Bool, true),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, true),
+				})),
+			},
+			equal: false,
+		},
+		"allValsNilDiff": {
+			diff1: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: nil,
+				Value2: nil,
+			},
+			diff2: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, false),
+					NewValue(Bool, true),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, true),
+				})),
+			},
+			equal: false,
+		},
+		"primitiveEqual": {
+			diff1: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(String, "test")),
+				Value2: valuePointer(NewValue(String, "test 2")),
+			},
+			diff2: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(String, "test")),
+				Value2: valuePointer(NewValue(String, "test 2")),
+			},
+			equal: true,
+		},
+		"complexEqual": {
+			diff1: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test"),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test"),
+					NewValue(String, "test 2"),
+					NewValue(String, "test 3"),
+				})),
+			},
+			diff2: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test"),
+				})),
+				Value2: valuePointer(NewValue(List{
+					ElementType: String,
+				}, []Value{
+					NewValue(String, "test"),
+					NewValue(String, "test 2"),
+					NewValue(String, "test 3"),
+				})),
+			},
+			equal: true,
+		},
+		"val1NilEqual": {
+			diff1: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: nil,
+				Value2: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, true),
+					NewValue(Bool, false),
+				})),
+			},
+			diff2: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: nil,
+				Value2: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, true),
+					NewValue(Bool, false),
+				})),
+			},
+			equal: true,
+		},
+		"val2NilEqual": {
+			diff1: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, false),
+					NewValue(Bool, true),
+				})),
+				Value2: nil,
+			},
+			diff2: ValueDiff{
+				Path: AttributePath{}.WithElementKeyString("foo"),
+				Value1: valuePointer(NewValue(List{
+					ElementType: Bool,
+				}, []Value{
+					NewValue(Bool, false),
+					NewValue(Bool, true),
+				})),
+				Value2: nil,
+			},
+			equal: true,
+		},
+		"allValsNilEqual": {
+			diff1: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: nil,
+				Value2: nil,
+			},
+			diff2: ValueDiff{
+				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Value1: nil,
+				Value2: nil,
+			},
+			equal: true,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			isEqual := test.diff1.Equal(test.diff2)
+			if isEqual != test.equal {
+				t.Fatalf("expected %v, got %v", test.equal, isEqual)
+			}
+			isEqual = test.diff2.Equal(test.diff1)
+			if isEqual != test.equal {
+				t.Fatalf("expected %v, got %v", test.equal, isEqual)
+			}
+		})
+	}
 }
 
 func TestValueDiffDiff(t *testing.T) {

--- a/tfprotov5/tftypes/diff_test.go
+++ b/tfprotov5/tftypes/diff_test.go
@@ -487,7 +487,7 @@ func TestValueDiffDiff(t *testing.T) {
 			}
 
 			// run the same test, but which value is val1
-			diffs, err = test.val2.Diff(test.val1)
+			_, err = test.val2.Diff(test.val1)
 			if (err == nil && test.err != nil) || (test.err == nil && err != nil) || (test.err != nil && err != nil && test.err.Error() != err.Error()) {
 				t.Errorf("Expected reversed error to be %v, got %v", test.err, err)
 			}

--- a/tfprotov5/tftypes/diff_test.go
+++ b/tfprotov5/tftypes/diff_test.go
@@ -1,0 +1,11 @@
+package tftypes
+
+import "testing"
+
+func TestValueDiffEqual(t *testing.T) {
+	t.Error("not implemented")
+}
+
+func TestValueDiffDiff(t *testing.T) {
+	t.Error("not implemented")
+}

--- a/tfprotov5/tftypes/list.go
+++ b/tfprotov5/tftypes/list.go
@@ -29,7 +29,7 @@ func (l List) Is(t Type) bool {
 }
 
 func (l List) String() string {
-	return "tftypes.List"
+	return "tftypes.List[" + l.ElementType.String() + "]"
 }
 
 func (l List) private() {}

--- a/tfprotov5/tftypes/map.go
+++ b/tfprotov5/tftypes/map.go
@@ -28,7 +28,7 @@ func (m Map) Is(t Type) bool {
 }
 
 func (m Map) String() string {
-	return "tftypes.Map"
+	return "tftypes.Map[" + m.AttributeType.String() + "]"
 }
 
 func (m Map) private() {}

--- a/tfprotov5/tftypes/object.go
+++ b/tfprotov5/tftypes/object.go
@@ -1,6 +1,10 @@
 package tftypes
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
 
 // Object is a Terraform type representing an unordered collection of
 // attributes, potentially of differing types, each identifiable with a unique
@@ -43,7 +47,22 @@ func (o Object) Is(t Type) bool {
 }
 
 func (o Object) String() string {
-	return "tftypes.Object"
+	var res strings.Builder
+	res.WriteString("tftypes.Object[")
+	keys := make([]string, 0, len(o.AttributeTypes))
+	for k := range o.AttributeTypes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for pos, key := range keys {
+		if pos != 0 {
+			res.WriteString(", ")
+		}
+		res.WriteString(`"` + key + `":`)
+		res.WriteString(o.AttributeTypes[key].String())
+	}
+	res.WriteString("]")
+	return res.String()
 }
 
 func (o Object) private() {}

--- a/tfprotov5/tftypes/set.go
+++ b/tfprotov5/tftypes/set.go
@@ -29,7 +29,7 @@ func (s Set) Is(t Type) bool {
 }
 
 func (s Set) String() string {
-	return "tftypes.Set"
+	return "tftypes.Set[" + s.ElementType.String() + "]"
 }
 
 func (s Set) private() {}

--- a/tfprotov5/tftypes/tuple.go
+++ b/tfprotov5/tftypes/tuple.go
@@ -1,6 +1,9 @@
 package tftypes
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // Tuple is a Terraform type representing an ordered collection of elements,
 // potentially of differing types. The number of elements and their types are
@@ -40,7 +43,16 @@ func (tu Tuple) Is(t Type) bool {
 }
 
 func (tu Tuple) String() string {
-	return "tftypes.Tuple"
+	var res strings.Builder
+	res.WriteString("tftypes.Tuple[")
+	for pos, t := range tu.ElementTypes {
+		if pos != 0 {
+			res.WriteString(", ")
+		}
+		res.WriteString(t.String())
+	}
+	res.WriteString("]")
+	return res.String()
 }
 
 func (tu Tuple) private() {}

--- a/tfprotov5/tftypes/value.go
+++ b/tfprotov5/tftypes/value.go
@@ -170,6 +170,9 @@ func (val Value) ApplyTerraform5AttributePathStep(step AttributePathStep) (inter
 		if !val.Type().Is(List{}) && !val.Type().Is(Tuple{}) {
 			return nil, ErrInvalidStep
 		}
+		if int64(s) < 0 {
+			return nil, ErrInvalidStep
+		}
 		sl := []Value{}
 		err := val.As(&sl)
 		if err != nil {

--- a/tfprotov5/tftypes/value_msgpack.go
+++ b/tfprotov5/tftypes/value_msgpack.go
@@ -141,12 +141,10 @@ func marshalMsgPackList(val Value, typ Type, p AttributePath, enc *msgpack.Encod
 		return p.NewErrorf("error encoding list length: %w", err)
 	}
 	for pos, i := range l {
-		p.WithElementKeyInt(int64(pos))
-		err := marshalMsgPack(i, typ.(List).ElementType, p, enc)
+		err := marshalMsgPack(i, typ.(List).ElementType, p.WithElementKeyInt(int64(pos)), enc)
 		if err != nil {
 			return err
 		}
-		p.WithoutLastStep()
 	}
 	return nil
 }
@@ -161,12 +159,10 @@ func marshalMsgPackSet(val Value, typ Type, p AttributePath, enc *msgpack.Encode
 		return p.NewErrorf("error encoding set length: %w", err)
 	}
 	for _, i := range s {
-		p.WithElementKeyValue(i)
-		err := marshalMsgPack(i, typ.(Set).ElementType, p, enc)
+		err := marshalMsgPack(i, typ.(Set).ElementType, p.WithElementKeyValue(i), enc)
 		if err != nil {
 			return err
 		}
-		p.WithoutLastStep()
 	}
 	return nil
 }
@@ -181,8 +177,7 @@ func marshalMsgPackMap(val Value, typ Type, p AttributePath, enc *msgpack.Encode
 		return p.NewErrorf("error encoding map length: %w", err)
 	}
 	for k, v := range m {
-		p.WithElementKeyString(k)
-		err := marshalMsgPack(NewValue(String, k), String, p, enc)
+		err := marshalMsgPack(NewValue(String, k), String, p.WithElementKeyString(k), enc)
 		if err != nil {
 			return p.NewErrorf("error encoding map key: %w", err)
 		}
@@ -190,7 +185,6 @@ func marshalMsgPackMap(val Value, typ Type, p AttributePath, enc *msgpack.Encode
 		if err != nil {
 			return err
 		}
-		p.WithoutLastStep()
 	}
 	return nil
 }
@@ -206,13 +200,11 @@ func marshalMsgPackTuple(val Value, typ Type, p AttributePath, enc *msgpack.Enco
 		return p.NewErrorf("error encoding tuple length: %w", err)
 	}
 	for pos, v := range t {
-		p.WithElementKeyInt(int64(pos))
 		ty := types[pos]
-		err := marshalMsgPack(v, ty, p, enc)
+		err := marshalMsgPack(v, ty, p.WithElementKeyInt(int64(pos)), enc)
 		if err != nil {
 			return err
 		}
-		p.WithoutLastStep()
 	}
 	return nil
 }
@@ -233,21 +225,19 @@ func marshalMsgPackObject(val Value, typ Type, p AttributePath, enc *msgpack.Enc
 		return p.NewErrorf("error encoding object length: %w", err)
 	}
 	for _, k := range keys {
-		p.WithAttributeName(k)
 		ty := types[k]
 		v, ok := o[k]
 		if !ok {
-			return p.NewErrorf("no value set")
+			return p.WithAttributeName(k).NewErrorf("no value set")
 		}
-		err := marshalMsgPack(NewValue(String, k), String, p, enc)
+		err := marshalMsgPack(NewValue(String, k), String, p.WithAttributeName(k), enc)
 		if err != nil {
 			return err
 		}
-		err = marshalMsgPack(v, ty, p, enc)
+		err = marshalMsgPack(v, ty, p.WithAttributeName(k), enc)
 		if err != nil {
 			return err
 		}
-		p.WithoutLastStep()
 	}
 	return nil
 }

--- a/tfprotov5/tftypes/value_msgpack.go
+++ b/tfprotov5/tftypes/value_msgpack.go
@@ -50,9 +50,9 @@ func marshalMsgPack(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) 
 }
 
 func marshalMsgPackDynamicPseudoType(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
-	typeJSON, err := val.typ.MarshalJSON()
+	typeJSON, err := val.Type().MarshalJSON()
 	if err != nil {
-		return p.NewErrorf("error generating JSON for type %s: %w", val.typ, err)
+		return p.NewErrorf("error generating JSON for type %s: %w", val.Type(), err)
 	}
 	err = enc.EncodeArrayLen(2)
 	if err != nil {
@@ -62,7 +62,7 @@ func marshalMsgPackDynamicPseudoType(val Value, typ Type, p AttributePath, enc *
 	if err != nil {
 		return p.NewErrorf("error encoding JSON type info: %w", err)
 	}
-	err = marshalMsgPack(val, val.typ, p, enc)
+	err = marshalMsgPack(val, val.Type(), p, enc)
 	if err != nil {
 		return p.NewErrorf("error marshaling DynamicPseudoType value: %w", err)
 	}

--- a/tfprotov5/tftypes/value_test.go
+++ b/tfprotov5/tftypes/value_test.go
@@ -1,6 +1,7 @@
 package tftypes
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 
@@ -723,13 +724,862 @@ func TestValueIsKnown(t *testing.T) {
 }
 
 func TestValueEqual(t *testing.T) {
-	t.Error("not implemented")
+	t.Parallel()
+	type testCase struct {
+		val1  Value
+		val2  Value
+		equal bool
+	}
+	tests := map[string]testCase{
+		"stringEqual": {
+			val1:  NewValue(String, "hello"),
+			val2:  NewValue(String, "hello"),
+			equal: true,
+		},
+		"stringDiff": {
+			val1:  NewValue(String, "hello"),
+			val2:  NewValue(String, "world"),
+			equal: false,
+		},
+		"boolEqual": {
+			val1:  NewValue(Bool, true),
+			val2:  NewValue(Bool, true),
+			equal: true,
+		},
+		"boolDiff": {
+			val1:  NewValue(Bool, false),
+			val2:  NewValue(Bool, true),
+			equal: false,
+		},
+		"numberEqual": {
+			val1:  NewValue(Number, big.NewFloat(123)),
+			val2:  NewValue(Number, big.NewFloat(0).SetInt64(123)),
+			equal: true,
+		},
+		"numberDiff": {
+			val1:  NewValue(Number, big.NewFloat(1)),
+			val2:  NewValue(Number, big.NewFloat(2)),
+			equal: false,
+		},
+		"unknownEqual": {
+			val1:  NewValue(String, UnknownValue),
+			val2:  NewValue(String, UnknownValue),
+			equal: true,
+		},
+		"unknownDiff": {
+			val1:  NewValue(String, UnknownValue),
+			val2:  NewValue(String, "world"),
+			equal: false,
+		},
+		"listEqual": {
+			val1: NewValue(List{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+				NewValue(String, "abc"),
+			}),
+			val2: NewValue(List{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+				NewValue(String, "abc"),
+			}),
+			equal: true,
+		},
+		"listDiffLength": {
+			val1: NewValue(List{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+				NewValue(String, "abc"),
+			}),
+			val2: NewValue(List{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "abc"),
+			}),
+			equal: false,
+		},
+		"listDiffElement": {
+			val1: NewValue(List{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+				NewValue(String, "abc"),
+			}),
+			val2: NewValue(List{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world!"),
+				NewValue(String, "abc"),
+			}),
+			equal: false,
+		},
+		"setEqual": {
+			val1: NewValue(Set{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+				NewValue(String, "abc"),
+			}),
+			val2: NewValue(Set{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+				NewValue(String, "abc"),
+			}),
+			equal: true,
+		},
+		"setDiffLength": {
+			val1: NewValue(Set{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+				NewValue(String, "abc"),
+			}),
+			val2: NewValue(Set{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "abc"),
+			}),
+			equal: false,
+		},
+		"setDiffElement": {
+			val1: NewValue(Set{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+				NewValue(String, "abc"),
+			}),
+			val2: NewValue(Set{ElementType: String}, []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world!"),
+				NewValue(String, "abc"),
+			}),
+			equal: false,
+		},
+		"tupleEqual": {
+			val1: NewValue(Tuple{ElementTypes: []Type{
+				String, Bool, Number, List{ElementType: String},
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Bool, true),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(List{ElementType: String}, []Value{
+					NewValue(String, "a"),
+					NewValue(String, "b"),
+					NewValue(String, "c"),
+				}),
+			}),
+			val2: NewValue(Tuple{ElementTypes: []Type{
+				String, Bool, Number, List{ElementType: String},
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Bool, true),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(List{ElementType: String}, []Value{
+					NewValue(String, "a"),
+					NewValue(String, "b"),
+					NewValue(String, "c"),
+				}),
+			}),
+			equal: true,
+		},
+		"tupleDiff": {
+			val1: NewValue(Tuple{ElementTypes: []Type{
+				String, Bool, Number, List{ElementType: String},
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Bool, true),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(List{ElementType: String}, []Value{
+					NewValue(String, "a"),
+					NewValue(String, "b"),
+					NewValue(String, "c"),
+				}),
+			}),
+			val2: NewValue(Tuple{ElementTypes: []Type{
+				String, Bool, Number, List{ElementType: String},
+			}}, []Value{
+				NewValue(String, "hello, world"),
+				NewValue(Bool, true),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(List{ElementType: String}, []Value{
+					NewValue(String, "a"),
+					NewValue(String, "b"),
+					NewValue(String, "c"),
+				}),
+			}),
+			equal: false,
+		},
+		"tupleDiffNested": {
+			val1: NewValue(Tuple{ElementTypes: []Type{
+				String, Bool, Number, List{ElementType: String},
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Bool, true),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(List{ElementType: String}, []Value{
+					NewValue(String, "a"),
+					NewValue(String, "b"),
+					NewValue(String, "c"),
+				}),
+			}),
+			val2: NewValue(Tuple{ElementTypes: []Type{
+				String, Bool, Number, List{ElementType: String},
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Bool, true),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(List{ElementType: String}, []Value{
+					NewValue(String, "a"),
+					NewValue(String, "d"),
+					NewValue(String, "c"),
+				}),
+			}),
+			equal: false,
+		},
+		"mapEqual": {
+			val1: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			val2: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			equal: true,
+		},
+		"mapDiffLength": {
+			val1: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			val2: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			equal: false,
+		},
+		"mapDiffValue": {
+			val1: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			val2: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(4)),
+			}),
+			equal: false,
+		},
+		"mapDiffKeys": {
+			val1: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			val2: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":  NewValue(Number, big.NewFloat(1)),
+				"two":  NewValue(Number, big.NewFloat(2)),
+				"four": NewValue(Number, big.NewFloat(3)),
+			}),
+			equal: false,
+		},
+		"objectEqual": {
+			val1: NewValue(Object{AttributeTypes: map[string]Type{
+				"one":   Number,
+				"hello": String,
+				"true":  Bool,
+				"set":   Set{ElementType: Bool},
+			}}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"hello": NewValue(String, "world"),
+				"true":  NewValue(Bool, true),
+				"set": NewValue(Set{ElementType: Bool}, []Value{
+					NewValue(Bool, true), NewValue(Bool, false),
+				}),
+			}),
+			val2: NewValue(Object{AttributeTypes: map[string]Type{
+				"one":   Number,
+				"hello": String,
+				"true":  Bool,
+				"set":   Set{ElementType: Bool},
+			}}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"hello": NewValue(String, "world"),
+				"true":  NewValue(Bool, true),
+				"set": NewValue(Set{ElementType: Bool}, []Value{
+					NewValue(Bool, true), NewValue(Bool, false),
+				}),
+			}),
+			equal: true,
+		},
+		"objectDiff": {
+			val1: NewValue(Object{AttributeTypes: map[string]Type{
+				"one":   Number,
+				"hello": String,
+				"true":  Bool,
+				"set":   Set{ElementType: Bool},
+			}}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"hello": NewValue(String, "world"),
+				"true":  NewValue(Bool, true),
+				"set": NewValue(Set{ElementType: Bool}, []Value{
+					NewValue(Bool, true), NewValue(Bool, false),
+				}),
+			}),
+			val2: NewValue(Object{AttributeTypes: map[string]Type{
+				"one":   Number,
+				"hello": String,
+				"true":  Bool,
+				"set":   Set{ElementType: Bool},
+			}}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"hello": NewValue(String, "world!"),
+				"true":  NewValue(Bool, true),
+				"set": NewValue(Set{ElementType: Bool}, []Value{
+					NewValue(Bool, true), NewValue(Bool, false),
+				}),
+			}),
+			equal: false,
+		},
+		"objectDiffNested": {
+			val1: NewValue(Object{AttributeTypes: map[string]Type{
+				"one":   Number,
+				"hello": String,
+				"true":  Bool,
+				"set":   Set{ElementType: Bool},
+			}}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"hello": NewValue(String, "world"),
+				"true":  NewValue(Bool, true),
+				"set": NewValue(Set{ElementType: Bool}, []Value{
+					NewValue(Bool, true), NewValue(Bool, false),
+				}),
+			}),
+			val2: NewValue(Object{AttributeTypes: map[string]Type{
+				"one":   Number,
+				"hello": String,
+				"true":  Bool,
+				"set":   Set{ElementType: Bool},
+			}}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"hello": NewValue(String, "world"),
+				"true":  NewValue(Bool, true),
+				"set": NewValue(Set{ElementType: Bool}, []Value{
+					NewValue(Bool, true),
+				}),
+			}),
+			equal: false,
+		},
+		"nullEqual": {
+			val1:  NewValue(String, nil),
+			val2:  NewValue(String, nil),
+			equal: true,
+		},
+		"nullDiff": {
+			val1:  NewValue(String, nil),
+			val2:  NewValue(String, "hello"),
+			equal: false,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if result := test.val1.Equal(test.val2); result != test.equal {
+				t.Errorf("expected %v, got %v comparing %s and %s", test.equal, result, test.val1, test.val2)
+			}
+			if result := test.val2.Equal(test.val1); result != test.equal {
+				t.Errorf("expected %v, got %v comparing %s and %s", test.equal, result, test.val2, test.val1)
+			}
+		})
+	}
 }
 
 func TestValueApplyTerraform5AttributePathStep(t *testing.T) {
-	t.Error("not implemented")
+	t.Parallel()
+
+	type testCase struct {
+		val  Value
+		step AttributePathStep
+		res  interface{}
+		err  error
+	}
+	tests := map[string]testCase{
+		"string_attr": {
+			val:  NewValue(String, "hello"),
+			step: AttributeName("test"),
+			err:  ErrInvalidStep,
+		},
+		"string_eki": {
+			val:  NewValue(String, "hello"),
+			step: ElementKeyInt(123),
+			err:  ErrInvalidStep,
+		},
+		"string_eks": {
+			val:  NewValue(String, "hello"),
+			step: ElementKeyString("test"),
+			err:  ErrInvalidStep,
+		},
+		"string_ekv": {
+			val:  NewValue(String, "hello"),
+			step: ElementKeyValue(NewValue(String, "hello")),
+			err:  ErrInvalidStep,
+		},
+		"number_attr": {
+			val:  NewValue(Number, big.NewFloat(123)),
+			step: AttributeName("test"),
+			err:  ErrInvalidStep,
+		},
+		"number_eki": {
+			val:  NewValue(Number, big.NewFloat(123)),
+			step: ElementKeyInt(123),
+			err:  ErrInvalidStep,
+		},
+		"number_eks": {
+			val:  NewValue(Number, big.NewFloat(123)),
+			step: ElementKeyString("test"),
+			err:  ErrInvalidStep,
+		},
+		"number_ekv": {
+			val:  NewValue(Number, big.NewFloat(123)),
+			step: ElementKeyValue(NewValue(Number, big.NewFloat(123))),
+			err:  ErrInvalidStep,
+		},
+		"bool_attr": {
+			val:  NewValue(Bool, true),
+			step: AttributeName("test"),
+			err:  ErrInvalidStep,
+		},
+		"bool_eki": {
+			val:  NewValue(Bool, true),
+			step: ElementKeyInt(123),
+			err:  ErrInvalidStep,
+		},
+		"bool_eks": {
+			val:  NewValue(Bool, true),
+			step: ElementKeyString("test"),
+			err:  ErrInvalidStep,
+		},
+		"bool_ekv": {
+			val:  NewValue(Bool, true),
+			step: ElementKeyValue(NewValue(Bool, true)),
+			err:  ErrInvalidStep,
+		},
+		"unknown_attr": {
+			val:  NewValue(String, UnknownValue),
+			step: AttributeName("test"),
+			err:  ErrInvalidStep,
+		},
+		"unknown_eki": {
+			val:  NewValue(String, UnknownValue),
+			step: ElementKeyInt(123),
+			err:  ErrInvalidStep,
+		},
+		"unknown_eks": {
+			val:  NewValue(String, UnknownValue),
+			step: ElementKeyString("test"),
+			err:  ErrInvalidStep,
+		},
+		"unknown_ekv": {
+			val:  NewValue(String, UnknownValue),
+			step: ElementKeyValue(NewValue(String, UnknownValue)),
+			err:  ErrInvalidStep,
+		},
+		"null_attr": {
+			val:  NewValue(List{ElementType: Number}, nil),
+			step: AttributeName("test"),
+			err:  ErrInvalidStep,
+		},
+		"null_eki": {
+			val:  NewValue(List{ElementType: Number}, nil),
+			step: ElementKeyInt(123),
+			err:  ErrInvalidStep,
+		},
+		"null_eks": {
+			val:  NewValue(List{ElementType: Number}, nil),
+			step: ElementKeyString("test"),
+			err:  ErrInvalidStep,
+		},
+		"null_ekv": {
+			val:  NewValue(List{ElementType: Number}, nil),
+			step: ElementKeyValue(NewValue(List{ElementType: Number}, nil)),
+			err:  ErrInvalidStep,
+		},
+		"list_attr": {
+			val: NewValue(List{ElementType: Number}, []Value{
+				NewValue(Number, big.NewFloat(1)),
+				NewValue(Number, big.NewFloat(2)),
+				NewValue(Number, big.NewFloat(3)),
+			}),
+			step: AttributeName("test"),
+			err:  ErrInvalidStep,
+		},
+		"list_eki": {
+			val: NewValue(List{ElementType: Number}, []Value{
+				NewValue(Number, big.NewFloat(1)),
+				NewValue(Number, big.NewFloat(2)),
+				NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyInt(1),
+			res:  NewValue(Number, big.NewFloat(2)),
+		},
+		"list_eki_invalid_index": {
+			val: NewValue(List{ElementType: Number}, []Value{
+				NewValue(Number, big.NewFloat(1)),
+				NewValue(Number, big.NewFloat(2)),
+				NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyInt(3),
+			err:  ErrInvalidStep,
+		},
+		"list_eks": {
+			val: NewValue(List{ElementType: Number}, []Value{
+				NewValue(Number, big.NewFloat(1)),
+				NewValue(Number, big.NewFloat(2)),
+				NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyString("test"),
+			err:  ErrInvalidStep,
+		},
+		"list_ekv": {
+			val: NewValue(List{ElementType: Number}, []Value{
+				NewValue(Number, big.NewFloat(1)),
+				NewValue(Number, big.NewFloat(2)),
+				NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyValue(NewValue(Number, big.NewFloat(1))),
+			err:  ErrInvalidStep,
+		},
+		"set_eki": {
+			val: NewValue(Set{ElementType: Number}, []Value{
+				NewValue(Number, big.NewFloat(1)),
+				NewValue(Number, big.NewFloat(2)),
+				NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyInt(1),
+			err:  ErrInvalidStep,
+		},
+		"set_eks": {
+			val: NewValue(Set{ElementType: Number}, []Value{
+				NewValue(Number, big.NewFloat(1)),
+				NewValue(Number, big.NewFloat(2)),
+				NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyString("test"),
+			err:  ErrInvalidStep,
+		},
+		"set_ekv": {
+			val: NewValue(Set{ElementType: Number}, []Value{
+				NewValue(Number, big.NewFloat(1)),
+				NewValue(Number, big.NewFloat(2)),
+				NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyValue(NewValue(Number, big.NewFloat(2))),
+			res:  NewValue(Number, big.NewFloat(2)),
+		},
+		"set_ekv_invalid_value": {
+			val: NewValue(Set{ElementType: Number}, []Value{
+				NewValue(Number, big.NewFloat(1)),
+				NewValue(Number, big.NewFloat(2)),
+				NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyValue(NewValue(Number, big.NewFloat(4))),
+			err:  ErrInvalidStep,
+		},
+		"object_attr": {
+			val: NewValue(Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}}, map[string]Value{
+				"a": NewValue(String, "hello, world"),
+				"b": NewValue(Number, big.NewFloat(1)),
+				"c": NewValue(Bool, true),
+			}),
+			step: AttributeName("a"),
+			res:  NewValue(String, "hello, world"),
+		},
+		"object_attr_notfound": {
+			val: NewValue(Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}}, map[string]Value{
+				"a": NewValue(String, "hello, world"),
+				"b": NewValue(Number, big.NewFloat(1)),
+				"c": NewValue(Bool, true),
+			}),
+			step: AttributeName("foo"),
+			err:  ErrInvalidStep,
+		},
+		"object_eki": {
+			val: NewValue(Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}}, map[string]Value{
+				"a": NewValue(String, "hello, world"),
+				"b": NewValue(Number, big.NewFloat(1)),
+				"c": NewValue(Bool, true),
+			}),
+			step: ElementKeyInt(123),
+			err:  ErrInvalidStep,
+		},
+		"object_eks": {
+			val: NewValue(Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}}, map[string]Value{
+				"a": NewValue(String, "hello, world"),
+				"b": NewValue(Number, big.NewFloat(1)),
+				"c": NewValue(Bool, true),
+			}),
+			step: ElementKeyString("foo"),
+			err:  ErrInvalidStep,
+		},
+		"object_ekv": {
+			val: NewValue(Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}}, map[string]Value{
+				"a": NewValue(String, "hello, world"),
+				"b": NewValue(Number, big.NewFloat(1)),
+				"c": NewValue(Bool, true),
+			}),
+			step: ElementKeyValue(NewValue(String, "a")),
+			err:  ErrInvalidStep,
+		},
+		"tuple_attr": {
+			val: NewValue(Tuple{ElementTypes: []Type{
+				String, Number, Bool,
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(Bool, true),
+			}),
+			step: AttributeName("test"),
+			err:  ErrInvalidStep,
+		},
+		"tuple_eki": {
+			val: NewValue(Tuple{ElementTypes: []Type{
+				String, Number, Bool,
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(Bool, true),
+			}),
+			step: ElementKeyInt(0),
+			res:  NewValue(String, "hello"),
+		},
+		"tuple_eki_invalid_index": {
+			val: NewValue(Tuple{ElementTypes: []Type{
+				String, Number, Bool,
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(Bool, true),
+			}),
+			step: ElementKeyInt(3),
+			err:  ErrInvalidStep,
+		},
+		"tuple_eki_negative_index": {
+			val: NewValue(Tuple{ElementTypes: []Type{
+				String, Number, Bool,
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(Bool, true),
+			}),
+			step: ElementKeyInt(-1),
+			err:  ErrInvalidStep,
+		},
+		"tuple_eks": {
+			val: NewValue(Tuple{ElementTypes: []Type{
+				String, Number, Bool,
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(Bool, true),
+			}),
+			step: ElementKeyString("test"),
+			err:  ErrInvalidStep,
+		},
+		"tuple_ekv": {
+			val: NewValue(Tuple{ElementTypes: []Type{
+				String, Number, Bool,
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(Bool, true),
+			}),
+			step: ElementKeyValue(NewValue(String, "test")),
+			err:  ErrInvalidStep,
+		},
+		"map_attr": {
+			val: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			step: AttributeName("one"),
+			err:  ErrInvalidStep,
+		},
+		"map_eki": {
+			val: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyInt(123),
+			err:  ErrInvalidStep,
+		},
+		"map_eks": {
+			val: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyString("two"),
+			res:  NewValue(Number, big.NewFloat(2)),
+		},
+		"map_eks_invalid_key": {
+			val: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyString("four"),
+			err:  ErrInvalidStep,
+		},
+		"map_ekv": {
+			val: NewValue(Map{AttributeType: Number}, map[string]Value{
+				"one":   NewValue(Number, big.NewFloat(1)),
+				"two":   NewValue(Number, big.NewFloat(2)),
+				"three": NewValue(Number, big.NewFloat(3)),
+			}),
+			step: ElementKeyValue(NewValue(String, "four")),
+			err:  ErrInvalidStep,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := test.val.ApplyTerraform5AttributePathStep(test.step)
+			if !errors.Is(err, test.err) {
+				t.Errorf("Expected %v, got %v", test.err, err)
+			}
+			if !cmp.Equal(res, test.res) {
+				t.Errorf("Expected %v, got %v", test.res, res)
+			}
+		})
+	}
 }
 
 func TestValueWalkAttributePath(t *testing.T) {
-	t.Error("not implemented")
+	t.Parallel()
+	type testCase struct {
+		val      Value
+		path     AttributePath
+		expected Value
+	}
+	tests := map[string]testCase{
+		"primitive": {
+			val:      NewValue(String, "hello"),
+			path:     AttributePath{},
+			expected: NewValue(String, "hello"),
+		},
+		"list": {
+			val: NewValue(List{ElementType: String}, []Value{
+				NewValue(String, "foo"), NewValue(String, "bar"),
+			}),
+			path:     AttributePath{}.WithElementKeyInt(1),
+			expected: NewValue(String, "bar"),
+		},
+		"set": {
+			val: NewValue(Set{ElementType: String}, []Value{
+				NewValue(String, "foo"), NewValue(String, "bar"),
+			}),
+			path:     AttributePath{}.WithElementKeyValue(NewValue(String, "bar")),
+			expected: NewValue(String, "bar"),
+		},
+		"map": {
+			val: NewValue(Map{AttributeType: String}, map[string]Value{
+				"a": NewValue(String, "foo"),
+				"b": NewValue(String, "bar"),
+			}),
+			path:     AttributePath{}.WithElementKeyString("b"),
+			expected: NewValue(String, "bar"),
+		},
+		"object": {
+			val: NewValue(Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+			}}, map[string]Value{
+				"a": NewValue(String, "foo"),
+				"b": NewValue(Number, big.NewFloat(123)),
+			}),
+			path:     AttributePath{}.WithAttributeName("b"),
+			expected: NewValue(Number, big.NewFloat(123)),
+		},
+		"tuple": {
+			val: NewValue(Tuple{ElementTypes: []Type{
+				String, Number,
+			}}, []Value{
+				NewValue(String, "foo"),
+				NewValue(Number, big.NewFloat(123)),
+			}),
+			path:     AttributePath{}.WithElementKeyInt(1),
+			expected: NewValue(Number, big.NewFloat(123)),
+		},
+		"complex": {
+			val: NewValue(Object{AttributeTypes: map[string]Type{
+				"a": List{ElementType: Tuple{ElementTypes: []Type{
+					Number, Bool, List{ElementType: String},
+				}}},
+			}}, map[string]Value{
+				"a": NewValue(List{ElementType: Tuple{ElementTypes: []Type{
+					Number, Bool, List{ElementType: String},
+				}}}, []Value{
+					NewValue(Tuple{ElementTypes: []Type{
+						Number, Bool, List{ElementType: String},
+					}}, []Value{
+						NewValue(Number, big.NewFloat(1)),
+						NewValue(Bool, true),
+						NewValue(List{ElementType: String}, []Value{
+							NewValue(String, "foo"),
+							NewValue(String, "bar"),
+						}),
+					}),
+					NewValue(Tuple{ElementTypes: []Type{
+						Number, Bool, List{ElementType: String},
+					}}, []Value{
+						NewValue(Number, big.NewFloat(456)),
+						NewValue(Bool, false),
+						NewValue(List{ElementType: String}, []Value{
+							NewValue(String, "hello"),
+							NewValue(String, "world"),
+						}),
+					}),
+				}),
+			}),
+			path:     AttributePath{}.WithAttributeName("a").WithElementKeyInt(1).WithElementKeyInt(2).WithElementKeyInt(1),
+			expected: NewValue(String, "world"),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			result, remaining, err := WalkAttributePath(test.val, test.path)
+			if err != nil {
+				t.Fatalf("error walking attribute path, %v still remains in the path: %s", remaining, err)
+			}
+			if res, ok := result.(Value); !ok {
+				t.Errorf("got non-Value result %v", result)
+			} else if !res.Equal(test.expected) {
+				t.Errorf("expected %s, got %s", test.expected, res)
+			}
+		})
+	}
 }

--- a/tfprotov5/tftypes/value_test.go
+++ b/tfprotov5/tftypes/value_test.go
@@ -721,3 +721,15 @@ func TestValueIsKnown(t *testing.T) {
 		})
 	}
 }
+
+func TestValueEqual(t *testing.T) {
+	t.Error("not implemented")
+}
+
+func TestValueApplyTerraform5AttributePathStep(t *testing.T) {
+	t.Error("not implemented")
+}
+
+func TestValueWalkAttributePath(t *testing.T) {
+	t.Error("not implemented")
+}

--- a/tfprotov5/tftypes/walk.go
+++ b/tfprotov5/tftypes/walk.go
@@ -1,0 +1,192 @@
+package tftypes
+
+// these functions are based heavily on github.com/zclconf/go-cty
+// used under the MIT License
+//
+// Copyright (c) 2017-2018 Martin Atkins
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import (
+	"errors"
+)
+
+func Walk(val Value, cb func(AttributePath, Value) (bool, error)) error {
+	var path AttributePath
+	return walk(path, val, cb)
+}
+
+func walk(path AttributePath, val Value, cb func(AttributePath, Value) (bool, error)) error {
+	shouldContinue, err := cb(path, val)
+	if err != nil {
+		var ape attributePathError
+		if !errors.As(err, &ape) {
+			err = path.NewError(err)
+		}
+		return err
+	}
+	if !shouldContinue {
+		return nil
+	}
+
+	if val.IsNull() || !val.IsKnown() {
+		return nil
+	}
+
+	// TODO(paddy): replace with val.Type() once #58 lands
+	ty := val.typ
+	switch {
+	case ty.Is(List{}), ty.Is(Set{}), ty.Is(Tuple{}):
+		var v []Value
+		err := val.As(&v)
+		if err != nil {
+			// should never happen
+			return path.NewError(err)
+		}
+		for pos, el := range v {
+			if ty.Is(Set{}) {
+				path = path.WithElementKeyValue(el)
+			} else {
+				path = path.WithElementKeyInt(int64(pos))
+			}
+			err = walk(path, el, cb)
+			if err != nil {
+				var ape attributePathError
+				if !errors.As(err, &ape) {
+					err = path.NewError(err)
+				}
+				return err
+			}
+			path = path.WithoutLastStep()
+		}
+	case ty.Is(Map{}), ty.Is(Object{}):
+		v := map[string]Value{}
+		err := val.As(&v)
+		if err != nil {
+			// should never happen
+			return err
+		}
+		for k, el := range v {
+			if ty.Is(Map{}) {
+				path = path.WithElementKeyString(k)
+			} else if ty.Is(Object{}) {
+				path = path.WithAttributeName(k)
+			}
+			err = walk(path, el, cb)
+			if err != nil {
+				var ape attributePathError
+				if !errors.As(err, &ape) {
+					err = path.NewError(err)
+				}
+				return err
+			}
+			path = path.WithoutLastStep()
+		}
+	}
+
+	return nil
+}
+
+func Transform(val Value, cb func(AttributePath, Value) (Value, error)) (Value, error) {
+	var path AttributePath
+	return transform(path, val, cb)
+}
+
+func transform(path AttributePath, val Value, cb func(AttributePath, Value) (Value, error)) (Value, error) {
+	var newVal Value
+	// TODO(paddy): change this to val.Type() when #58 lands
+	ty := val.typ
+
+	switch {
+	case val.IsNull() || !val.IsKnown():
+		newVal = val
+	case ty.Is(List{}), ty.Is(Set{}), ty.Is(Tuple{}):
+		var v []Value
+		err := val.As(&v)
+		if err != nil {
+			return val, err
+		}
+		if len(v) == 0 {
+			newVal = val
+		} else {
+			elems := make([]Value, 0, len(v))
+			for pos, el := range v {
+				if ty.Is(Set{}) {
+					path = path.WithElementKeyValue(el)
+				} else {
+					path = path.WithElementKeyInt(int64(pos))
+				}
+				newEl, err := transform(path, el, cb)
+				if err != nil {
+					var ape attributePathError
+					if !errors.As(err, &ape) {
+						err = path.NewError(err)
+					}
+					return val, err
+				}
+				elems = append(elems, newEl)
+				path = path.WithoutLastStep()
+			}
+			newVal = NewValue(ty, elems)
+		}
+	case ty.Is(Map{}), ty.Is(Object{}):
+		v := map[string]Value{}
+		err := val.As(&v)
+		if err != nil {
+			return val, err
+		}
+		if len(v) == 0 {
+			newVal = val
+		} else {
+			elems := map[string]Value{}
+			for k, el := range v {
+				if ty.Is(Map{}) {
+					path = path.WithElementKeyString(k)
+				} else {
+					path = path.WithAttributeName(k)
+				}
+				newEl, err := transform(path, el, cb)
+				if err != nil {
+					var ape attributePathError
+					if !errors.As(err, &ape) {
+						err = path.NewError(err)
+					}
+					return val, err
+				}
+				elems[k] = newEl
+				path = path.WithoutLastStep()
+			}
+			newVal = NewValue(ty, elems)
+		}
+	default:
+		newVal = val
+	}
+	res, err := cb(path, newVal)
+	if err != nil {
+		var ape attributePathError
+		if !errors.As(err, &ape) {
+			err = path.NewError(err)
+		}
+		return res, err
+	}
+	if !newVal.Is(ty) {
+		return val, path.NewError(errors.New("invalid transform: value changed type"))
+	}
+	return res, err
+}

--- a/tfprotov5/tftypes/walk.go
+++ b/tfprotov5/tftypes/walk.go
@@ -27,6 +27,16 @@ import (
 	"errors"
 )
 
+// Walk traverses a Value, calling the passed function for every element and
+// attribute in the Value. The AttributePath passed to the callback function
+// will identify which attribute or element is currently being surfaced by the
+// Walk, and the passed Value will be the element or attribute at that
+// AttributePath. Returning true from the callback function will indicate that
+// any attributes or elements of the surfaced Value should be walked, too;
+// returning false short-circuits the walk at that element or attribute, and
+// does not visit any of its descendants. The return value of the callback does
+// not matter when the Value that has been surfaced has no elements or
+// attributes. Walk uses a depth-first traversal.
 func Walk(val Value, cb func(AttributePath, Value) (bool, error)) error {
 	var path AttributePath
 	return walk(path, val, cb)
@@ -102,6 +112,15 @@ func walk(path AttributePath, val Value, cb func(AttributePath, Value) (bool, er
 	return nil
 }
 
+// Transform uses a callback to mutate a Value. Each element or attribute will
+// be visited in turn, with the AttributePath and Value surfaced to the
+// callback, as in Walk. Unlike in Walk, the callback returns a Value instead
+// of a boolean; this is the Value that will be stored at that AttributePath.
+// The callback must return the passed Value unmodified if it wishes to not
+// mutate a Value. Elements and attributes of a Value will be passed to the
+// callback prior to the Value they belong to being passed to the callback,
+// which means a callback can overwrite its own modifications. Values passed to
+// the callback will always reflect the results of earlier callback calls.
 func Transform(val Value, cb func(AttributePath, Value) (Value, error)) (Value, error) {
 	var path AttributePath
 	return transform(path, val, cb)

--- a/tfprotov5/tftypes/walk.go
+++ b/tfprotov5/tftypes/walk.go
@@ -49,8 +49,7 @@ func walk(path AttributePath, val Value, cb func(AttributePath, Value) (bool, er
 		return nil
 	}
 
-	// TODO(paddy): replace with val.Type() once #58 lands
-	ty := val.typ
+	ty := val.Type()
 	switch {
 	case ty.Is(List{}), ty.Is(Set{}), ty.Is(Tuple{}):
 		var v []Value
@@ -110,8 +109,7 @@ func Transform(val Value, cb func(AttributePath, Value) (Value, error)) (Value, 
 
 func transform(path AttributePath, val Value, cb func(AttributePath, Value) (Value, error)) (Value, error) {
 	var newVal Value
-	// TODO(paddy): change this to val.Type() when #58 lands
-	ty := val.typ
+	ty := val.Type()
 
 	switch {
 	case val.IsNull() || !val.IsKnown():
@@ -185,7 +183,7 @@ func transform(path AttributePath, val Value, cb func(AttributePath, Value) (Val
 		}
 		return res, err
 	}
-	if !newVal.Is(ty) {
+	if !newVal.Type().Is(ty) {
 		return val, path.NewError(errors.New("invalid transform: value changed type"))
 	}
 	return res, err

--- a/tfprotov5/tftypes/walk_test.go
+++ b/tfprotov5/tftypes/walk_test.go
@@ -1,0 +1,1177 @@
+package tftypes
+
+// these tests are based heavily on github.com/zclconf/go-cty
+// used under the MIT License
+//
+// Copyright (c) 2017-2018 Martin Atkins
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestWalk(t *testing.T) {
+	valType := Object{
+		AttributeTypes: map[string]Type{
+			"string":       String,
+			"number":       Number,
+			"bool":         Bool,
+			"list":         List{ElementType: Bool},
+			"list_empty":   List{ElementType: Bool},
+			"set":          Set{ElementType: Bool},
+			"set_empty":    Set{ElementType: Bool},
+			"tuple":        Tuple{ElementTypes: []Type{Bool}},
+			"tuple_empty":  Tuple{ElementTypes: []Type{}},
+			"map":          Map{AttributeType: Bool},
+			"map_empty":    Map{AttributeType: Bool},
+			"object":       Object{AttributeTypes: map[string]Type{"true": Bool}},
+			"object_empty": Object{AttributeTypes: map[string]Type{}},
+			"null":         List{ElementType: String},
+			"unknown":      Map{AttributeType: Bool},
+		},
+	}
+	listContent := []Value{NewValue(Bool, true)}
+	setContent := []Value{NewValue(Bool, true)}
+	tupleContent := []Value{NewValue(Bool, true)}
+	mapContent := map[string]Value{"true": NewValue(Bool, true)}
+	objectContent := map[string]Value{"true": NewValue(Bool, true)}
+	valContent := map[string]Value{
+		"string":       NewValue(valType.AttributeTypes["string"], "hello"),
+		"number":       NewValue(valType.AttributeTypes["number"], big.NewFloat(10)),
+		"bool":         NewValue(valType.AttributeTypes["bool"], true),
+		"list":         NewValue(valType.AttributeTypes["list"], listContent),
+		"list_empty":   NewValue(valType.AttributeTypes["list_empty"], []Value{}),
+		"set":          NewValue(valType.AttributeTypes["set"], setContent),
+		"set_empty":    NewValue(valType.AttributeTypes["set_empty"], []Value{}),
+		"tuple":        NewValue(valType.AttributeTypes["tuple"], tupleContent),
+		"tuple_empty":  NewValue(valType.AttributeTypes["tuple_empty"], []Value{}),
+		"map":          NewValue(valType.AttributeTypes["map"], mapContent),
+		"map_empty":    NewValue(valType.AttributeTypes["map_empty"], map[string]Value{}),
+		"object":       NewValue(valType.AttributeTypes["object"], objectContent),
+		"object_empty": NewValue(valType.AttributeTypes["object_empty"], map[string]Value{}),
+		"null":         NewValue(valType.AttributeTypes["null"], nil),
+		"unknown":      NewValue(valType.AttributeTypes["unknown"], UnknownValue),
+	}
+	val := NewValue(valType, valContent)
+
+	gotCalls := map[string]Value{}
+	wantCalls := map[string]Value{
+		``:                                       val,
+		`AttributeName("string")`:                valContent["string"],
+		`AttributeName("number")`:                valContent["number"],
+		`AttributeName("bool")`:                  valContent["bool"],
+		`AttributeName("list")`:                  valContent["list"],
+		`AttributeName("list").ElementKeyInt(0)`: listContent[0],
+		`AttributeName("list_empty")`:            valContent["list_empty"],
+		`AttributeName("set")`:                   valContent["set"],
+		`AttributeName("set").ElementKeyValue(` + setContent[0].String() + `)`: setContent[0],
+		`AttributeName("set_empty")`:                    valContent["set_empty"],
+		`AttributeName("tuple")`:                        valContent["tuple"],
+		`AttributeName("tuple").ElementKeyInt(0)`:       tupleContent[0],
+		`AttributeName("tuple_empty")`:                  valContent["tuple_empty"],
+		`AttributeName("map")`:                          valContent["map"],
+		`AttributeName("map").ElementKeyString("true")`: mapContent["true"],
+		`AttributeName("map_empty")`:                    valContent["map_empty"],
+		`AttributeName("object")`:                       valContent["object"],
+		`AttributeName("object").AttributeName("true")`: objectContent["true"],
+		`AttributeName("object_empty")`:                 valContent["object_empty"],
+		`AttributeName("null")`:                         valContent["null"],
+		`AttributeName("unknown")`:                      valContent["unknown"],
+	}
+
+	err := Walk(val, func(path AttributePath, val Value) (bool, error) {
+		gotCalls[path.String()] = val
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for path, expected := range wantCalls {
+		got, ok := gotCalls[path]
+		if !ok {
+			t.Errorf("no value at %q, expected %s", path, expected.String())
+		} else {
+			if diff := cmp.Diff(expected, got, ValueComparer()); diff != "" {
+				t.Errorf("wrong value at %q. (-wanted, +got): %s", path, diff)
+			}
+		}
+	}
+
+	for path, unexpected := range gotCalls {
+		if _, ok := wantCalls[path]; ok {
+			continue
+		}
+		t.Errorf("unexpected call to %q, has value %s", path, unexpected.String())
+	}
+}
+
+func TestTransform(t *testing.T) {
+	valType := Object{
+		AttributeTypes: map[string]Type{
+			"string":       String,
+			"number":       Number,
+			"bool":         Bool,
+			"list":         List{ElementType: Bool},
+			"list_empty":   List{ElementType: Bool},
+			"set":          Set{ElementType: Bool},
+			"set_empty":    Set{ElementType: Bool},
+			"tuple":        Tuple{ElementTypes: []Type{Bool}},
+			"tuple_empty":  Tuple{ElementTypes: []Type{}},
+			"map":          Map{AttributeType: Bool},
+			"map_empty":    Map{AttributeType: Bool},
+			"object":       Object{AttributeTypes: map[string]Type{"true": Bool}},
+			"object_empty": Object{AttributeTypes: map[string]Type{}},
+			"null":         List{ElementType: String},
+			"unknown":      Map{AttributeType: Bool},
+		},
+	}
+	valContent := map[string]Value{
+		"string":     NewValue(valType.AttributeTypes["string"], "hello"),
+		"number":     NewValue(valType.AttributeTypes["number"], big.NewFloat(10)),
+		"bool":       NewValue(valType.AttributeTypes["bool"], true),
+		"list":       NewValue(valType.AttributeTypes["list"], []Value{NewValue(Bool, true)}),
+		"list_empty": NewValue(valType.AttributeTypes["list_empty"], []Value{}),
+		"set":        NewValue(valType.AttributeTypes["set"], []Value{NewValue(Bool, true)}),
+		"set_empty":  NewValue(valType.AttributeTypes["set_empty"], []Value{}),
+		"tuple":      NewValue(valType.AttributeTypes["tuple"], []Value{NewValue(Bool, true)}),
+		"map":        NewValue(valType.AttributeTypes["map"], map[string]Value{"true": NewValue(Bool, true)}),
+		"map_empty":  NewValue(valType.AttributeTypes["map_empty"], map[string]Value{}),
+		"object":     NewValue(valType.AttributeTypes["object"], map[string]Value{"true": NewValue(Bool, true)}),
+		"null":       NewValue(valType.AttributeTypes["null"], nil),
+		"unknown":    NewValue(valType.AttributeTypes["unknown"], UnknownValue),
+	}
+	val := NewValue(valType, valContent)
+
+	type testCase struct {
+		f     func(AttributePath, Value) (Value, error)
+		diffs []ValueDiff
+	}
+
+	newValuePointer := func(typ Type, v interface{}) *Value {
+		val := NewValue(typ, v)
+		return &val
+	}
+
+	tests := map[string]testCase{
+		"string": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("string")
+				if path.Equal(target) {
+					return NewValue(String, "hello, world"), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("string"),
+					Value1: newValuePointer(String, "hello"),
+					Value2: newValuePointer(String, "hello, world"),
+				},
+			},
+		},
+		"string:null": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("string")
+				if path.Equal(target) {
+					return NewValue(String, nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("string"),
+					Value1: newValuePointer(String, "hello"),
+					Value2: newValuePointer(String, nil),
+				},
+			},
+		},
+		"string:unknown": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("string")
+				if path.Equal(target) {
+					return NewValue(String, UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("string"),
+					Value1: newValuePointer(String, "hello"),
+					Value2: newValuePointer(String, UnknownValue),
+				},
+			},
+		},
+		"number": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("number")
+				if path.Equal(target) {
+					return NewValue(Number, big.NewFloat(123)), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("number"),
+					Value1: newValuePointer(Number, big.NewFloat(10)),
+					Value2: newValuePointer(Number, big.NewFloat(123)),
+				},
+			},
+		},
+		"number:null": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("number")
+				if path.Equal(target) {
+					return NewValue(Number, nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("number"),
+					Value1: newValuePointer(Number, big.NewFloat(10)),
+					Value2: newValuePointer(Number, nil),
+				},
+			},
+		},
+		"number:unknown": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("number")
+				if path.Equal(target) {
+					return NewValue(Number, UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("number"),
+					Value1: newValuePointer(Number, big.NewFloat(10)),
+					Value2: newValuePointer(Number, UnknownValue),
+				},
+			},
+		},
+		"bool": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("bool")
+				if path.Equal(target) {
+					return NewValue(Bool, false), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("bool"),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, false),
+				},
+			},
+		},
+		"bool:null": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("bool")
+				if path.Equal(target) {
+					return NewValue(Bool, nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("bool"),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, nil),
+				},
+			},
+		},
+		"bool:unknown": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("bool")
+				if path.Equal(target) {
+					return NewValue(Bool, UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("bool"),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, UnknownValue),
+				},
+			},
+		},
+		"list:null": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("list")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["list"], nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("list"),
+					Value1: newValuePointer(valType.AttributeTypes["list"], []Value{
+						NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["list"], nil),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"list:unknown": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("list")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["list"], UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("list"),
+					Value1: newValuePointer(valType.AttributeTypes["list"], []Value{
+						NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["list"], UnknownValue),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"list:nullElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("list").WithElementKeyInt(0)
+				if path.Equal(target) {
+					return NewValue(Bool, nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, nil),
+				},
+			},
+		},
+		"list:unknownElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("list").WithElementKeyInt(0)
+				if path.Equal(target) {
+					return NewValue(Bool, UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, UnknownValue),
+				},
+			},
+		},
+		"list:replaceElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("list").WithElementKeyInt(0)
+				if path.Equal(target) {
+					return NewValue(Bool, false), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, false),
+				},
+			},
+		},
+		"list:addElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("list")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["list"], []Value{
+						NewValue(Bool, true), NewValue(Bool, false),
+					}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("list"),
+					Value1: newValuePointer(valType.AttributeTypes["list"], []Value{
+						NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["list"], []Value{
+						NewValue(Bool, true), NewValue(Bool, false),
+					}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(1),
+					Value1: nil,
+					Value2: newValuePointer(Bool, false),
+				},
+			},
+		},
+		"list:removeElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("list")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["list"], []Value{}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("list"),
+					Value1: newValuePointer(valType.AttributeTypes["list"], []Value{
+						NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["list"], []Value{}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"list_empty": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("list_empty")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["list_empty"], []Value{
+						NewValue(Bool, true),
+					}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("list_empty"),
+					Value1: newValuePointer(valType.AttributeTypes["list_empty"], []Value{}),
+					Value2: newValuePointer(valType.AttributeTypes["list_empty"], []Value{
+						NewValue(Bool, true),
+					}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("list_empty").WithElementKeyInt(0),
+					Value1: nil,
+					Value2: newValuePointer(Bool, true),
+				},
+			},
+		},
+		"set:null": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("set")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["set"], nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("set"),
+					Value1: newValuePointer(valType.AttributeTypes["set"], []Value{
+						NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["set"], nil),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"set:unknown": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("set")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["set"], UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("set"),
+					Value1: newValuePointer(valType.AttributeTypes["set"], []Value{
+						NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["set"], UnknownValue),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"set:nullElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true))
+				if path.Equal(target) {
+					return NewValue(Bool, nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, nil)),
+					Value1: nil,
+					Value2: newValuePointer(Bool, nil),
+				},
+			},
+		},
+		"set:unknownElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true))
+				if path.Equal(target) {
+					return NewValue(Bool, UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, UnknownValue)),
+					Value1: nil,
+					Value2: newValuePointer(Bool, UnknownValue),
+				},
+			},
+		},
+		"set:replaceElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true))
+				if path.Equal(target) {
+					return NewValue(Bool, false), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, false)),
+					Value1: nil,
+					Value2: newValuePointer(Bool, false),
+				},
+			},
+		},
+		"set:addElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("set")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["set"], []Value{
+						NewValue(Bool, true), NewValue(Bool, false),
+					}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("set"),
+					Value1: newValuePointer(valType.AttributeTypes["set"], []Value{
+						NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["set"], []Value{
+						NewValue(Bool, true), NewValue(Bool, false),
+					}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, false)),
+					Value1: nil,
+					Value2: newValuePointer(Bool, false),
+				},
+			},
+		},
+		"set:removeElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("set")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["set"], []Value{}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("set"),
+					Value1: newValuePointer(valType.AttributeTypes["set"], []Value{
+						NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["set"], []Value{}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"set_empty": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("set_empty")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["set_empty"], []Value{
+						NewValue(Bool, true),
+					}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("set_empty"),
+					Value1: newValuePointer(valType.AttributeTypes["set_empty"], []Value{}),
+					Value2: newValuePointer(valType.AttributeTypes["set_empty"], []Value{
+						NewValue(Bool, true),
+					}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("set_empty").WithElementKeyValue(NewValue(Bool, true)),
+					Value1: nil,
+					Value2: newValuePointer(Bool, true),
+				},
+			},
+		},
+		"tuple:null": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("tuple")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["tuple"], nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("tuple"),
+					Value1: newValuePointer(valType.AttributeTypes["tuple"], []Value{
+						NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["tuple"], nil),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"tuple:unknown": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("tuple")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["tuple"], UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("tuple"),
+					Value1: newValuePointer(valType.AttributeTypes["tuple"], []Value{
+						NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["tuple"], UnknownValue),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"tuple:nullElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0)
+				if path.Equal(target) {
+					return NewValue(Bool, nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, nil),
+				},
+			},
+		},
+		"tuple:unknownElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0)
+				if path.Equal(target) {
+					return NewValue(Bool, UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, UnknownValue),
+				},
+			},
+		},
+		"tuple:replaceElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0)
+				if path.Equal(target) {
+					return NewValue(Bool, false), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, false),
+				},
+			},
+		},
+		"map:null": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("map")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["map"], nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("map"),
+					Value1: newValuePointer(valType.AttributeTypes["map"], map[string]Value{
+						"true": NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["map"], nil),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"map:unknown": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("map")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["map"], UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("map"),
+					Value1: newValuePointer(valType.AttributeTypes["map"], map[string]Value{
+						"true": NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["map"], UnknownValue),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"map:nullElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("map").WithElementKeyString("true")
+				if path.Equal(target) {
+					return NewValue(Bool, nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, nil),
+				},
+			},
+		},
+		"map:unknownElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("map").WithElementKeyString("true")
+				if path.Equal(target) {
+					return NewValue(Bool, UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, UnknownValue),
+				},
+			},
+		},
+		"map:replaceElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("map").WithElementKeyString("true")
+				if path.Equal(target) {
+					return NewValue(Bool, false), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, false),
+				},
+			},
+		},
+		"map:addElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("map")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["map"], map[string]Value{
+						"true":  NewValue(Bool, true),
+						"false": NewValue(Bool, false),
+					}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("map"),
+					Value1: newValuePointer(valType.AttributeTypes["map"], map[string]Value{
+						"true": NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["map"], map[string]Value{
+						"true":  NewValue(Bool, true),
+						"false": NewValue(Bool, false),
+					}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("false"),
+					Value1: nil,
+					Value2: newValuePointer(Bool, false),
+				},
+			},
+		},
+		"map:removeElement": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("map")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["map"], map[string]Value{}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path: AttributePath{}.WithAttributeName("map"),
+					Value1: newValuePointer(valType.AttributeTypes["map"], map[string]Value{
+						"true": NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["map"], map[string]Value{}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+			},
+		},
+		"map_empty": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("map_empty")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["map_empty"], map[string]Value{
+						"foo": NewValue(Bool, true),
+					}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("map_empty"),
+					Value1: newValuePointer(valType.AttributeTypes["map_empty"], map[string]Value{}),
+					Value2: newValuePointer(valType.AttributeTypes["map_empty"], map[string]Value{
+						"foo": NewValue(Bool, true),
+					}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("map_empty").WithElementKeyString("foo"),
+					Value1: nil,
+					Value2: newValuePointer(Bool, true),
+				},
+			},
+		},
+		"object:unknown": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("object")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["object"], UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("object").WithAttributeName("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+				{
+					Path: AttributePath{}.WithAttributeName("object"),
+					Value1: newValuePointer(valType.AttributeTypes["object"], map[string]Value{
+						"true": NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["object"], UnknownValue),
+				},
+			},
+		},
+		"object:null": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("object")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["object"], nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("object").WithAttributeName("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: nil,
+				},
+				{
+					Path: AttributePath{}.WithAttributeName("object"),
+					Value1: newValuePointer(valType.AttributeTypes["object"], map[string]Value{
+						"true": NewValue(Bool, true),
+					}),
+					Value2: newValuePointer(valType.AttributeTypes["object"], nil),
+				},
+			},
+		},
+		"object:attributeNull": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("object").WithAttributeName("true")
+				if path.Equal(target) {
+					return NewValue(Bool, nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("object").WithAttributeName("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, nil),
+				},
+			},
+		},
+		"object:attributeUnknown": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("object").WithAttributeName("true")
+				if path.Equal(target) {
+					return NewValue(Bool, UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("object").WithAttributeName("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, UnknownValue),
+				},
+			},
+		},
+		"object:replaceAttribute": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("object").WithAttributeName("true")
+				if path.Equal(target) {
+					return NewValue(Bool, false), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("object").WithAttributeName("true"),
+					Value1: newValuePointer(Bool, true),
+					Value2: newValuePointer(Bool, false),
+				},
+			},
+		},
+		"null:unknown": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("null")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["null"], UnknownValue), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("null"),
+					Value1: newValuePointer(valType.AttributeTypes["null"], nil),
+					Value2: newValuePointer(valType.AttributeTypes["null"], UnknownValue),
+				},
+			},
+		},
+		"null:set": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("null")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["null"], []Value{
+						NewValue(String, "testing"),
+					}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("null"),
+					Value1: newValuePointer(valType.AttributeTypes["null"], nil),
+					Value2: newValuePointer(valType.AttributeTypes["null"], []Value{
+						NewValue(String, "testing"),
+					}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("null").WithElementKeyInt(0),
+					Value1: nil,
+					Value2: newValuePointer(String, "testing"),
+				},
+			},
+		},
+		"unknown:null": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("unknown")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["unknown"], nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("unknown"),
+					Value1: newValuePointer(valType.AttributeTypes["unknown"], UnknownValue),
+					Value2: newValuePointer(valType.AttributeTypes["unknown"], nil),
+				},
+			},
+		},
+		"unknown:set": {
+			f: func(path AttributePath, v Value) (Value, error) {
+				target := AttributePath{}.WithAttributeName("unknown")
+				if path.Equal(target) {
+					return NewValue(valType.AttributeTypes["unknown"], map[string]Value{
+						"testing": NewValue(Bool, true),
+					}), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("unknown"),
+					Value1: newValuePointer(valType.AttributeTypes["unknown"], UnknownValue),
+					Value2: newValuePointer(valType.AttributeTypes["unknown"], map[string]Value{
+						"testing": NewValue(Bool, true),
+					}),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("unknown").WithElementKeyString("testing"),
+					Value1: nil,
+					Value2: newValuePointer(Bool, true),
+				},
+			},
+		},
+		"null:byValue": {
+			f: func(_ AttributePath, v Value) (Value, error) {
+				if v.IsNull() {
+					// TODO: replace with v.Type() when #58 lands
+					return NewValue(v.typ, UnknownValue), nil
+				}
+				if !v.IsKnown() {
+					return NewValue(v.typ, nil), nil
+				}
+				return v, nil
+			},
+			diffs: []ValueDiff{
+				{
+					Path:   AttributePath{}.WithAttributeName("unknown"),
+					Value1: newValuePointer(valType.AttributeTypes["unknown"], UnknownValue),
+					Value2: newValuePointer(valType.AttributeTypes["unknown"], nil),
+				},
+				{
+					Path:   AttributePath{}.WithAttributeName("null"),
+					Value1: newValuePointer(valType.AttributeTypes["null"], nil),
+					Value2: newValuePointer(valType.AttributeTypes["null"], UnknownValue),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range tests {
+		name, testCase, val := name, testCase, val.Copy()
+		t.Run(fmt.Sprintf("testCase=%s", name), func(t *testing.T) {
+			gotVal, err := Transform(val, testCase.f)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			diffs, err := val.Diff(gotVal)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			wantedDiffs := map[string]ValueDiff{}
+			for _, diff := range testCase.diffs {
+				wantedDiffs[diff.Path.String()] = diff
+			}
+			gotDiffs := map[string]ValueDiff{}
+			for _, diff := range diffs {
+				gotDiffs[diff.Path.String()] = diff
+			}
+			for k, diff := range wantedDiffs {
+				gotDiff, ok := gotDiffs[k]
+				if !ok {
+					t.Errorf("Missing diff %s", diff)
+				} else if !diff.Equal(gotDiff) {
+					t.Errorf("Unexpected diff, wanted %s, got %s", diff, gotDiff)
+				}
+			}
+			for k, diff := range gotDiffs {
+				if _, ok := wantedDiffs[k]; ok {
+					continue
+				}
+				t.Errorf("Unexpected diff: %s", diff)
+			}
+		})
+	}
+}

--- a/tfprotov5/tftypes/walk_test.go
+++ b/tfprotov5/tftypes/walk_test.go
@@ -1116,11 +1116,10 @@ func TestTransform(t *testing.T) {
 		"null:byValue": {
 			f: func(_ AttributePath, v Value) (Value, error) {
 				if v.IsNull() {
-					// TODO: replace with v.Type() when #58 lands
-					return NewValue(v.typ, UnknownValue), nil
+					return NewValue(v.Type(), UnknownValue), nil
 				}
 				if !v.IsKnown() {
-					return NewValue(v.typ, nil), nil
+					return NewValue(v.Type(), nil), nil
 				}
 				return v, nil
 			},


### PR DESCRIPTION
This turned into a massive commit. I'm really sorry.

I set out to implement Walk and Transform. Walk was simple enough.
Transform was implemented quickly and easily enough. And then I tried to
test it.

Testing Transform reasonably necessitated all the other changes you see
here:

* We needed to be able to Diff Values to be able to express changes
  between Values so we could test that Transform made the changes we
  wanted it to.
* We needed to be able to represent AttributePaths as strings so we
  could have specific, useful test output. This also entailed making
  Values strings (AttributePaths can use Values as a step) and making
  Types have more specific strings (aggregate types now expose the
  subtypes that make up their type signature).
* In doing so, we kept accidentally overwriting our AttributePaths,
  meaning it was time for them to stop being modified in place and start
  being passed by value, with the steps defensively copied to avoid
  accidental modification.
* We needed the ability to detect whether Diffs were equal to know
  whether the changes we expected were the changes we actually got or
  not.
* We needed to make Values an AttributePathStepper so we could implement
  Diff, which is done by Walking one Value, and then retrieving the same
  sub-Value from the Value we're Diffing against to check if they're the
  same. We already have WalkAttributePath to retrieve part of a Go type
  based on the AttributePath passed in, we just needed to tell it how to
  index into a Value type.
* We needed the ability to Copy a Value type so that it was not sharing
  the same memory space anymore so our transformations didn't leak
  across tests.

The result is this PR of alarming size. The good news is a lot of these
new lines are tests.