### PR TITLE
Upgrade to Go 1.15.

### DIFF
--- a/.changelog/62.txt
+++ b/.changelog/62.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+With the release of Go 1.16, Go 1.15 is now the lowest supported version of Go to use with terraform-plugin-go.
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,15 +23,15 @@ commands:
             - "bin/"
 
 jobs:
-  "docker-go114 build":
+  "docker-go116 build":
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
     steps:
       - get_dependencies
       - run: go build ./...
-  "docker-go114 test":
+  "docker-go116 test":
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
         environment:
           TF_ACC_TERRAFORM_VERSION: "0.12.26"
     parameters:
@@ -51,28 +51,75 @@ jobs:
           destination: raw-test-output
       - store_test_results:
           path: << parameters.test_results >>
-  "docker-go114 vet":
+  "docker-go116 vet":
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
     steps:
       - get_dependencies
       - run: go vet ./...
-  "docker-go114 gofmt":
+  "docker-go116 gofmt":
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
     steps:
       - get_dependencies
       - run: ./scripts/gofmtcheck.sh
-  "docker-go114 golangci-lint":
+  "docker-go116 golangci-lint":
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.16
     steps:
       - get_dependencies
       - get_golangci_lint
       - run: bin/golangci-lint run -v ./...
-  "docker-go114 release":
+  "docker-go115 build":
     docker:
-      - image: circleci/golang:1.14
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
+    steps:
+      - get_dependencies
+      - run: go build ./...
+  "docker-go115 test":
+    docker:
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
+        environment:
+          TF_ACC_TERRAFORM_VERSION: "0.12.26"
+    parameters:
+      test_results:
+        type: string
+        default: /tmp/test-results
+    steps:
+      - get_dependencies
+      - run: mkdir -p << parameters.test_results >>/report
+      - run:
+          command: |
+            gotestsum --junitfile << parameters.test_results >>/report/gotestsum-report.xml -- -coverprofile=cover.out ./...
+            go tool cover -html=cover.out -o coverage.html
+            mv coverage.html << parameters.test_results >>
+      - store_artifacts:
+          path: << parameters.test_results >>
+          destination: raw-test-output
+      - store_test_results:
+          path: << parameters.test_results >>
+  "docker-go115 vet":
+    docker:
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
+    steps:
+      - get_dependencies
+      - run: go vet ./...
+  "docker-go115 gofmt":
+    docker:
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
+    steps:
+      - get_dependencies
+      - run: ./scripts/gofmtcheck.sh
+  "docker-go115 golangci-lint":
+    docker:
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.15
+    steps:
+      - get_dependencies
+      - get_golangci_lint
+      - run: bin/golangci-lint run -v ./...
+  "docker-go115 release":
+    docker:
+      - image: circleci/golang:1.15
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -84,48 +131,78 @@ workflows:
   version: 2
   pr:
     jobs:
-      - "docker-go114 build"
-      - "docker-go114 test":
+      - "docker-go115 build"
+      - "docker-go115 test":
           requires:
-            - "docker-go114 build"
-      - "docker-go114 vet":
+            - "docker-go115 build"
+      - "docker-go115 vet":
           requires:
-            - "docker-go114 build"
-      - "docker-go114 gofmt":
+            - "docker-go115 build"
+      - "docker-go115 gofmt":
           requires:
-            - "docker-go114 build"
-      - "docker-go114 golangci-lint":
+            - "docker-go115 build"
+      - "docker-go115 golangci-lint":
           requires:
-            - "docker-go114 build"
+            - "docker-go115 build"
+      - "docker-go116 build"
+      - "docker-go116 test":
+          requires:
+            - "docker-go116 build"
+      - "docker-go116 vet":
+          requires:
+            - "docker-go116 build"
+      - "docker-go116 gofmt":
+          requires:
+            - "docker-go116 build"
+      - "docker-go116 golangci-lint":
+          requires:
+            - "docker-go116 build"
   release:
     jobs:
-      - "docker-go114 build"
-      - "docker-go114 test":
+      - "docker-go116 build"
+      - "docker-go116 test":
           requires:
-            - "docker-go114 build"
-      - "docker-go114 vet":
+            - "docker-go116 build"
+      - "docker-go116 vet":
           requires:
-            - "docker-go114 build"
-      - "docker-go114 gofmt":
+            - "docker-go116 build"
+      - "docker-go116 gofmt":
           requires:
-            - "docker-go114 build"
-      - "docker-go114 golangci-lint":
+            - "docker-go116 build"
+      - "docker-go116 golangci-lint":
           requires:
-            - "docker-go114 build"
+            - "docker-go116 build"
+      - "docker-go115 build"
+      - "docker-go115 test":
+          requires:
+            - "docker-go115 build"
+      - "docker-go115 vet":
+          requires:
+            - "docker-go115 build"
+      - "docker-go115 gofmt":
+          requires:
+            - "docker-go115 build"
+      - "docker-go115 golangci-lint":
+          requires:
+            - "docker-go115 build"
       - trigger-release:
           filters:
             branches:
               only:
                 - main
           type: approval
-      - "docker-go114 release":
+      - "docker-go115 release":
           filters:
             branches:
               only:
                 - main
           requires:
             - trigger-release
-            - "docker-go114 test"
-            - "docker-go114 vet"
-            - "docker-go114 gofmt"
-            - "docker-go114 golangci-lint"
+            - "docker-go115 test"
+            - "docker-go115 vet"
+            - "docker-go115 gofmt"
+            - "docker-go116 golangci-lint"
+            - "docker-go116 test"
+            - "docker-go116 vet"
+            - "docker-go116 gofmt"
+            - "docker-go116 golangci-lint"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-plugin-go
 
-go 1.14
+go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.2


### PR DESCRIPTION
As Go 1.16 is out, our latest supported version is now Go 1.15. Upgrade
to it, and add Go 1.16 to our CI testing matrix.