### PR TITLE
Fix panic in IsFullyKnown.

### DIFF
--- a/.changelog/69.txt
+++ b/.changelog/69.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed a bug in `tftypes.Value.IsFullyKnown` that would cause a panic when calling `IsFullyKnown` on `tftypes.Value` with a `tftypes.Type` of Map, Object, List, Set, or Tuple if the `tftypes.Value` was null.
+```

--- a/tfprotov5/tftypes/value.go
+++ b/tfprotov5/tftypes/value.go
@@ -609,6 +609,9 @@ func (val Value) IsFullyKnown() bool {
 	case primitive:
 		return true
 	case List, Set, Tuple:
+		if val.value == nil {
+			return true
+		}
 		for _, v := range val.value.([]Value) {
 			if !v.IsFullyKnown() {
 				return false
@@ -616,6 +619,9 @@ func (val Value) IsFullyKnown() bool {
 		}
 		return true
 	case Map, Object:
+		if val.value == nil {
+			return true
+		}
 		for _, v := range val.value.(map[string]Value) {
 			if !v.IsFullyKnown() {
 				return false

--- a/tfprotov5/tftypes/value.go
+++ b/tfprotov5/tftypes/value.go
@@ -605,13 +605,13 @@ func (val Value) IsFullyKnown() bool {
 	if !val.IsKnown() {
 		return false
 	}
+	if val.value == nil {
+		return true
+	}
 	switch val.Type().(type) {
 	case primitive:
 		return true
 	case List, Set, Tuple:
-		if val.value == nil {
-			return true
-		}
 		for _, v := range val.value.([]Value) {
 			if !v.IsFullyKnown() {
 				return false
@@ -619,9 +619,6 @@ func (val Value) IsFullyKnown() bool {
 		}
 		return true
 	case Map, Object:
-		if val.value == nil {
-			return true
-		}
 		for _, v := range val.value.(map[string]Value) {
 			if !v.IsFullyKnown() {
 				return false

--- a/tfprotov5/tftypes/value_test.go
+++ b/tfprotov5/tftypes/value_test.go
@@ -705,6 +705,33 @@ func TestValueIsKnown(t *testing.T) {
 			known:      true,
 			fullyKnown: false,
 		},
+		"object-null": {
+			value: NewValue(Object{AttributeTypes: map[string]Type{
+				"foo": String,
+			}}, nil),
+			known:      true,
+			fullyKnown: true,
+		},
+		"map-null": {
+			value:      NewValue(Map{AttributeType: String}, nil),
+			known:      true,
+			fullyKnown: true,
+		},
+		"tuple-null": {
+			value:      NewValue(Tuple{ElementTypes: []Type{String}}, nil),
+			known:      true,
+			fullyKnown: true,
+		},
+		"list-null": {
+			value:      NewValue(List{ElementType: String}, nil),
+			known:      true,
+			fullyKnown: true,
+		},
+		"set-null": {
+			value:      NewValue(Set{ElementType: String}, nil),
+			known:      true,
+			fullyKnown: true,
+		},
 	}
 	for name, test := range tests {
 		name, test := name, test


### PR DESCRIPTION
Calling Value.IsFullyKnown would panic if the type of the value was an
aggregate type (List, Set, Tuple, Map, or Object) and if that value
itself was null.

This adds tests to reproduce those panics and a minor change to
IsFullyKnown that prevents the panics.