### PR TITLE
Make AttributePaths pointers, fix AttributePathErrors.

### DIFF
--- a/.changelog/68.txt
+++ b/.changelog/68.txt
@@ -1,0 +1,15 @@
+```release-note:breaking-change
+`tftypes.AttributePath` is now referenced as a pointer instead of a value pretty much everywhere it is used. This enables much more ergonomic use with `tfprotov5.Diagnostic` values.
+```
+
+```release-note:breaking-change
+`tftypes.AttributePath`'s `Steps` property is now internal-only. Use `tftypes.AttributePath.Steps()` to access the list of `tftypes.AttributePathSteps`, and `tftypes.NewAttributePath` or `tftypes.NewAttributePathWithSteps` to create a new `tftypes.AttributePath`.
+```
+
+```release-note:enhancement
+`tftypes.AttributePathError` is now exported. Provider developers can use `errors.Is` and `errors.As` to check for `tftypes.AttributePathError`s, `errors.Unwrap` to get to the underlying error, and the `Path` property on a `tftypes.AttributePathError` to access the `tftypes.AttributePath` the error is associated with. `tftypes.AttributePath.NewError` and `tftypes.AttributePath.NewErrorf` are still the supported ways to create a `tftypes.AttributePathError`.
+```
+
+```release-note:enhancement
+A number of methods in `tftypes` are benefitting from a better error message for `tftypes.AttributePathError`s, which are returned in various places, and will now surface the path associated with the error as part of the error message.
+```

--- a/tfprotov5/internal/fromproto/attribute_path.go
+++ b/tfprotov5/internal/fromproto/attribute_path.go
@@ -14,9 +14,7 @@ func AttributePath(in *tfplugin5.AttributePath) (*tftypes.AttributePath, error) 
 	if err != nil {
 		return nil, err
 	}
-	return &tftypes.AttributePath{
-		Steps: steps,
-	}, nil
+	return tftypes.NewAttributePathWithSteps(steps), nil
 }
 
 func AttributePaths(in []*tfplugin5.AttributePath) ([]*tftypes.AttributePath, error) {

--- a/tfprotov5/internal/toproto/attribute_path.go
+++ b/tfprotov5/internal/toproto/attribute_path.go
@@ -10,7 +10,10 @@ import (
 var ErrUnknownAttributePathStepType = errors.New("unknown type of AttributePath_Step")
 
 func AttributePath(in *tftypes.AttributePath) (*tfplugin5.AttributePath, error) {
-	steps, err := AttributePath_Steps(in.Steps)
+	if in == nil {
+		return nil, nil
+	}
+	steps, err := AttributePath_Steps(in.Steps())
 	if err != nil {
 		return nil, err
 	}

--- a/tfprotov5/tftypes/attribute_path.go
+++ b/tfprotov5/tftypes/attribute_path.go
@@ -25,12 +25,37 @@ var (
 type AttributePath struct {
 	// Steps are the steps that must be followed from the root of the value
 	// to obtain the value being indicated.
-	Steps []AttributePathStep
+	steps []AttributePathStep
 }
 
-func (a AttributePath) String() string {
+// NewAttributePath returns an empty AttributePath, ready to have steps added
+// to it using WithElementKeyString, WithElementKeyInt, WithElementKeyValue, or
+// WithAttributeName.
+func NewAttributePath() *AttributePath {
+	return &AttributePath{}
+}
+
+// NewAttributePathWithSteps returns an AttributePath populated with the passed
+// AttributePathSteps.
+func NewAttributePathWithSteps(steps []AttributePathStep) *AttributePath {
+	return &AttributePath{
+		steps: steps,
+	}
+}
+
+// Steps returns the AttributePathSteps that make up an AttributePath.
+func (a *AttributePath) Steps() []AttributePathStep {
+	if a == nil {
+		return nil
+	}
+	steps := make([]AttributePathStep, len(a.steps))
+	copy(steps, a.steps)
+	return steps
+}
+
+func (a *AttributePath) String() string {
 	var res strings.Builder
-	for pos, step := range a.Steps {
+	for pos, step := range a.Steps() {
 		if pos != 0 {
 			res.WriteString(".")
 		}
@@ -51,12 +76,15 @@ func (a AttributePath) String() string {
 // Equal returns true if two AttributePaths should be considered equal.
 // AttributePaths are considered equal if they have the same number of steps,
 // the steps are all the same types, and the steps have all the same values.
-func (a AttributePath) Equal(o AttributePath) bool {
-	if len(a.Steps) != len(o.Steps) {
+func (a *AttributePath) Equal(o *AttributePath) bool {
+	if len(a.Steps()) == 0 && len(o.Steps()) == 0 {
+		return true
+	}
+	if len(a.Steps()) != len(o.Steps()) {
 		return false
 	}
-	for pos, aStep := range a.Steps {
-		oStep := o.Steps[pos]
+	for pos, aStep := range a.Steps() {
+		oStep := o.Steps()[pos]
 		switch aStep.(type) {
 		case AttributeName, ElementKeyString, ElementKeyInt:
 			if oStep != aStep {
@@ -79,74 +107,73 @@ func (a AttributePath) Equal(o AttributePath) bool {
 
 // NewErrorf returns an error associated with the value indicated by `a`. This
 // is equivalent to calling a.NewError(fmt.Errorf(f, args...)).
-func (a AttributePath) NewErrorf(f string, args ...interface{}) error {
-	return attributePathError{
-		error: fmt.Errorf(f, args...),
-		path:  a,
-	}
+func (a *AttributePath) NewErrorf(f string, args ...interface{}) error {
+	return a.NewError(fmt.Errorf(f, args...))
 }
 
 // NewError returns an error that associates `err` with the value indicated by
 // `a`.
-func (a AttributePath) NewError(err error) error {
-	return attributePathError{
-		error: err,
-		path:  a,
+func (a *AttributePath) NewError(err error) error {
+	var wrapped AttributePathError
+	if errors.As(err, &wrapped) {
+		// TODO: at some point we'll probably want to handle the
+		// AttributePathError-within-AttributePathError situation,
+		// either by de-duplicating the paths we're surfacing, or
+		// privileging one, or something. For now, let's just do the
+		// naive thing and not add our own path.
+		return err
+	}
+	return AttributePathError{
+		Path: a,
+		err:  err,
 	}
 }
 
 // WithAttributeName adds an AttributeName step to `a`, using `name` as the
-// attribute's name.
-func (a AttributePath) WithAttributeName(name string) AttributePath {
-	steps := make([]AttributePathStep, len(a.Steps))
-	copy(steps, a.Steps)
-	return AttributePath{
-		Steps: append(steps, AttributeName(name)),
+// attribute's name. `a` is copied, not modified.
+func (a *AttributePath) WithAttributeName(name string) *AttributePath {
+	steps := a.Steps()
+	return &AttributePath{
+		steps: append(steps, AttributeName(name)),
 	}
 }
 
 // WithElementKeyString adds an ElementKeyString step to `a`, using `key` as
-// the element's key.
-func (a AttributePath) WithElementKeyString(key string) AttributePath {
-	steps := make([]AttributePathStep, len(a.Steps))
-	copy(steps, a.Steps)
-	return AttributePath{
-		Steps: append(steps, ElementKeyString(key)),
+// the element's key. `a` is copied, not modified.
+func (a *AttributePath) WithElementKeyString(key string) *AttributePath {
+	steps := a.Steps()
+	return &AttributePath{
+		steps: append(steps, ElementKeyString(key)),
 	}
 }
 
 // WithElementKeyInt adds an ElementKeyInt step to `a`, using `key` as the
-// element's key.
-func (a AttributePath) WithElementKeyInt(key int64) AttributePath {
-	steps := make([]AttributePathStep, len(a.Steps))
-	copy(steps, a.Steps)
-	return AttributePath{
-		Steps: append(steps, ElementKeyInt(key)),
+// element's key. `a` is copied, not modified.
+func (a *AttributePath) WithElementKeyInt(key int64) *AttributePath {
+	steps := a.Steps()
+	return &AttributePath{
+		steps: append(steps, ElementKeyInt(key)),
 	}
 }
 
 // WithElementKeyValue adds an ElementKeyValue to `a`, using `key` as the
-// element's key.
-func (a AttributePath) WithElementKeyValue(key Value) AttributePath {
-	steps := make([]AttributePathStep, len(a.Steps))
-	copy(steps, a.Steps)
-	return AttributePath{
-		Steps: append(steps, ElementKeyValue(key.Copy())),
+// element's key. `a` is copied, not modified.
+func (a *AttributePath) WithElementKeyValue(key Value) *AttributePath {
+	steps := a.Steps()
+	return &AttributePath{
+		steps: append(steps, ElementKeyValue(key.Copy())),
 	}
 }
 
 // WithoutLastStep removes the last step, whatever kind of step it was, from
-// `a`.
-func (a AttributePath) WithoutLastStep() AttributePath {
-	steps := make([]AttributePathStep, len(a.Steps))
-	copy(steps, a.Steps)
-	if len(a.Steps) < 1 {
-		return AttributePath{
-			Steps: steps,
-		}
+// `a`. `a` is copied, not modified.
+func (a *AttributePath) WithoutLastStep() *AttributePath {
+	steps := a.Steps()
+	if len(steps) == 0 {
+		return nil
 	}
-	return AttributePath{
-		Steps: steps[:len(steps)-1],
+	return &AttributePath{
+		steps: steps[:len(steps)-1],
 	}
 }
 
@@ -214,8 +241,8 @@ type AttributePathStepper interface {
 // map[string]interface{} and []interface{} types have built-in support. Other
 // types need to use the AttributePathStepper interface to tell
 // WalkAttributePath how to traverse themselves.
-func WalkAttributePath(in interface{}, path AttributePath) (interface{}, AttributePath, error) {
-	if len(path.Steps) < 1 {
+func WalkAttributePath(in interface{}, path *AttributePath) (interface{}, *AttributePath, error) {
+	if len(path.Steps()) < 1 {
 		return in, path, nil
 	}
 	stepper, ok := in.(AttributePathStepper)
@@ -225,12 +252,11 @@ func WalkAttributePath(in interface{}, path AttributePath) (interface{}, Attribu
 			return in, path, ErrNotAttributePathStepper
 		}
 	}
-	next, err := stepper.ApplyTerraform5AttributePathStep(path.Steps[0])
+	next, err := stepper.ApplyTerraform5AttributePathStep(path.Steps()[0])
 	if err != nil {
 		return in, path, err
 	}
-	path.Steps = path.Steps[1:]
-	return WalkAttributePath(next, path)
+	return WalkAttributePath(next, &AttributePath{steps: path.Steps()[1:]})
 }
 
 func builtinAttributePathStepper(in interface{}) (AttributePathStepper, bool) {

--- a/tfprotov5/tftypes/attribute_path_error.go
+++ b/tfprotov5/tftypes/attribute_path_error.go
@@ -1,6 +1,20 @@
 package tftypes
 
-type attributePathError struct {
-	path AttributePath
-	error
+import (
+	"fmt"
+)
+
+// AttributePathError represents an error associated with part of a
+// tftypes.Value, indicated by the Path property.
+type AttributePathError struct {
+	Path *AttributePath
+	err  error
+}
+
+func (a AttributePathError) Error() string {
+	return fmt.Sprintf("%s: %s", a.Path, a.err)
+}
+
+func (a AttributePathError) Unwrap() error {
+	return a.err
 }

--- a/tfprotov5/tftypes/attribute_path_test.go
+++ b/tfprotov5/tftypes/attribute_path_test.go
@@ -44,7 +44,7 @@ func TestWalkAttributePath(t *testing.T) {
 	t.Parallel()
 	type testCase struct {
 		value    interface{}
-		path     AttributePath
+		path     *AttributePath
 		expected interface{}
 	}
 	tests := map[string]testCase{
@@ -59,8 +59,8 @@ func TestWalkAttributePath(t *testing.T) {
 					"blue": 234,
 				},
 			},
-			path: AttributePath{
-				Steps: []AttributePathStep{
+			path: &AttributePath{
+				steps: []AttributePathStep{
 					AttributeName("a"),
 				},
 			},
@@ -80,8 +80,8 @@ func TestWalkAttributePath(t *testing.T) {
 					"blue": 234,
 				},
 			},
-			path: AttributePath{
-				Steps: []AttributePathStep{
+			path: &AttributePath{
+				steps: []AttributePathStep{
 					AttributeName("a"),
 					AttributeName("red"),
 				},
@@ -104,8 +104,8 @@ func TestWalkAttributePath(t *testing.T) {
 					},
 				},
 			},
-			path: AttributePath{
-				Steps: []AttributePathStep{
+			path: &AttributePath{
+				steps: []AttributePathStep{
 					ElementKeyInt(1),
 				},
 			},
@@ -134,8 +134,8 @@ func TestWalkAttributePath(t *testing.T) {
 					},
 				},
 			},
-			path: AttributePath{
-				Steps: []AttributePathStep{
+			path: &AttributePath{
+				steps: []AttributePathStep{
 					ElementKeyInt(1),
 					AttributeName("c"),
 					ElementKeyInt(0),
@@ -158,8 +158,8 @@ func TestWalkAttributePath(t *testing.T) {
 					},
 				},
 			},
-			path: AttributePath{
-				Steps: []AttributePathStep{
+			path: &AttributePath{
+				steps: []AttributePathStep{
 					ElementKeyInt(1),
 					AttributeName("Colors"),
 					ElementKeyInt(0),
@@ -187,75 +187,82 @@ func TestWalkAttributePath(t *testing.T) {
 func TestAttributePathEqual(t *testing.T) {
 	t.Parallel()
 	type testCase struct {
-		path1 AttributePath
-		path2 AttributePath
+		path1 *AttributePath
+		path2 *AttributePath
 		equal bool
 	}
 
 	tests := map[string]testCase{
 		"empty": {
-			path1: AttributePath{},
-			path2: AttributePath{},
+			path1: NewAttributePath(),
+			path2: NewAttributePath(),
+			equal: true,
+		},
+		"nil": {
+			equal: true,
+		},
+		"empty-and-nil": {
+			path1: NewAttributePath(),
 			equal: true,
 		},
 		"an-different-types": {
-			path1: AttributePath{}.WithAttributeName("testing"),
-			path2: AttributePath{}.WithElementKeyString("testing"),
+			path1: NewAttributePath().WithAttributeName("testing"),
+			path2: NewAttributePath().WithElementKeyString("testing"),
 			equal: false,
 		},
 		"eks-different-types": {
-			path1: AttributePath{}.WithElementKeyString("testing"),
-			path2: AttributePath{}.WithAttributeName("testing"),
+			path1: NewAttributePath().WithElementKeyString("testing"),
+			path2: NewAttributePath().WithAttributeName("testing"),
 			equal: false,
 		},
 		"eki-different-types": {
-			path1: AttributePath{}.WithElementKeyInt(1234),
-			path2: AttributePath{}.WithAttributeName("testing"),
+			path1: NewAttributePath().WithElementKeyInt(1234),
+			path2: NewAttributePath().WithAttributeName("testing"),
 			equal: false,
 		},
 		"ekv-different-types": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(String, "testing")),
-			path2: AttributePath{}.WithAttributeName("testing"),
+			path1: NewAttributePath().WithElementKeyValue(NewValue(String, "testing")),
+			path2: NewAttributePath().WithAttributeName("testing"),
 			equal: false,
 		},
 		"an": {
-			path1: AttributePath{}.WithAttributeName("testing"),
-			path2: AttributePath{}.WithAttributeName("testing"),
+			path1: NewAttributePath().WithAttributeName("testing"),
+			path2: NewAttributePath().WithAttributeName("testing"),
 			equal: true,
 		},
 		"an-an": {
-			path1: AttributePath{}.WithAttributeName("testing").WithAttributeName("testing2"),
-			path2: AttributePath{}.WithAttributeName("testing").WithAttributeName("testing2"),
+			path1: NewAttributePath().WithAttributeName("testing").WithAttributeName("testing2"),
+			path2: NewAttributePath().WithAttributeName("testing").WithAttributeName("testing2"),
 			equal: true,
 		},
 		"eks": {
-			path1: AttributePath{}.WithElementKeyString("testing"),
-			path2: AttributePath{}.WithElementKeyString("testing"),
+			path1: NewAttributePath().WithElementKeyString("testing"),
+			path2: NewAttributePath().WithElementKeyString("testing"),
 			equal: true,
 		},
 		"eks-eks": {
-			path1: AttributePath{}.WithElementKeyString("testing").WithElementKeyString("testing2"),
-			path2: AttributePath{}.WithElementKeyString("testing").WithElementKeyString("testing2"),
+			path1: NewAttributePath().WithElementKeyString("testing").WithElementKeyString("testing2"),
+			path2: NewAttributePath().WithElementKeyString("testing").WithElementKeyString("testing2"),
 			equal: true,
 		},
 		"eki": {
-			path1: AttributePath{}.WithElementKeyInt(123),
-			path2: AttributePath{}.WithElementKeyInt(123),
+			path1: NewAttributePath().WithElementKeyInt(123),
+			path2: NewAttributePath().WithElementKeyInt(123),
 			equal: true,
 		},
 		"eki-eki": {
-			path1: AttributePath{}.WithElementKeyInt(123).WithElementKeyInt(456),
-			path2: AttributePath{}.WithElementKeyInt(123).WithElementKeyInt(456),
+			path1: NewAttributePath().WithElementKeyInt(123).WithElementKeyInt(456),
+			path2: NewAttributePath().WithElementKeyInt(123).WithElementKeyInt(456),
 			equal: true,
 		},
 		"ekv": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(List{
+			path1: NewAttributePath().WithElementKeyValue(NewValue(List{
 				ElementType: String,
 			}, []Value{
 				NewValue(String, "hello"),
 				NewValue(String, "world"),
 			})),
-			path2: AttributePath{}.WithElementKeyValue(NewValue(List{
+			path2: NewAttributePath().WithElementKeyValue(NewValue(List{
 				ElementType: String,
 			}, []Value{
 				NewValue(String, "hello"),
@@ -264,13 +271,13 @@ func TestAttributePathEqual(t *testing.T) {
 			equal: true,
 		},
 		"ekv-ekv": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(List{
+			path1: NewAttributePath().WithElementKeyValue(NewValue(List{
 				ElementType: String,
 			}, []Value{
 				NewValue(String, "hello"),
 				NewValue(String, "world"),
 			})).WithElementKeyValue(NewValue(Bool, true)),
-			path2: AttributePath{}.WithElementKeyValue(NewValue(List{
+			path2: NewAttributePath().WithElementKeyValue(NewValue(List{
 				ElementType: String,
 			}, []Value{
 				NewValue(String, "hello"),
@@ -279,12 +286,12 @@ func TestAttributePathEqual(t *testing.T) {
 			equal: true,
 		},
 		"an-eks-eki-ekv": {
-			path1: AttributePath{}.WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
-			path2: AttributePath{}.WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
+			path1: NewAttributePath().WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
+			path2: NewAttributePath().WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
 			equal: true,
 		},
 		"ekv-eki-eks-an": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(Object{
+			path1: NewAttributePath().WithElementKeyValue(NewValue(Object{
 				AttributeTypes: map[string]Type{
 					"foo": Bool,
 					"bar": Number,
@@ -293,7 +300,7 @@ func TestAttributePathEqual(t *testing.T) {
 				"foo": NewValue(Bool, true),
 				"bar": NewValue(Number, big.NewFloat(1234)),
 			})).WithElementKeyInt(123).WithElementKeyString("testing").WithAttributeName("othertesting"),
-			path2: AttributePath{}.WithElementKeyValue(NewValue(Object{
+			path2: NewAttributePath().WithElementKeyValue(NewValue(Object{
 				AttributeTypes: map[string]Type{
 					"foo": Bool,
 					"bar": Number,
@@ -305,58 +312,58 @@ func TestAttributePathEqual(t *testing.T) {
 			equal: true,
 		},
 		"an-diff": {
-			path1: AttributePath{}.WithAttributeName("testing"),
-			path2: AttributePath{}.WithAttributeName("testing2"),
+			path1: NewAttributePath().WithAttributeName("testing"),
+			path2: NewAttributePath().WithAttributeName("testing2"),
 			equal: false,
 		},
 		"an-an-diff": {
-			path1: AttributePath{}.WithAttributeName("testing").WithAttributeName("testing2"),
-			path2: AttributePath{}.WithAttributeName("testing2").WithAttributeName("testing2"),
+			path1: NewAttributePath().WithAttributeName("testing").WithAttributeName("testing2"),
+			path2: NewAttributePath().WithAttributeName("testing2").WithAttributeName("testing2"),
 			equal: false,
 		},
 		"an-an-diff-2": {
-			path1: AttributePath{}.WithAttributeName("testing").WithAttributeName("testing2"),
-			path2: AttributePath{}.WithAttributeName("testing").WithAttributeName("testing3"),
+			path1: NewAttributePath().WithAttributeName("testing").WithAttributeName("testing2"),
+			path2: NewAttributePath().WithAttributeName("testing").WithAttributeName("testing3"),
 			equal: false,
 		},
 		"eks-diff": {
-			path1: AttributePath{}.WithElementKeyString("testing"),
-			path2: AttributePath{}.WithElementKeyString("testing2"),
+			path1: NewAttributePath().WithElementKeyString("testing"),
+			path2: NewAttributePath().WithElementKeyString("testing2"),
 			equal: false,
 		},
 		"eks-eks-diff": {
-			path1: AttributePath{}.WithElementKeyString("testing").WithElementKeyString("testing2"),
-			path2: AttributePath{}.WithElementKeyString("testing2").WithElementKeyString("testing2"),
+			path1: NewAttributePath().WithElementKeyString("testing").WithElementKeyString("testing2"),
+			path2: NewAttributePath().WithElementKeyString("testing2").WithElementKeyString("testing2"),
 			equal: false,
 		},
 		"eks-eks-diff-2": {
-			path1: AttributePath{}.WithElementKeyString("testing").WithElementKeyString("testing2"),
-			path2: AttributePath{}.WithElementKeyString("testing").WithElementKeyString("testing3"),
+			path1: NewAttributePath().WithElementKeyString("testing").WithElementKeyString("testing2"),
+			path2: NewAttributePath().WithElementKeyString("testing").WithElementKeyString("testing3"),
 			equal: false,
 		},
 		"eki-diff": {
-			path1: AttributePath{}.WithElementKeyInt(123),
-			path2: AttributePath{}.WithElementKeyInt(1234),
+			path1: NewAttributePath().WithElementKeyInt(123),
+			path2: NewAttributePath().WithElementKeyInt(1234),
 			equal: false,
 		},
 		"eki-eki-diff": {
-			path1: AttributePath{}.WithElementKeyInt(123).WithElementKeyInt(456),
-			path2: AttributePath{}.WithElementKeyInt(1234).WithElementKeyInt(456),
+			path1: NewAttributePath().WithElementKeyInt(123).WithElementKeyInt(456),
+			path2: NewAttributePath().WithElementKeyInt(1234).WithElementKeyInt(456),
 			equal: false,
 		},
 		"eki-eki-diff-2": {
-			path1: AttributePath{}.WithElementKeyInt(123).WithElementKeyInt(456),
-			path2: AttributePath{}.WithElementKeyInt(123).WithElementKeyInt(4567),
+			path1: NewAttributePath().WithElementKeyInt(123).WithElementKeyInt(456),
+			path2: NewAttributePath().WithElementKeyInt(123).WithElementKeyInt(4567),
 			equal: false,
 		},
 		"ekv-diff": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(List{
+			path1: NewAttributePath().WithElementKeyValue(NewValue(List{
 				ElementType: String,
 			}, []Value{
 				NewValue(String, "hello"),
 				NewValue(String, "world"),
 			})),
-			path2: AttributePath{}.WithElementKeyValue(NewValue(List{
+			path2: NewAttributePath().WithElementKeyValue(NewValue(List{
 				ElementType: String,
 			}, []Value{
 				NewValue(String, "hello"),
@@ -365,13 +372,13 @@ func TestAttributePathEqual(t *testing.T) {
 			equal: false,
 		},
 		"ekv-ekv-diff": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(List{
+			path1: NewAttributePath().WithElementKeyValue(NewValue(List{
 				ElementType: String,
 			}, []Value{
 				NewValue(String, "hello"),
 				NewValue(String, "world"),
 			})).WithElementKeyValue(NewValue(Bool, true)),
-			path2: AttributePath{}.WithElementKeyValue(NewValue(List{
+			path2: NewAttributePath().WithElementKeyValue(NewValue(List{
 				ElementType: String,
 			}, []Value{
 				NewValue(String, "hello"),
@@ -380,13 +387,13 @@ func TestAttributePathEqual(t *testing.T) {
 			equal: false,
 		},
 		"ekv-ekv-diff-2": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(List{
+			path1: NewAttributePath().WithElementKeyValue(NewValue(List{
 				ElementType: String,
 			}, []Value{
 				NewValue(String, "hello"),
 				NewValue(String, "world"),
 			})).WithElementKeyValue(NewValue(Bool, true)),
-			path2: AttributePath{}.WithElementKeyValue(NewValue(List{
+			path2: NewAttributePath().WithElementKeyValue(NewValue(List{
 				ElementType: String,
 			}, []Value{
 				NewValue(String, "hello"),
@@ -395,27 +402,27 @@ func TestAttributePathEqual(t *testing.T) {
 			equal: false,
 		},
 		"an-eks-eki-ekv-diff": {
-			path1: AttributePath{}.WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
-			path2: AttributePath{}.WithAttributeName("testing2").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
+			path1: NewAttributePath().WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
+			path2: NewAttributePath().WithAttributeName("testing2").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
 			equal: false,
 		},
 		"an-eks-eki-ekv-diff-2": {
-			path1: AttributePath{}.WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
-			path2: AttributePath{}.WithAttributeName("testing").WithElementKeyString("testing3").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
+			path1: NewAttributePath().WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
+			path2: NewAttributePath().WithAttributeName("testing").WithElementKeyString("testing3").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
 			equal: false,
 		},
 		"an-eks-eki-ekv-diff-3": {
-			path1: AttributePath{}.WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
-			path2: AttributePath{}.WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(1234).WithElementKeyValue(NewValue(String, "hello, world")),
+			path1: NewAttributePath().WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
+			path2: NewAttributePath().WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(1234).WithElementKeyValue(NewValue(String, "hello, world")),
 			equal: false,
 		},
 		"an-eks-eki-ekv-diff-4": {
-			path1: AttributePath{}.WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
-			path2: AttributePath{}.WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, friend")),
+			path1: NewAttributePath().WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, world")),
+			path2: NewAttributePath().WithAttributeName("testing").WithElementKeyString("testing2").WithElementKeyInt(123).WithElementKeyValue(NewValue(String, "hello, friend")),
 			equal: false,
 		},
 		"ekv-eki-eks-an-diff": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(Object{
+			path1: NewAttributePath().WithElementKeyValue(NewValue(Object{
 				AttributeTypes: map[string]Type{
 					"foo": Bool,
 					"bar": Number,
@@ -424,7 +431,7 @@ func TestAttributePathEqual(t *testing.T) {
 				"foo": NewValue(Bool, true),
 				"bar": NewValue(Number, big.NewFloat(1234)),
 			})).WithElementKeyInt(123).WithElementKeyString("testing").WithAttributeName("othertesting"),
-			path2: AttributePath{}.WithElementKeyValue(NewValue(Object{
+			path2: NewAttributePath().WithElementKeyValue(NewValue(Object{
 				AttributeTypes: map[string]Type{
 					"foo": Bool,
 					"bar": Number,
@@ -436,7 +443,7 @@ func TestAttributePathEqual(t *testing.T) {
 			equal: false,
 		},
 		"ekv-eki-eks-an-diff-2": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(Object{
+			path1: NewAttributePath().WithElementKeyValue(NewValue(Object{
 				AttributeTypes: map[string]Type{
 					"foo": Bool,
 					"bar": Number,
@@ -445,7 +452,7 @@ func TestAttributePathEqual(t *testing.T) {
 				"foo": NewValue(Bool, true),
 				"bar": NewValue(Number, big.NewFloat(1234)),
 			})).WithElementKeyInt(123).WithElementKeyString("testing").WithAttributeName("othertesting"),
-			path2: AttributePath{}.WithElementKeyValue(NewValue(Object{
+			path2: NewAttributePath().WithElementKeyValue(NewValue(Object{
 				AttributeTypes: map[string]Type{
 					"foo": Bool,
 					"bar": Number,
@@ -457,7 +464,7 @@ func TestAttributePathEqual(t *testing.T) {
 			equal: false,
 		},
 		"ekv-eki-eks-an-diff-3": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(Object{
+			path1: NewAttributePath().WithElementKeyValue(NewValue(Object{
 				AttributeTypes: map[string]Type{
 					"foo": Bool,
 					"bar": Number,
@@ -466,7 +473,7 @@ func TestAttributePathEqual(t *testing.T) {
 				"foo": NewValue(Bool, true),
 				"bar": NewValue(Number, big.NewFloat(1234)),
 			})).WithElementKeyInt(123).WithElementKeyString("testing").WithAttributeName("othertesting"),
-			path2: AttributePath{}.WithElementKeyValue(NewValue(Object{
+			path2: NewAttributePath().WithElementKeyValue(NewValue(Object{
 				AttributeTypes: map[string]Type{
 					"foo": Bool,
 					"bar": Number,
@@ -478,7 +485,7 @@ func TestAttributePathEqual(t *testing.T) {
 			equal: false,
 		},
 		"ekv-eki-eks-an-diff-4": {
-			path1: AttributePath{}.WithElementKeyValue(NewValue(Object{
+			path1: NewAttributePath().WithElementKeyValue(NewValue(Object{
 				AttributeTypes: map[string]Type{
 					"foo": Bool,
 					"bar": Number,
@@ -487,7 +494,7 @@ func TestAttributePathEqual(t *testing.T) {
 				"foo": NewValue(Bool, true),
 				"bar": NewValue(Number, big.NewFloat(1234)),
 			})).WithElementKeyInt(123).WithElementKeyString("testing").WithAttributeName("othertesting"),
-			path2: AttributePath{}.WithElementKeyValue(NewValue(Object{
+			path2: NewAttributePath().WithElementKeyValue(NewValue(Object{
 				AttributeTypes: map[string]Type{
 					"foo": Bool,
 					"bar": Number,

--- a/tfprotov5/tftypes/diff.go
+++ b/tfprotov5/tftypes/diff.go
@@ -15,7 +15,7 @@ import (
 type ValueDiff struct {
 	// The Path these different subsets are located at in the original
 	// Values.
-	Path AttributePath
+	Path *AttributePath
 
 	// The subset of the first Value passed to Diff found at the
 	// AttributePath indicated by Path.
@@ -81,7 +81,7 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 	var diffs []ValueDiff
 
 	// make sure everything in val2 is also in val1
-	err := Walk(val2, func(path AttributePath, value2 Value) (bool, error) {
+	err := Walk(val2, func(path *AttributePath, value2 Value) (bool, error) {
 		_, _, err := WalkAttributePath(val1, path)
 		if err != nil && err != ErrInvalidStep {
 			return false, fmt.Errorf("Error walking %q: %w", path, err)
@@ -100,7 +100,7 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 	}
 
 	// make sure everything in val1 is also in val2 and also that it all matches
-	err = Walk(val1, func(path AttributePath, value1 Value) (bool, error) {
+	err = Walk(val1, func(path *AttributePath, value1 Value) (bool, error) {
 		// pull out the Value at the same path in val2
 		value2I, _, err := WalkAttributePath(val2, path)
 		if err != nil && err != ErrInvalidStep {
@@ -179,11 +179,11 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 			var s1, s2 string
 			err := value1.As(&s1)
 			if err != nil {
-				return false, fmt.Errorf("Error converting %q: %w", path, err)
+				return false, fmt.Errorf("Error converting %s (value1) at %q: %w", value1, path, err)
 			}
 			err = value2.As(&s2)
 			if err != nil {
-				return false, fmt.Errorf("Error converting %q: %w", path, err)
+				return false, fmt.Errorf("Error converting %s (value2) at %q: %w", value2, path, err)
 			}
 			if s1 != s2 {
 				diffs = append(diffs, ValueDiff{

--- a/tfprotov5/tftypes/diff_test.go
+++ b/tfprotov5/tftypes/diff_test.go
@@ -23,12 +23,12 @@ func TestValueDiffEqual(t *testing.T) {
 	tests := map[string]testCase{
 		"pathDiff": {
 			diff1: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(String, "test")),
 				Value2: valuePointer(NewValue(String, "test 2")),
 			},
 			diff2: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyInt(123),
+				Path:   NewAttributePath().WithElementKeyInt(123),
 				Value1: valuePointer(NewValue(String, "test")),
 				Value2: valuePointer(NewValue(String, "test 2")),
 			},
@@ -36,12 +36,12 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"primitiveVal1Diff": {
 			diff1: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(String, "test")),
 				Value2: valuePointer(NewValue(String, "test 2")),
 			},
 			diff2: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(String, "test 3")),
 				Value2: valuePointer(NewValue(String, "test 2")),
 			},
@@ -49,12 +49,12 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"primitiveVal2Diff": {
 			diff1: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(String, "test")),
 				Value2: valuePointer(NewValue(String, "test 2")),
 			},
 			diff2: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(String, "test")),
 				Value2: valuePointer(NewValue(String, "test 3")),
 			},
@@ -62,12 +62,12 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"primitiveTypeDiff": {
 			diff1: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(String, "test")),
 				Value2: valuePointer(NewValue(String, "test 2")),
 			},
 			diff2: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(Number, big.NewFloat(123))),
 				Value2: valuePointer(NewValue(Number, big.NewFloat(1234))),
 			},
@@ -75,7 +75,7 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"complexVal1Diff": {
 			diff1: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: String,
 				}, []Value{
@@ -90,7 +90,7 @@ func TestValueDiffEqual(t *testing.T) {
 				})),
 			},
 			diff2: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: String,
 				}, []Value{
@@ -108,7 +108,7 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"complexVal2Diff": {
 			diff1: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: String,
 				}, []Value{
@@ -123,7 +123,7 @@ func TestValueDiffEqual(t *testing.T) {
 				})),
 			},
 			diff2: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: String,
 				}, []Value{
@@ -141,7 +141,7 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"complexTypeDiff": {
 			diff1: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: String,
 				}, []Value{
@@ -155,7 +155,7 @@ func TestValueDiffEqual(t *testing.T) {
 				})),
 			},
 			diff2: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: Bool,
 				}, []Value{
@@ -172,7 +172,7 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"val1NilDiff": {
 			diff1: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: nil,
 				Value2: valuePointer(NewValue(List{
 					ElementType: Bool,
@@ -182,7 +182,7 @@ func TestValueDiffEqual(t *testing.T) {
 				})),
 			},
 			diff2: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: Bool,
 				}, []Value{
@@ -199,7 +199,7 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"val2NilDiff": {
 			diff1: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: Bool,
 				}, []Value{
@@ -209,7 +209,7 @@ func TestValueDiffEqual(t *testing.T) {
 				Value2: nil,
 			},
 			diff2: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: Bool,
 				}, []Value{
@@ -226,12 +226,12 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"allValsNilDiff": {
 			diff1: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: nil,
 				Value2: nil,
 			},
 			diff2: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: Bool,
 				}, []Value{
@@ -248,12 +248,12 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"primitiveEqual": {
 			diff1: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(String, "test")),
 				Value2: valuePointer(NewValue(String, "test 2")),
 			},
 			diff2: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(String, "test")),
 				Value2: valuePointer(NewValue(String, "test 2")),
 			},
@@ -261,7 +261,7 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"complexEqual": {
 			diff1: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: String,
 				}, []Value{
@@ -276,7 +276,7 @@ func TestValueDiffEqual(t *testing.T) {
 				})),
 			},
 			diff2: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: String,
 				}, []Value{
@@ -294,7 +294,7 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"val1NilEqual": {
 			diff1: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: nil,
 				Value2: valuePointer(NewValue(List{
 					ElementType: Bool,
@@ -304,7 +304,7 @@ func TestValueDiffEqual(t *testing.T) {
 				})),
 			},
 			diff2: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: nil,
 				Value2: valuePointer(NewValue(List{
 					ElementType: Bool,
@@ -317,7 +317,7 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"val2NilEqual": {
 			diff1: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: Bool,
 				}, []Value{
@@ -327,7 +327,7 @@ func TestValueDiffEqual(t *testing.T) {
 				Value2: nil,
 			},
 			diff2: ValueDiff{
-				Path: AttributePath{}.WithElementKeyString("foo"),
+				Path: NewAttributePath().WithElementKeyString("foo"),
 				Value1: valuePointer(NewValue(List{
 					ElementType: Bool,
 				}, []Value{
@@ -340,12 +340,12 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 		"allValsNilEqual": {
 			diff1: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: nil,
 				Value2: nil,
 			},
 			diff2: ValueDiff{
-				Path:   AttributePath{}.WithElementKeyString("foo"),
+				Path:   NewAttributePath().WithElementKeyString("foo"),
 				Value1: nil,
 				Value2: nil,
 			},
@@ -413,7 +413,7 @@ func TestValueDiffDiff(t *testing.T) {
 			}),
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithElementKeyInt(2),
+					Path:   NewAttributePath().WithElementKeyInt(2),
 					Value1: nil,
 					Value2: valuePointer(NewValue(String, "baz")),
 				},
@@ -465,7 +465,7 @@ func TestValueDiffDiff(t *testing.T) {
 					})),
 				},
 				{
-					Path:   AttributePath{}.WithElementKeyInt(2),
+					Path:   NewAttributePath().WithElementKeyInt(2),
 					Value1: valuePointer(NewValue(String, "baz")),
 					Value2: nil,
 				},

--- a/tfprotov5/tftypes/value.go
+++ b/tfprotov5/tftypes/value.go
@@ -639,14 +639,14 @@ func (val Value) MarshalMsgPack(t Type) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := msgpack.NewEncoder(&buf)
 
-	err := marshalMsgPack(val, t, AttributePath{}, enc)
+	err := marshalMsgPack(val, t, NewAttributePath(), enc)
 	if err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
 }
 
-func unexpectedValueTypeError(p AttributePath, expected, got interface{}, typ Type) error {
+func unexpectedValueTypeError(p *AttributePath, expected, got interface{}, typ Type) error {
 	return p.NewErrorf("unexpected value type %T, %s values must be of type %T", got, typ, expected)
 }
 

--- a/tfprotov5/tftypes/value_msgpack.go
+++ b/tfprotov5/tftypes/value_msgpack.go
@@ -9,7 +9,7 @@ import (
 	"github.com/vmihailenco/msgpack"
 )
 
-func marshalMsgPack(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPack(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
 	if typ.Is(DynamicPseudoType) && !val.Type().Is(DynamicPseudoType) {
 		return marshalMsgPackDynamicPseudoType(val, typ, p, enc)
 
@@ -49,7 +49,7 @@ func marshalMsgPack(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) 
 	return fmt.Errorf("unknown type %s", typ)
 }
 
-func marshalMsgPackDynamicPseudoType(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackDynamicPseudoType(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
 	typeJSON, err := val.Type().MarshalJSON()
 	if err != nil {
 		return p.NewErrorf("error generating JSON for type %s: %w", val.Type(), err)
@@ -69,7 +69,7 @@ func marshalMsgPackDynamicPseudoType(val Value, typ Type, p AttributePath, enc *
 	return nil
 }
 
-func marshalMsgPackString(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackString(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
 	s, ok := val.value.(string)
 	if !ok {
 		return unexpectedValueTypeError(p, s, val.value, typ)
@@ -81,7 +81,7 @@ func marshalMsgPackString(val Value, typ Type, p AttributePath, enc *msgpack.Enc
 	return nil
 }
 
-func marshalMsgPackNumber(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackNumber(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
 	n, ok := val.value.(*big.Float)
 	if !ok {
 		return unexpectedValueTypeError(p, n, val.value, typ)
@@ -119,7 +119,7 @@ func marshalMsgPackNumber(val Value, typ Type, p AttributePath, enc *msgpack.Enc
 	return nil
 }
 
-func marshalMsgPackBool(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackBool(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
 	b, ok := val.value.(bool)
 	if !ok {
 		return unexpectedValueTypeError(p, b, val.value, typ)
@@ -131,7 +131,7 @@ func marshalMsgPackBool(val Value, typ Type, p AttributePath, enc *msgpack.Encod
 	return nil
 }
 
-func marshalMsgPackList(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackList(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
 	l, ok := val.value.([]Value)
 	if !ok {
 		return unexpectedValueTypeError(p, l, val.value, typ)
@@ -149,7 +149,7 @@ func marshalMsgPackList(val Value, typ Type, p AttributePath, enc *msgpack.Encod
 	return nil
 }
 
-func marshalMsgPackSet(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackSet(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
 	s, ok := val.value.([]Value)
 	if !ok {
 		return unexpectedValueTypeError(p, s, val.value, typ)
@@ -167,7 +167,7 @@ func marshalMsgPackSet(val Value, typ Type, p AttributePath, enc *msgpack.Encode
 	return nil
 }
 
-func marshalMsgPackMap(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackMap(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
 	m, ok := val.value.(map[string]Value)
 	if !ok {
 		return unexpectedValueTypeError(p, m, val.value, typ)
@@ -189,7 +189,7 @@ func marshalMsgPackMap(val Value, typ Type, p AttributePath, enc *msgpack.Encode
 	return nil
 }
 
-func marshalMsgPackTuple(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackTuple(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
 	t, ok := val.value.([]Value)
 	if !ok {
 		return unexpectedValueTypeError(p, t, val.value, typ)
@@ -209,7 +209,7 @@ func marshalMsgPackTuple(val Value, typ Type, p AttributePath, enc *msgpack.Enco
 	return nil
 }
 
-func marshalMsgPackObject(val Value, typ Type, p AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackObject(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
 	o, ok := val.value.(map[string]Value)
 	if !ok {
 		return unexpectedValueTypeError(p, o, val.value, typ)

--- a/tfprotov5/tftypes/value_test.go
+++ b/tfprotov5/tftypes/value_test.go
@@ -1479,27 +1479,27 @@ func TestValueWalkAttributePath(t *testing.T) {
 	t.Parallel()
 	type testCase struct {
 		val      Value
-		path     AttributePath
+		path     *AttributePath
 		expected Value
 	}
 	tests := map[string]testCase{
 		"primitive": {
 			val:      NewValue(String, "hello"),
-			path:     AttributePath{},
+			path:     NewAttributePath(),
 			expected: NewValue(String, "hello"),
 		},
 		"list": {
 			val: NewValue(List{ElementType: String}, []Value{
 				NewValue(String, "foo"), NewValue(String, "bar"),
 			}),
-			path:     AttributePath{}.WithElementKeyInt(1),
+			path:     NewAttributePath().WithElementKeyInt(1),
 			expected: NewValue(String, "bar"),
 		},
 		"set": {
 			val: NewValue(Set{ElementType: String}, []Value{
 				NewValue(String, "foo"), NewValue(String, "bar"),
 			}),
-			path:     AttributePath{}.WithElementKeyValue(NewValue(String, "bar")),
+			path:     NewAttributePath().WithElementKeyValue(NewValue(String, "bar")),
 			expected: NewValue(String, "bar"),
 		},
 		"map": {
@@ -1507,7 +1507,7 @@ func TestValueWalkAttributePath(t *testing.T) {
 				"a": NewValue(String, "foo"),
 				"b": NewValue(String, "bar"),
 			}),
-			path:     AttributePath{}.WithElementKeyString("b"),
+			path:     NewAttributePath().WithElementKeyString("b"),
 			expected: NewValue(String, "bar"),
 		},
 		"object": {
@@ -1518,7 +1518,7 @@ func TestValueWalkAttributePath(t *testing.T) {
 				"a": NewValue(String, "foo"),
 				"b": NewValue(Number, big.NewFloat(123)),
 			}),
-			path:     AttributePath{}.WithAttributeName("b"),
+			path:     NewAttributePath().WithAttributeName("b"),
 			expected: NewValue(Number, big.NewFloat(123)),
 		},
 		"tuple": {
@@ -1528,7 +1528,7 @@ func TestValueWalkAttributePath(t *testing.T) {
 				NewValue(String, "foo"),
 				NewValue(Number, big.NewFloat(123)),
 			}),
-			path:     AttributePath{}.WithElementKeyInt(1),
+			path:     NewAttributePath().WithElementKeyInt(1),
 			expected: NewValue(Number, big.NewFloat(123)),
 		},
 		"complex": {
@@ -1562,7 +1562,7 @@ func TestValueWalkAttributePath(t *testing.T) {
 					}),
 				}),
 			}),
-			path:     AttributePath{}.WithAttributeName("a").WithElementKeyInt(1).WithElementKeyInt(2).WithElementKeyInt(1),
+			path:     NewAttributePath().WithAttributeName("a").WithElementKeyInt(1).WithElementKeyInt(2).WithElementKeyInt(1),
 			expected: NewValue(String, "world"),
 		},
 	}

--- a/tfprotov5/tftypes/walk_test.go
+++ b/tfprotov5/tftypes/walk_test.go
@@ -100,7 +100,7 @@ func TestWalk(t *testing.T) {
 		`AttributeName("unknown")`:                      valContent["unknown"],
 	}
 
-	err := Walk(val, func(path AttributePath, val Value) (bool, error) {
+	err := Walk(val, func(path *AttributePath, val Value) (bool, error) {
 		gotCalls[path.String()] = val
 		return true, nil
 	})
@@ -165,7 +165,7 @@ func TestTransform(t *testing.T) {
 	val := NewValue(valType, valContent)
 
 	type testCase struct {
-		f     func(AttributePath, Value) (Value, error)
+		f     func(*AttributePath, Value) (Value, error)
 		diffs []ValueDiff
 	}
 
@@ -176,8 +176,8 @@ func TestTransform(t *testing.T) {
 
 	tests := map[string]testCase{
 		"string": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("string")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("string")
 				if path.Equal(target) {
 					return NewValue(String, "hello, world"), nil
 				}
@@ -185,15 +185,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("string"),
+					Path:   NewAttributePath().WithAttributeName("string"),
 					Value1: newValuePointer(String, "hello"),
 					Value2: newValuePointer(String, "hello, world"),
 				},
 			},
 		},
 		"string:null": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("string")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("string")
 				if path.Equal(target) {
 					return NewValue(String, nil), nil
 				}
@@ -201,15 +201,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("string"),
+					Path:   NewAttributePath().WithAttributeName("string"),
 					Value1: newValuePointer(String, "hello"),
 					Value2: newValuePointer(String, nil),
 				},
 			},
 		},
 		"string:unknown": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("string")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("string")
 				if path.Equal(target) {
 					return NewValue(String, UnknownValue), nil
 				}
@@ -217,15 +217,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("string"),
+					Path:   NewAttributePath().WithAttributeName("string"),
 					Value1: newValuePointer(String, "hello"),
 					Value2: newValuePointer(String, UnknownValue),
 				},
 			},
 		},
 		"number": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("number")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("number")
 				if path.Equal(target) {
 					return NewValue(Number, big.NewFloat(123)), nil
 				}
@@ -233,15 +233,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("number"),
+					Path:   NewAttributePath().WithAttributeName("number"),
 					Value1: newValuePointer(Number, big.NewFloat(10)),
 					Value2: newValuePointer(Number, big.NewFloat(123)),
 				},
 			},
 		},
 		"number:null": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("number")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("number")
 				if path.Equal(target) {
 					return NewValue(Number, nil), nil
 				}
@@ -249,15 +249,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("number"),
+					Path:   NewAttributePath().WithAttributeName("number"),
 					Value1: newValuePointer(Number, big.NewFloat(10)),
 					Value2: newValuePointer(Number, nil),
 				},
 			},
 		},
 		"number:unknown": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("number")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("number")
 				if path.Equal(target) {
 					return NewValue(Number, UnknownValue), nil
 				}
@@ -265,15 +265,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("number"),
+					Path:   NewAttributePath().WithAttributeName("number"),
 					Value1: newValuePointer(Number, big.NewFloat(10)),
 					Value2: newValuePointer(Number, UnknownValue),
 				},
 			},
 		},
 		"bool": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("bool")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("bool")
 				if path.Equal(target) {
 					return NewValue(Bool, false), nil
 				}
@@ -281,15 +281,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("bool"),
+					Path:   NewAttributePath().WithAttributeName("bool"),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, false),
 				},
 			},
 		},
 		"bool:null": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("bool")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("bool")
 				if path.Equal(target) {
 					return NewValue(Bool, nil), nil
 				}
@@ -297,15 +297,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("bool"),
+					Path:   NewAttributePath().WithAttributeName("bool"),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, nil),
 				},
 			},
 		},
 		"bool:unknown": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("bool")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("bool")
 				if path.Equal(target) {
 					return NewValue(Bool, UnknownValue), nil
 				}
@@ -313,15 +313,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("bool"),
+					Path:   NewAttributePath().WithAttributeName("bool"),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, UnknownValue),
 				},
 			},
 		},
 		"list:null": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("list")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("list")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["list"], nil), nil
 				}
@@ -329,22 +329,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("list"),
+					Path: NewAttributePath().WithAttributeName("list"),
 					Value1: newValuePointer(valType.AttributeTypes["list"], []Value{
 						NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["list"], nil),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("list").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"list:unknown": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("list")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("list")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["list"], UnknownValue), nil
 				}
@@ -352,22 +352,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("list"),
+					Path: NewAttributePath().WithAttributeName("list"),
 					Value1: newValuePointer(valType.AttributeTypes["list"], []Value{
 						NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["list"], UnknownValue),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("list").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"list:nullElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("list").WithElementKeyInt(0)
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("list").WithElementKeyInt(0)
 				if path.Equal(target) {
 					return NewValue(Bool, nil), nil
 				}
@@ -375,15 +375,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("list").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, nil),
 				},
 			},
 		},
 		"list:unknownElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("list").WithElementKeyInt(0)
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("list").WithElementKeyInt(0)
 				if path.Equal(target) {
 					return NewValue(Bool, UnknownValue), nil
 				}
@@ -391,15 +391,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("list").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, UnknownValue),
 				},
 			},
 		},
 		"list:replaceElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("list").WithElementKeyInt(0)
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("list").WithElementKeyInt(0)
 				if path.Equal(target) {
 					return NewValue(Bool, false), nil
 				}
@@ -407,15 +407,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("list").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, false),
 				},
 			},
 		},
 		"list:addElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("list")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("list")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["list"], []Value{
 						NewValue(Bool, true), NewValue(Bool, false),
@@ -425,7 +425,7 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("list"),
+					Path: NewAttributePath().WithAttributeName("list"),
 					Value1: newValuePointer(valType.AttributeTypes["list"], []Value{
 						NewValue(Bool, true),
 					}),
@@ -434,15 +434,15 @@ func TestTransform(t *testing.T) {
 					}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(1),
+					Path:   NewAttributePath().WithAttributeName("list").WithElementKeyInt(1),
 					Value1: nil,
 					Value2: newValuePointer(Bool, false),
 				},
 			},
 		},
 		"list:removeElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("list")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("list")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["list"], []Value{}), nil
 				}
@@ -450,22 +450,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("list"),
+					Path: NewAttributePath().WithAttributeName("list"),
 					Value1: newValuePointer(valType.AttributeTypes["list"], []Value{
 						NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["list"], []Value{}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("list").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("list").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"list_empty": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("list_empty")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("list_empty")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["list_empty"], []Value{
 						NewValue(Bool, true),
@@ -475,22 +475,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("list_empty"),
+					Path:   NewAttributePath().WithAttributeName("list_empty"),
 					Value1: newValuePointer(valType.AttributeTypes["list_empty"], []Value{}),
 					Value2: newValuePointer(valType.AttributeTypes["list_empty"], []Value{
 						NewValue(Bool, true),
 					}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("list_empty").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("list_empty").WithElementKeyInt(0),
 					Value1: nil,
 					Value2: newValuePointer(Bool, true),
 				},
 			},
 		},
 		"set:null": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("set")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("set")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["set"], nil), nil
 				}
@@ -498,22 +498,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("set"),
+					Path: NewAttributePath().WithAttributeName("set"),
 					Value1: newValuePointer(valType.AttributeTypes["set"], []Value{
 						NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["set"], nil),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Path:   NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"set:unknown": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("set")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("set")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["set"], UnknownValue), nil
 				}
@@ -521,22 +521,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("set"),
+					Path: NewAttributePath().WithAttributeName("set"),
 					Value1: newValuePointer(valType.AttributeTypes["set"], []Value{
 						NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["set"], UnknownValue),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Path:   NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"set:nullElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true))
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true))
 				if path.Equal(target) {
 					return NewValue(Bool, nil), nil
 				}
@@ -544,20 +544,20 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Path:   NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, nil)),
+					Path:   NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, nil)),
 					Value1: nil,
 					Value2: newValuePointer(Bool, nil),
 				},
 			},
 		},
 		"set:unknownElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true))
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true))
 				if path.Equal(target) {
 					return NewValue(Bool, UnknownValue), nil
 				}
@@ -565,20 +565,20 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Path:   NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, UnknownValue)),
+					Path:   NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, UnknownValue)),
 					Value1: nil,
 					Value2: newValuePointer(Bool, UnknownValue),
 				},
 			},
 		},
 		"set:replaceElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true))
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true))
 				if path.Equal(target) {
 					return NewValue(Bool, false), nil
 				}
@@ -586,20 +586,20 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Path:   NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, false)),
+					Path:   NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, false)),
 					Value1: nil,
 					Value2: newValuePointer(Bool, false),
 				},
 			},
 		},
 		"set:addElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("set")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("set")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["set"], []Value{
 						NewValue(Bool, true), NewValue(Bool, false),
@@ -609,7 +609,7 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("set"),
+					Path: NewAttributePath().WithAttributeName("set"),
 					Value1: newValuePointer(valType.AttributeTypes["set"], []Value{
 						NewValue(Bool, true),
 					}),
@@ -618,15 +618,15 @@ func TestTransform(t *testing.T) {
 					}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, false)),
+					Path:   NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, false)),
 					Value1: nil,
 					Value2: newValuePointer(Bool, false),
 				},
 			},
 		},
 		"set:removeElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("set")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("set")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["set"], []Value{}), nil
 				}
@@ -634,22 +634,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("set"),
+					Path: NewAttributePath().WithAttributeName("set"),
 					Value1: newValuePointer(valType.AttributeTypes["set"], []Value{
 						NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["set"], []Value{}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
+					Path:   NewAttributePath().WithAttributeName("set").WithElementKeyValue(NewValue(Bool, true)),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"set_empty": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("set_empty")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("set_empty")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["set_empty"], []Value{
 						NewValue(Bool, true),
@@ -659,22 +659,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("set_empty"),
+					Path:   NewAttributePath().WithAttributeName("set_empty"),
 					Value1: newValuePointer(valType.AttributeTypes["set_empty"], []Value{}),
 					Value2: newValuePointer(valType.AttributeTypes["set_empty"], []Value{
 						NewValue(Bool, true),
 					}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("set_empty").WithElementKeyValue(NewValue(Bool, true)),
+					Path:   NewAttributePath().WithAttributeName("set_empty").WithElementKeyValue(NewValue(Bool, true)),
 					Value1: nil,
 					Value2: newValuePointer(Bool, true),
 				},
 			},
 		},
 		"tuple:null": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("tuple")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("tuple")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["tuple"], nil), nil
 				}
@@ -682,22 +682,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("tuple"),
+					Path: NewAttributePath().WithAttributeName("tuple"),
 					Value1: newValuePointer(valType.AttributeTypes["tuple"], []Value{
 						NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["tuple"], nil),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("tuple").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"tuple:unknown": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("tuple")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("tuple")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["tuple"], UnknownValue), nil
 				}
@@ -705,22 +705,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("tuple"),
+					Path: NewAttributePath().WithAttributeName("tuple"),
 					Value1: newValuePointer(valType.AttributeTypes["tuple"], []Value{
 						NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["tuple"], UnknownValue),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("tuple").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"tuple:nullElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0)
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("tuple").WithElementKeyInt(0)
 				if path.Equal(target) {
 					return NewValue(Bool, nil), nil
 				}
@@ -728,15 +728,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("tuple").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, nil),
 				},
 			},
 		},
 		"tuple:unknownElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0)
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("tuple").WithElementKeyInt(0)
 				if path.Equal(target) {
 					return NewValue(Bool, UnknownValue), nil
 				}
@@ -744,15 +744,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("tuple").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, UnknownValue),
 				},
 			},
 		},
 		"tuple:replaceElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0)
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("tuple").WithElementKeyInt(0)
 				if path.Equal(target) {
 					return NewValue(Bool, false), nil
 				}
@@ -760,15 +760,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("tuple").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("tuple").WithElementKeyInt(0),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, false),
 				},
 			},
 		},
 		"map:null": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("map")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("map")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["map"], nil), nil
 				}
@@ -776,22 +776,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("map"),
+					Path: NewAttributePath().WithAttributeName("map"),
 					Value1: newValuePointer(valType.AttributeTypes["map"], map[string]Value{
 						"true": NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["map"], nil),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Path:   NewAttributePath().WithAttributeName("map").WithElementKeyString("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"map:unknown": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("map")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("map")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["map"], UnknownValue), nil
 				}
@@ -799,22 +799,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("map"),
+					Path: NewAttributePath().WithAttributeName("map"),
 					Value1: newValuePointer(valType.AttributeTypes["map"], map[string]Value{
 						"true": NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["map"], UnknownValue),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Path:   NewAttributePath().WithAttributeName("map").WithElementKeyString("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"map:nullElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("map").WithElementKeyString("true")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("map").WithElementKeyString("true")
 				if path.Equal(target) {
 					return NewValue(Bool, nil), nil
 				}
@@ -822,15 +822,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Path:   NewAttributePath().WithAttributeName("map").WithElementKeyString("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, nil),
 				},
 			},
 		},
 		"map:unknownElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("map").WithElementKeyString("true")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("map").WithElementKeyString("true")
 				if path.Equal(target) {
 					return NewValue(Bool, UnknownValue), nil
 				}
@@ -838,15 +838,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Path:   NewAttributePath().WithAttributeName("map").WithElementKeyString("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, UnknownValue),
 				},
 			},
 		},
 		"map:replaceElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("map").WithElementKeyString("true")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("map").WithElementKeyString("true")
 				if path.Equal(target) {
 					return NewValue(Bool, false), nil
 				}
@@ -854,15 +854,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Path:   NewAttributePath().WithAttributeName("map").WithElementKeyString("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, false),
 				},
 			},
 		},
 		"map:addElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("map")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("map")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["map"], map[string]Value{
 						"true":  NewValue(Bool, true),
@@ -873,7 +873,7 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("map"),
+					Path: NewAttributePath().WithAttributeName("map"),
 					Value1: newValuePointer(valType.AttributeTypes["map"], map[string]Value{
 						"true": NewValue(Bool, true),
 					}),
@@ -883,15 +883,15 @@ func TestTransform(t *testing.T) {
 					}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("false"),
+					Path:   NewAttributePath().WithAttributeName("map").WithElementKeyString("false"),
 					Value1: nil,
 					Value2: newValuePointer(Bool, false),
 				},
 			},
 		},
 		"map:removeElement": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("map")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("map")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["map"], map[string]Value{}), nil
 				}
@@ -899,22 +899,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path: AttributePath{}.WithAttributeName("map"),
+					Path: NewAttributePath().WithAttributeName("map"),
 					Value1: newValuePointer(valType.AttributeTypes["map"], map[string]Value{
 						"true": NewValue(Bool, true),
 					}),
 					Value2: newValuePointer(valType.AttributeTypes["map"], map[string]Value{}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("map").WithElementKeyString("true"),
+					Path:   NewAttributePath().WithAttributeName("map").WithElementKeyString("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 			},
 		},
 		"map_empty": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("map_empty")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("map_empty")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["map_empty"], map[string]Value{
 						"foo": NewValue(Bool, true),
@@ -924,22 +924,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("map_empty"),
+					Path:   NewAttributePath().WithAttributeName("map_empty"),
 					Value1: newValuePointer(valType.AttributeTypes["map_empty"], map[string]Value{}),
 					Value2: newValuePointer(valType.AttributeTypes["map_empty"], map[string]Value{
 						"foo": NewValue(Bool, true),
 					}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("map_empty").WithElementKeyString("foo"),
+					Path:   NewAttributePath().WithAttributeName("map_empty").WithElementKeyString("foo"),
 					Value1: nil,
 					Value2: newValuePointer(Bool, true),
 				},
 			},
 		},
 		"object:unknown": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("object")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("object")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["object"], UnknownValue), nil
 				}
@@ -947,12 +947,12 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("object").WithAttributeName("true"),
+					Path:   NewAttributePath().WithAttributeName("object").WithAttributeName("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 				{
-					Path: AttributePath{}.WithAttributeName("object"),
+					Path: NewAttributePath().WithAttributeName("object"),
 					Value1: newValuePointer(valType.AttributeTypes["object"], map[string]Value{
 						"true": NewValue(Bool, true),
 					}),
@@ -961,8 +961,8 @@ func TestTransform(t *testing.T) {
 			},
 		},
 		"object:null": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("object")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("object")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["object"], nil), nil
 				}
@@ -970,12 +970,12 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("object").WithAttributeName("true"),
+					Path:   NewAttributePath().WithAttributeName("object").WithAttributeName("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: nil,
 				},
 				{
-					Path: AttributePath{}.WithAttributeName("object"),
+					Path: NewAttributePath().WithAttributeName("object"),
 					Value1: newValuePointer(valType.AttributeTypes["object"], map[string]Value{
 						"true": NewValue(Bool, true),
 					}),
@@ -984,8 +984,8 @@ func TestTransform(t *testing.T) {
 			},
 		},
 		"object:attributeNull": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("object").WithAttributeName("true")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("object").WithAttributeName("true")
 				if path.Equal(target) {
 					return NewValue(Bool, nil), nil
 				}
@@ -993,15 +993,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("object").WithAttributeName("true"),
+					Path:   NewAttributePath().WithAttributeName("object").WithAttributeName("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, nil),
 				},
 			},
 		},
 		"object:attributeUnknown": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("object").WithAttributeName("true")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("object").WithAttributeName("true")
 				if path.Equal(target) {
 					return NewValue(Bool, UnknownValue), nil
 				}
@@ -1009,15 +1009,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("object").WithAttributeName("true"),
+					Path:   NewAttributePath().WithAttributeName("object").WithAttributeName("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, UnknownValue),
 				},
 			},
 		},
 		"object:replaceAttribute": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("object").WithAttributeName("true")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("object").WithAttributeName("true")
 				if path.Equal(target) {
 					return NewValue(Bool, false), nil
 				}
@@ -1025,15 +1025,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("object").WithAttributeName("true"),
+					Path:   NewAttributePath().WithAttributeName("object").WithAttributeName("true"),
 					Value1: newValuePointer(Bool, true),
 					Value2: newValuePointer(Bool, false),
 				},
 			},
 		},
 		"null:unknown": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("null")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("null")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["null"], UnknownValue), nil
 				}
@@ -1041,15 +1041,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("null"),
+					Path:   NewAttributePath().WithAttributeName("null"),
 					Value1: newValuePointer(valType.AttributeTypes["null"], nil),
 					Value2: newValuePointer(valType.AttributeTypes["null"], UnknownValue),
 				},
 			},
 		},
 		"null:set": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("null")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("null")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["null"], []Value{
 						NewValue(String, "testing"),
@@ -1059,22 +1059,22 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("null"),
+					Path:   NewAttributePath().WithAttributeName("null"),
 					Value1: newValuePointer(valType.AttributeTypes["null"], nil),
 					Value2: newValuePointer(valType.AttributeTypes["null"], []Value{
 						NewValue(String, "testing"),
 					}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("null").WithElementKeyInt(0),
+					Path:   NewAttributePath().WithAttributeName("null").WithElementKeyInt(0),
 					Value1: nil,
 					Value2: newValuePointer(String, "testing"),
 				},
 			},
 		},
 		"unknown:null": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("unknown")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("unknown")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["unknown"], nil), nil
 				}
@@ -1082,15 +1082,15 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("unknown"),
+					Path:   NewAttributePath().WithAttributeName("unknown"),
 					Value1: newValuePointer(valType.AttributeTypes["unknown"], UnknownValue),
 					Value2: newValuePointer(valType.AttributeTypes["unknown"], nil),
 				},
 			},
 		},
 		"unknown:set": {
-			f: func(path AttributePath, v Value) (Value, error) {
-				target := AttributePath{}.WithAttributeName("unknown")
+			f: func(path *AttributePath, v Value) (Value, error) {
+				target := NewAttributePath().WithAttributeName("unknown")
 				if path.Equal(target) {
 					return NewValue(valType.AttributeTypes["unknown"], map[string]Value{
 						"testing": NewValue(Bool, true),
@@ -1100,21 +1100,21 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("unknown"),
+					Path:   NewAttributePath().WithAttributeName("unknown"),
 					Value1: newValuePointer(valType.AttributeTypes["unknown"], UnknownValue),
 					Value2: newValuePointer(valType.AttributeTypes["unknown"], map[string]Value{
 						"testing": NewValue(Bool, true),
 					}),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("unknown").WithElementKeyString("testing"),
+					Path:   NewAttributePath().WithAttributeName("unknown").WithElementKeyString("testing"),
 					Value1: nil,
 					Value2: newValuePointer(Bool, true),
 				},
 			},
 		},
 		"null:byValue": {
-			f: func(_ AttributePath, v Value) (Value, error) {
+			f: func(_ *AttributePath, v Value) (Value, error) {
 				if v.IsNull() {
 					return NewValue(v.Type(), UnknownValue), nil
 				}
@@ -1125,12 +1125,12 @@ func TestTransform(t *testing.T) {
 			},
 			diffs: []ValueDiff{
 				{
-					Path:   AttributePath{}.WithAttributeName("unknown"),
+					Path:   NewAttributePath().WithAttributeName("unknown"),
 					Value1: newValuePointer(valType.AttributeTypes["unknown"], UnknownValue),
 					Value2: newValuePointer(valType.AttributeTypes["unknown"], nil),
 				},
 				{
-					Path:   AttributePath{}.WithAttributeName("null"),
+					Path:   NewAttributePath().WithAttributeName("null"),
 					Value1: newValuePointer(valType.AttributeTypes["null"], nil),
 					Value2: newValuePointer(valType.AttributeTypes["null"], UnknownValue),
 				},


### PR DESCRIPTION
Make AttributePaths into pointers everywhere, so they can be
ergonomically used with diagnostics. nil pointers are considered
equivalent to AttributePaths with no steps.

Because modifying steps on the AttributePath without defensively copying
first is now A Major Headache and makes everything awful, I made them
private. This necessitated the creation of a NewAttributePathWithSteps
so our internal code for translating between protocol and tftypes could
create the AttributePath all in one go without a bunch of unnecessary
code. I also added NewAttributePath to avoid littering
`&AttributePath{}` around our code and provider code everywhere.

This also necessitated adding a `Steps` method to AttributePaths, so
provider devs could get at the steps in a read-only fashion. `Steps` is
safe to call even if the AttributePath it's called on is nil, it will
just return an empty slice.

AttributePathErrors became exported, so provider devs can detect them,
and the Path was exported so provider devs could get at it. It also
gained its own Error method, prefixing the error message it's wrapping
with the AttributePath it's associating that error with. It also got an
Unwrap method, supporting `errors.Is` and `errors.As`.

The rest of this is just updating our code to use these new types and
methods, as AttributePaths are used... well, basically everywhere.

Fixes #61.
Fixes #10.
Fixes #34.