### PR TITLE
Implement OptionalAttributes for Objects.

### DIFF
--- a/.changelog/74.txt
+++ b/.changelog/74.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Added support for OptionalAttributes to tftypes.Objects, allowing for objects with attributes that can be set or can be omitted. See https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes for more information on optional attributes in objects.
+```

--- a/.changelog/74.txt
+++ b/.changelog/74.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 Added support for OptionalAttributes to tftypes.Objects, allowing for objects with attributes that can be set or can be omitted. See https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes for more information on optional attributes in objects.
 ```
+
+```release-note:enhancement
+Added Equal method to tftypes.Type implementations, allowing them to be compared using github.com/google/go-cmp.
+```

--- a/tfprotov5/dynamic_value_msgpack.go
+++ b/tfprotov5/dynamic_value_msgpack.go
@@ -272,7 +272,7 @@ func msgpackUnmarshalObject(dec *msgpack.Decoder, types map[string]tftypes.Type,
 	case length == 0:
 		return tftypes.NewValue(tftypes.Object{
 			// no attributes means no types
-			AttributeTypes: nil,
+			AttributeTypes: map[string]tftypes.Type{},
 		}, map[string]tftypes.Value{}), nil
 	case length != len(types):
 		return tftypes.Value{}, path.NewErrorf("error decoding object; expected %d attributes, got %d", len(types), length)

--- a/tfprotov6/dynamic_value_msgpack.go
+++ b/tfprotov6/dynamic_value_msgpack.go
@@ -272,7 +272,7 @@ func msgpackUnmarshalObject(dec *msgpack.Decoder, types map[string]tftypes.Type,
 	case length == 0:
 		return tftypes.NewValue(tftypes.Object{
 			// no attributes means no types
-			AttributeTypes: nil,
+			AttributeTypes: map[string]tftypes.Type{},
 		}, map[string]tftypes.Value{}), nil
 	case length != len(types):
 		return tftypes.Value{}, path.NewErrorf("error decoding object; expected %d attributes, got %d", len(types), length)

--- a/tftypes/list_test.go
+++ b/tftypes/list_test.go
@@ -1,0 +1,147 @@
+package tftypes
+
+import "testing"
+
+func TestListEqual(t *testing.T) {
+	type testCase struct {
+		l1    List
+		l2    List
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			l1:    List{ElementType: String},
+			l2:    List{ElementType: String},
+			equal: true,
+		},
+		"unequal": {
+			l1:    List{ElementType: String},
+			l2:    List{ElementType: Number},
+			equal: false,
+		},
+		"equal-complex": {
+			l1: List{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			l2: List{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			equal: true,
+		},
+		"unequal-complex": {
+			l1: List{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			l2: List{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+				"d": DynamicPseudoType,
+			}}},
+			equal: false,
+		},
+		"unequal-empty": {
+			l1:    List{ElementType: String},
+			l2:    List{},
+			equal: false,
+		},
+		"unequal-complex-empty": {
+			l1: List{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			l2:    List{ElementType: Object{}},
+			equal: false,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.l1.Equal(tc.l2)
+			revRes := tc.l2.Equal(tc.l1)
+			if res != revRes {
+				t.Errorf("Expected Equal to be commutative, but l1.Equal(l2) is %v and l2.Equal(l1) is %v", res, revRes)
+			}
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}
+
+func TestListIs(t *testing.T) {
+	type testCase struct {
+		l1    List
+		l2    List
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			l1:    List{ElementType: String},
+			l2:    List{ElementType: String},
+			equal: true,
+		},
+		"unequal": {
+			l1:    List{ElementType: String},
+			l2:    List{ElementType: Number},
+			equal: false,
+		},
+		"equal-complex": {
+			l1: List{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			l2: List{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			equal: true,
+		},
+		"unequal-complex": {
+			l1: List{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			l2: List{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+				"d": DynamicPseudoType,
+			}}},
+			equal: false,
+		},
+		"unequal-empty": {
+			l1:    List{ElementType: String},
+			l2:    List{},
+			equal: true,
+		},
+		"unequal-complex-empty": {
+			l1: List{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			l2:    List{ElementType: Object{}},
+			equal: true,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.l1.Is(tc.l2)
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}

--- a/tftypes/map_test.go
+++ b/tftypes/map_test.go
@@ -1,0 +1,147 @@
+package tftypes
+
+import "testing"
+
+func TestMapEqual(t *testing.T) {
+	type testCase struct {
+		m1    Map
+		m2    Map
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			m1:    Map{AttributeType: String},
+			m2:    Map{AttributeType: String},
+			equal: true,
+		},
+		"unequal": {
+			m1:    Map{AttributeType: String},
+			m2:    Map{AttributeType: Number},
+			equal: false,
+		},
+		"equal-complex": {
+			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			m2: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			equal: true,
+		},
+		"unequal-complex": {
+			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			m2: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+				"d": DynamicPseudoType,
+			}}},
+			equal: false,
+		},
+		"unequal-empty": {
+			m1:    Map{AttributeType: String},
+			m2:    Map{},
+			equal: false,
+		},
+		"unequal-complex-empty": {
+			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			m2:    Map{AttributeType: Object{}},
+			equal: false,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.m1.Equal(tc.m2)
+			revRes := tc.m2.Equal(tc.m1)
+			if res != revRes {
+				t.Errorf("Expected Equal to be commutative, but m1.Equal(m2) is %v and m2.Equal(m1) is %v", res, revRes)
+			}
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}
+
+func TestMapIs(t *testing.T) {
+	type testCase struct {
+		m1    Map
+		m2    Map
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			m1:    Map{AttributeType: String},
+			m2:    Map{AttributeType: String},
+			equal: true,
+		},
+		"unequal": {
+			m1:    Map{AttributeType: String},
+			m2:    Map{AttributeType: Number},
+			equal: false,
+		},
+		"equal-complex": {
+			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			m2: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			equal: true,
+		},
+		"unequal-complex": {
+			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			m2: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+				"d": DynamicPseudoType,
+			}}},
+			equal: false,
+		},
+		"unequal-empty": {
+			m1:    Map{AttributeType: String},
+			m2:    Map{},
+			equal: true,
+		},
+		"unequal-complex-empty": {
+			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			m2:    Map{AttributeType: Object{}},
+			equal: true,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.m1.Is(tc.m2)
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}

--- a/tftypes/object.go
+++ b/tftypes/object.go
@@ -13,12 +13,35 @@ import (
 // of the type signature for the Object, and so two Objects with different
 // attribute names or types are considered to be distinct types.
 type Object struct {
+	// AttributeTypes is a map of attributes to their types. The key should
+	// be the name of the attribute, and the value should be the type of
+	// the attribute.
 	AttributeTypes map[string]Type
+
+	// OptionalAttributes is a set of attributes that are optional. This
+	// allows values of this object type to include or not include those
+	// attributes without changing the type of the value; other attributes
+	// are considered part of the type signature, and their absence means a
+	// value is no longer of that type.
+	//
+	// The key of OptionalAttributes should be the name of the attribute
+	// that is optional. The value should be an empty struct, used only to
+	// indicate presence.
+	//
+	// OptionalAttributes must also be listed in the AttributeTypes
+	// property, indicating their types.
+	OptionalAttributes map[string]struct{}
 
 	// used to make this type uncomparable
 	// see https://golang.org/ref/spec#Comparison_operators
 	// this enforces the use of Is, instead
 	_ []struct{}
+}
+
+// Equal returns true if the two Objects are exactly equal. Unlike Is, passing
+// in an Object with no AttributeTypes will always return false.
+func (o Object) Equal(other Object) bool {
+	return o.equals(other, true)
 }
 
 // Is returns whether `t` is an Object type or not. If `t` is an instance of
@@ -27,23 +50,63 @@ type Object struct {
 // equal, the same set of keys must be present in each, and each key's value
 // needs to be considered the same type between the two Objects.
 func (o Object) Is(t Type) bool {
+	return o.equals(t, false)
+}
+
+func (o Object) equals(t Type, exact bool) bool {
 	v, ok := t.(Object)
 	if !ok {
 		return false
 	}
-	if v.AttributeTypes != nil {
-		if len(o.AttributeTypes) != len(v.AttributeTypes) {
+	if v.AttributeTypes == nil || o.AttributeTypes == nil {
+		// when doing exact comparisons, we can't compare types that
+		// don't have attribute types set, so we just consider them not
+		// equal
+		//
+		// when doing inexact comparisons, the absence of an attribute
+		// type just means "is this a Object?" We know it is, so return
+		// true if and only if o has AttributeTypes and t doesn't. This
+		// behavior only makes sense if the user is trying to see if a
+		// proper type is a object, so we want to ensure that the
+		// method receiver always has attribute types.
+		if exact {
 			return false
 		}
-		for k, typ := range o.AttributeTypes {
-			if _, ok := v.AttributeTypes[k]; !ok {
-				return false
-			}
-			if !typ.Is(v.AttributeTypes[k]) {
-				return false
-			}
+		return o.AttributeTypes != nil
+	}
+
+	// if the don't have the exact same optional attributes, they're not
+	// the same type.
+	if len(v.OptionalAttributes) != len(o.OptionalAttributes) {
+		return false
+	}
+	for attr := range o.OptionalAttributes {
+		if !v.attrIsOptional(attr) {
+			return false
 		}
 	}
+
+	// if they don't have the same attribute types, they're not the
+	// same type.
+	if len(v.AttributeTypes) != len(o.AttributeTypes) {
+		return false
+	}
+	for k, typ := range o.AttributeTypes {
+		if _, ok := v.AttributeTypes[k]; !ok {
+			return false
+		}
+		if !typ.equals(v.AttributeTypes[k], exact) {
+			return false
+		}
+	}
+	return true
+}
+
+func (o Object) attrIsOptional(attr string) bool {
+	if o.OptionalAttributes == nil {
+		return false
+	}
+	_, ok := o.OptionalAttributes[attr]
 	return ok
 }
 
@@ -61,6 +124,9 @@ func (o Object) String() string {
 		}
 		res.WriteString(`"` + key + `":`)
 		res.WriteString(o.AttributeTypes[key].String())
+		if o.attrIsOptional(key) {
+			res.WriteString(`?`)
+		}
 	}
 	res.WriteString("]")
 	return res.String()
@@ -81,7 +147,7 @@ func valueCanBeObject(val interface{}) bool {
 	}
 }
 
-func valueFromObject(types map[string]Type, in interface{}) (Value, error) {
+func valueFromObject(types map[string]Type, optionalAttrs map[string]struct{}, in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case map[string]Value:
 		// types should only be null if the "Object" is actually a
@@ -90,6 +156,10 @@ func valueFromObject(types map[string]Type, in interface{}) (Value, error) {
 		// how many there will be, so let's not validate that at all
 		if types != nil {
 			for k := range types {
+				if _, ok := optionalAttrs[k]; ok {
+					// if it's optional, we don't need to check that it has a value
+					continue
+				}
 				if _, ok := value[k]; !ok {
 					return Value{}, fmt.Errorf("can't create a tftypes.Value of type %s, required attribute %q not set", Object{AttributeTypes: types}, k)
 				}
@@ -97,19 +167,19 @@ func valueFromObject(types map[string]Type, in interface{}) (Value, error) {
 			for k, v := range value {
 				typ, ok := types[k]
 				if !ok {
-					return Value{}, fmt.Errorf("can't set a value on %q in tftypes.NewValue, key not part of the object type %s.", k, Object{AttributeTypes: types})
+					return Value{}, fmt.Errorf("can't set a value on %q in tftypes.NewValue, key not part of the object type %s", k, Object{AttributeTypes: types})
 				}
 				if !v.Type().Is(types[k]) && !types[k].Is(DynamicPseudoType) {
-					return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value for %q in %s. Expected type is %s.", v.Type(), k, Object{AttributeTypes: types}, typ)
+					return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value for %q in %s; expected type is %s", v.Type(), k, Object{AttributeTypes: types}, typ)
 				}
 			}
 		}
 		return Value{
-			typ:   Object{AttributeTypes: types},
+			typ:   Object{AttributeTypes: types, OptionalAttributes: optionalAttrs},
 			value: value,
 		}, nil
 	default:
-		return Value{}, fmt.Errorf("tftypes.NewValue can't use %T as a tftypes.Object. Expected types are: %s", in, formattedSupportedGoTypes(Object{}))
+		return Value{}, fmt.Errorf("tftypes.NewValue can't use %T as a tftypes.Object; expected types are: %s", in, formattedSupportedGoTypes(Object{}))
 	}
 }
 
@@ -122,5 +192,19 @@ func (o Object) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []byte(`["object",` + string(attrs) + `]`), nil
+	var optionalAttrs []byte
+	if len(o.OptionalAttributes) > 0 {
+		optionalAttrs = append(optionalAttrs, []byte(",")...)
+		names := make([]string, 0, len(o.OptionalAttributes))
+		for k := range o.OptionalAttributes {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		optionalsJSON, err := json.Marshal(names)
+		if err != nil {
+			return nil, err
+		}
+		optionalAttrs = append(optionalAttrs, optionalsJSON...)
+	}
+	return []byte(`["object",` + string(attrs) + string(optionalAttrs) + `]`), nil
 }

--- a/tftypes/object_test.go
+++ b/tftypes/object_test.go
@@ -1,0 +1,347 @@
+package tftypes
+
+import "testing"
+
+func TestObjectEqual(t *testing.T) {
+	type testCase struct {
+		o1    Object
+		o2    Object
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			equal: true,
+		},
+		"unequal": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}},
+			equal: false,
+		},
+		"unequal-lengths": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+			}},
+			equal: false,
+		},
+		"unequal-different-keys": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"d": Bool,
+			}},
+			equal: false,
+		},
+		"unequal-optional-lengths": {
+			o1: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"a": {},
+				},
+			},
+			o2: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"a": {},
+					"b": {},
+				},
+			},
+			equal: false,
+		},
+		"unequal-optional-attrs": {
+			o1: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"a": {},
+				},
+			},
+			o2: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"b": {},
+				},
+			},
+			equal: false,
+		},
+		"equal-complex": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"list": List{ElementType: String},
+				"object": Object{AttributeTypes: map[string]Type{
+					"a": Number,
+					"b": String,
+					"c": Bool,
+				}}}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"list": List{ElementType: String},
+				"object": Object{AttributeTypes: map[string]Type{
+					"a": Number,
+					"b": String,
+					"c": Bool,
+				}}}},
+			equal: true,
+		},
+		"unequal-complex": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"list": List{ElementType: String},
+				"object": Object{AttributeTypes: map[string]Type{
+					"a": Number,
+					"b": String,
+					"c": Bool,
+				}}}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"list": List{ElementType: String},
+				"object": Object{AttributeTypes: map[string]Type{
+					"a": Number,
+					"b": String,
+					"c": Bool,
+					"d": DynamicPseudoType,
+				}}}},
+			equal: false,
+		},
+		"unequal-empty": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"a": String,
+			}},
+			o2:    Object{},
+			equal: false,
+		},
+		"unequal-complex-empty": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"list": List{ElementType: String},
+				"object": Object{AttributeTypes: map[string]Type{
+					"a": Number,
+					"b": String,
+					"c": Bool,
+				}}}},
+			o2:    Object{AttributeTypes: map[string]Type{}},
+			equal: false,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.o1.Equal(tc.o2)
+			revRes := tc.o2.Equal(tc.o1)
+			if res != revRes {
+				t.Errorf("Expected Equal to be commutative, but o1.Equal(o2) is %v and o2.Equal(o1) is %v", res, revRes)
+			}
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}
+
+func TestObjectIs(t *testing.T) {
+	type testCase struct {
+		o1    Object
+		o2    Object
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			equal: true,
+		},
+		"unequal": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}},
+			equal: false,
+		},
+		"unequal-lengths": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+			}},
+			equal: false,
+		},
+		"unequal-different-keys": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"d": Bool,
+			}},
+			equal: false,
+		},
+		"unequal-optional-lengths": {
+			o1: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"a": {},
+				},
+			},
+			o2: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"a": {},
+					"b": {},
+				},
+			},
+			equal: false,
+		},
+		"unequal-optional-attrs": {
+			o1: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"a": {},
+				},
+			},
+			o2: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"b": {},
+				},
+			},
+			equal: false,
+		},
+		"equal-complex": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"list": List{ElementType: String},
+				"object": Object{AttributeTypes: map[string]Type{
+					"a": Number,
+					"b": String,
+					"c": Bool,
+				}}}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"list": List{ElementType: String},
+				"object": Object{AttributeTypes: map[string]Type{
+					"a": Number,
+					"b": String,
+					"c": Bool,
+				}}}},
+			equal: true,
+		},
+		"unequal-complex": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"list": List{ElementType: String},
+				"object": Object{AttributeTypes: map[string]Type{
+					"a": Number,
+					"b": String,
+					"c": Bool,
+				}}}},
+			o2: Object{AttributeTypes: map[string]Type{
+				"list": List{ElementType: String},
+				"object": Object{AttributeTypes: map[string]Type{
+					"a": Number,
+					"b": String,
+					"c": Bool,
+					"d": DynamicPseudoType,
+				}}}},
+			equal: false,
+		},
+		"unequal-empty": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"a": String,
+			}},
+			o2:    Object{},
+			equal: true,
+		},
+		"unequal-complex-empty": {
+			o1: Object{AttributeTypes: map[string]Type{
+				"list": List{ElementType: String},
+				"object": Object{AttributeTypes: map[string]Type{
+					"a": Number,
+					"b": String,
+					"c": Bool,
+				}}}},
+			o2:    Object{},
+			equal: true,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.o1.Is(tc.o2)
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}

--- a/tftypes/primitive.go
+++ b/tftypes/primitive.go
@@ -37,7 +37,15 @@ type primitive struct {
 	_ []struct{}
 }
 
+func (p primitive) Equal(o primitive) bool {
+	return p.equals(o, true)
+}
+
 func (p primitive) Is(t Type) bool {
+	return p.equals(t, false)
+}
+
+func (p primitive) equals(t Type, exact bool) bool {
 	v, ok := t.(primitive)
 	if !ok {
 		return false
@@ -130,7 +138,7 @@ func valueFromString(in interface{}) (Value, error) {
 			value: value,
 		}, nil
 	default:
-		return Value{}, fmt.Errorf("tftypes.NewValue can't use %T as a tftypes.String. Expected types are: %s", in, formattedSupportedGoTypes(String))
+		return Value{}, fmt.Errorf("tftypes.NewValue can't use %T as a tftypes.String; expected types are: %s", in, formattedSupportedGoTypes(String))
 	}
 }
 
@@ -164,7 +172,7 @@ func valueFromBool(in interface{}) (Value, error) {
 			value: value,
 		}, nil
 	default:
-		return Value{}, fmt.Errorf("tftypes.NewValue can't use %T as a tftypes.Bool. Expected types are: %s", in, formattedSupportedGoTypes(Bool))
+		return Value{}, fmt.Errorf("tftypes.NewValue can't use %T as a tftypes.Bool; expected types are: %s", in, formattedSupportedGoTypes(Bool))
 	}
 }
 
@@ -371,7 +379,7 @@ func valueFromNumber(in interface{}) (Value, error) {
 			value: big.NewFloat(*value),
 		}, nil
 	default:
-		return Value{}, fmt.Errorf("tftypes.NewValue can't use %T as a tftypes.Number. Expected types are: %s", in, formattedSupportedGoTypes(Number))
+		return Value{}, fmt.Errorf("tftypes.NewValue can't use %T as a tftypes.Number; expected types are: %s", in, formattedSupportedGoTypes(Number))
 	}
 }
 
@@ -399,7 +407,7 @@ func valueFromDynamicPseudoType(val interface{}) (Value, error) {
 		v.typ = DynamicPseudoType
 		return v, nil
 	case valueCanBeObject(val):
-		v, err := valueFromObject(nil, val)
+		v, err := valueFromObject(nil, nil, val)
 		if err != nil {
 			return Value{}, err
 		}
@@ -413,6 +421,6 @@ func valueFromDynamicPseudoType(val interface{}) (Value, error) {
 		v.typ = DynamicPseudoType
 		return v, nil
 	default:
-		return Value{}, fmt.Errorf("tftypes.NewValue can't use %T as a tftypes.DynamicPseudoType. Expected types are: %s", val, formattedSupportedGoTypes(DynamicPseudoType))
+		return Value{}, fmt.Errorf("tftypes.NewValue can't use %T as a tftypes.DynamicPseudoType; expected types are: %s", val, formattedSupportedGoTypes(DynamicPseudoType))
 	}
 }

--- a/tftypes/primitive_test.go
+++ b/tftypes/primitive_test.go
@@ -1,0 +1,65 @@
+package tftypes
+
+import "testing"
+
+func TestPrimitiveEqual(t *testing.T) {
+	type testCase struct {
+		p1    primitive
+		p2    primitive
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			p1:    String,
+			p2:    String,
+			equal: true,
+		},
+		"unequal": {
+			p1:    String,
+			p2:    Number,
+			equal: false,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.p1.Equal(tc.p2)
+			revRes := tc.p2.Equal(tc.p1)
+			if res != revRes {
+				t.Errorf("Expected Equal to be commutative, but p1.Equal(p2) is %v and p2.Equal(p1) is %v", res, revRes)
+			}
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}
+
+func TestPrimitiveIs(t *testing.T) {
+	type testCase struct {
+		p1    primitive
+		p2    primitive
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			p1:    String,
+			p2:    String,
+			equal: true,
+		},
+		"unequal": {
+			p1:    String,
+			p2:    Number,
+			equal: false,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.p1.Is(tc.p2)
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}

--- a/tftypes/set_test.go
+++ b/tftypes/set_test.go
@@ -1,0 +1,147 @@
+package tftypes
+
+import "testing"
+
+func TestSetEqual(t *testing.T) {
+	type testCase struct {
+		s1    Set
+		s2    Set
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			s1:    Set{ElementType: String},
+			s2:    Set{ElementType: String},
+			equal: true,
+		},
+		"unequal": {
+			s1:    Set{ElementType: String},
+			s2:    Set{ElementType: Number},
+			equal: false,
+		},
+		"equal-complex": {
+			s1: Set{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			s2: Set{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			equal: true,
+		},
+		"unequal-complex": {
+			s1: Set{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			s2: Set{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+				"d": DynamicPseudoType,
+			}}},
+			equal: false,
+		},
+		"unequal-empty": {
+			s1:    Set{ElementType: String},
+			s2:    Set{},
+			equal: false,
+		},
+		"unequal-complex-empty": {
+			s1: Set{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			s2:    Set{ElementType: Object{}},
+			equal: false,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.s1.Equal(tc.s2)
+			revRes := tc.s2.Equal(tc.s1)
+			if res != revRes {
+				t.Errorf("Expected Equal to be commutative, but s1.Equal(s2) is %v and s2.Equal(s1) is %v", res, revRes)
+			}
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}
+
+func TestSetIs(t *testing.T) {
+	type testCase struct {
+		s1    Set
+		s2    Set
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			s1:    Set{ElementType: String},
+			s2:    Set{ElementType: String},
+			equal: true,
+		},
+		"unequal": {
+			s1:    Set{ElementType: String},
+			s2:    Set{ElementType: Number},
+			equal: false,
+		},
+		"equal-complex": {
+			s1: Set{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			s2: Set{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			equal: true,
+		},
+		"unequal-complex": {
+			s1: Set{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			s2: Set{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+				"d": DynamicPseudoType,
+			}}},
+			equal: false,
+		},
+		"unequal-empty": {
+			s1:    Set{ElementType: String},
+			s2:    Set{},
+			equal: true,
+		},
+		"unequal-complex-empty": {
+			s1: Set{ElementType: Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}},
+			s2:    Set{ElementType: Object{}},
+			equal: true,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.s1.Is(tc.s2)
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}

--- a/tftypes/tuple_test.go
+++ b/tftypes/tuple_test.go
@@ -1,0 +1,157 @@
+package tftypes
+
+import "testing"
+
+func TestTupleEqual(t *testing.T) {
+	type testCase struct {
+		t1    Tuple
+		t2    Tuple
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			t1:    Tuple{ElementTypes: []Type{String, Number, Bool}},
+			t2:    Tuple{ElementTypes: []Type{String, Number, Bool}},
+			equal: true,
+		},
+		"unequal": {
+			t1:    Tuple{ElementTypes: []Type{String, Number, Bool}},
+			t2:    Tuple{ElementTypes: []Type{Number, String, Bool}},
+			equal: false,
+		},
+		"unequal-lengths": {
+			t1:    Tuple{ElementTypes: []Type{String, Number, Bool}},
+			t2:    Tuple{ElementTypes: []Type{String, Number}},
+			equal: false,
+		},
+		"equal-complex": {
+			t1: Tuple{ElementTypes: []Type{Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}}},
+			t2: Tuple{ElementTypes: []Type{Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}}},
+			equal: true,
+		},
+		"unequal-complex": {
+			t1: Tuple{ElementTypes: []Type{Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}}},
+			t2: Tuple{ElementTypes: []Type{Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+				"d": DynamicPseudoType,
+			}}}},
+			equal: false,
+		},
+		"unequal-empty": {
+			t1:    Tuple{ElementTypes: []Type{String}},
+			t2:    Tuple{},
+			equal: false,
+		},
+		"unequal-complex-empty": {
+			t1: Tuple{ElementTypes: []Type{Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}}},
+			t2:    Tuple{ElementTypes: []Type{Object{}}},
+			equal: false,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.t1.Equal(tc.t2)
+			revRes := tc.t2.Equal(tc.t1)
+			if res != revRes {
+				t.Errorf("Expected Equal to be commutative, but t1.Equal(t2) is %v and t2.Equal(t1) is %v", res, revRes)
+			}
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}
+
+func TestTupleIs(t *testing.T) {
+	type testCase struct {
+		t1    Tuple
+		t2    Tuple
+		equal bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			t1:    Tuple{ElementTypes: []Type{String, Number, Bool}},
+			t2:    Tuple{ElementTypes: []Type{String, Number, Bool}},
+			equal: true,
+		},
+		"unequal": {
+			t1:    Tuple{ElementTypes: []Type{String, Number, Bool}},
+			t2:    Tuple{ElementTypes: []Type{Number, String, Bool}},
+			equal: false,
+		},
+		"unequal-lengths": {
+			t1:    Tuple{ElementTypes: []Type{String, Number, Bool}},
+			t2:    Tuple{ElementTypes: []Type{String, Number}},
+			equal: false,
+		},
+		"equal-complex": {
+			t1: Tuple{ElementTypes: []Type{Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}}},
+			t2: Tuple{ElementTypes: []Type{Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}}},
+			equal: true,
+		},
+		"unequal-complex": {
+			t1: Tuple{ElementTypes: []Type{Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}}},
+			t2: Tuple{ElementTypes: []Type{Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+				"d": DynamicPseudoType,
+			}}}},
+			equal: false,
+		},
+		"unequal-empty": {
+			t1:    Tuple{ElementTypes: []Type{String}},
+			t2:    Tuple{},
+			equal: true,
+		},
+		"unequal-complex-empty": {
+			t1: Tuple{ElementTypes: []Type{Object{AttributeTypes: map[string]Type{
+				"a": Number,
+				"b": String,
+				"c": Bool,
+			}}}},
+			t2:    Tuple{ElementTypes: []Type{Object{}}},
+			equal: true,
+		},
+	}
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			res := tc.t1.Is(tc.t2)
+			if res != tc.equal {
+				t.Errorf("Expected result to be %v, got %v", tc.equal, res)
+			}
+		})
+	}
+}

--- a/tftypes/type_json_test.go
+++ b/tftypes/type_json_test.go
@@ -51,6 +51,48 @@ func TestTypeJSON(t *testing.T) {
 				"baz": Bool,
 			}},
 		},
+		"object-string_number_bool-optional_string": {
+			json: `["object",{"foo":"string","bar":"number","baz":"bool"},["foo"]]`,
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"foo": String,
+					"bar": Number,
+					"baz": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"foo": {},
+				},
+			},
+		},
+		"object-string_number_bool-optional_string-number": {
+			json: `["object",{"foo":"string","bar":"number","baz":"bool"},["bar", "foo"]]`,
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"foo": String,
+					"bar": Number,
+					"baz": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"foo": {},
+					"bar": {},
+				},
+			},
+		},
+		"object-string_number_bool-optional_string-number-bool": {
+			json: `["object",{"foo":"string","bar":"number","baz":"bool"},["bar","baz","foo"]]`,
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"foo": String,
+					"bar": Number,
+					"baz": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"foo": {},
+					"bar": {},
+					"baz": {},
+				},
+			},
+		},
 		"tuple-string_number_bool": {
 			json: `["tuple",["string","number","bool"]]`,
 			typ: Tuple{ElementTypes: []Type{

--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -200,6 +200,9 @@ func (val Value) ApplyTerraform5AttributePathStep(step AttributePathStep) (inter
 // considered equal if their types are considered equal and if they represent
 // data that is considered equal.
 func (val Value) Equal(o Value) bool {
+	if val.typ == nil && o.typ == nil && val.value == nil && o.value == nil {
+		return true
+	}
 	if !val.Type().Is(o.Type()) {
 		return false
 	}
@@ -321,7 +324,7 @@ func newValue(t Type, val interface{}) (Value, error) {
 		}
 		return v, nil
 	case t.Is(Object{}):
-		v, err := valueFromObject(t.(Object).AttributeTypes, val)
+		v, err := valueFromObject(t.(Object).AttributeTypes, t.(Object).OptionalAttributes, val)
 		if err != nil {
 			return Value{}, err
 		}

--- a/tftypes/value_object_test.go
+++ b/tftypes/value_object_test.go
@@ -1,0 +1,199 @@
+package tftypes
+
+import (
+	"math/big"
+	"regexp"
+	"testing"
+)
+
+func Test_newValue_object(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		typ      Type
+		val      interface{}
+		err      *regexp.Regexp
+		expected Value
+	}
+	tests := map[string]testCase{
+		"normal": {
+			typ: Object{AttributeTypes: map[string]Type{
+				"a": String,
+				"b": Number,
+				"c": Bool,
+			}},
+			val: map[string]Value{
+				"a": NewValue(String, "hello"),
+				"b": NewValue(Number, 123),
+				"c": NewValue(Bool, true),
+			},
+			expected: Value{
+				typ: Object{AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				}},
+				value: map[string]Value{
+					"a": {
+						typ:   String,
+						value: "hello",
+					},
+					"b": {
+						typ:   Number,
+						value: big.NewFloat(123),
+					},
+					"c": {
+						typ:   Bool,
+						value: true,
+					},
+				},
+			},
+			err: nil,
+		},
+		"optional-included": {
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"a": {},
+				},
+			},
+			val: map[string]Value{
+				"a": NewValue(String, "hello"),
+				"b": NewValue(Number, 123),
+				"c": NewValue(Bool, true),
+			},
+			expected: Value{
+				typ: Object{
+					AttributeTypes: map[string]Type{
+						"a": String,
+						"b": Number,
+						"c": Bool,
+					},
+					OptionalAttributes: map[string]struct{}{
+						"a": {},
+					},
+				},
+				value: map[string]Value{
+					"a": {
+						typ:   String,
+						value: "hello",
+					},
+					"b": {
+						typ:   Number,
+						value: big.NewFloat(123),
+					},
+					"c": {
+						typ:   Bool,
+						value: true,
+					},
+				},
+			},
+			err: nil,
+		},
+		"optional-excluded": {
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+				OptionalAttributes: map[string]struct{}{
+					"a": {},
+				},
+			},
+			val: map[string]Value{
+				"b": NewValue(Number, 123),
+				"c": NewValue(Bool, true),
+			},
+			expected: Value{
+				typ: Object{
+					AttributeTypes: map[string]Type{
+						"a": String,
+						"b": Number,
+						"c": Bool,
+					},
+					OptionalAttributes: map[string]struct{}{
+						"a": {},
+					},
+				},
+				value: map[string]Value{
+					"b": {
+						typ:   Number,
+						value: big.NewFloat(123),
+					},
+					"c": {
+						typ:   Bool,
+						value: true,
+					},
+				},
+			},
+			err: nil,
+		},
+		"missing-attribute": {
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+			},
+			val: map[string]Value{
+				"b": NewValue(Number, 123),
+				"c": NewValue(Bool, true),
+			},
+			err: regexp.MustCompile(`required attribute "a" not set`),
+		},
+		"invalid-attribute": {
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+			},
+			val: map[string]Value{
+				"a": NewValue(String, "foo"),
+				"b": NewValue(Number, 123),
+				"c": NewValue(Bool, false),
+				"d": NewValue(Bool, true),
+			},
+			err: regexp.MustCompile(`can't set a value on "d" in tftypes.NewValue, key not part of the object type`),
+		},
+		"attribute-wrong-type": {
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": Bool,
+				},
+			},
+			val: map[string]Value{
+				"a": NewValue(String, "foo"),
+				"b": NewValue(Number, 123),
+				"c": NewValue(String, "false"),
+			},
+			err: regexp.MustCompile(`can't use type tftypes.String as a value for "c" in tftypes.Object\["a":tftypes.String, "b":tftypes.Number, "c":tftypes.Bool\]; expected type is tftypes.Bool`),
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := newValue(test.typ, test.val)
+			if err == nil && test.err != nil {
+				t.Errorf("Expected error to match %q, got nil", test.err)
+			} else if err != nil && test.err == nil {
+				t.Errorf("Expected error to be nil, got %q", err)
+			} else if err != nil && test.err != nil && !test.err.MatchString(err.Error()) {
+				t.Errorf("Expected error to match %s, got %q", test.err, err.Error())
+			}
+			if !res.Equal(test.expected) {
+				t.Errorf("Expected value to be %s, got %s", test.expected, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is another massive PR, sorry. I tried to separate out some of the
changes, but the code kept overlapping, unfortunately.

All our Types got an Equal method, so they can be compared using go-cmp.
This was necessary to make the tests pass. As part of this, the Type
interface was refactored to include an equals() private method, which
powers the Equal and Is methods on each type.

I also fixed some periods in error messages to make golint happy.

Of course, with these new methods, there was enough logic to add tests
to each Type, so I added some tests that exercised the equality checks.

I also added, which was the main thing I was trying to do here, an
OptionalAttributes property to Objects. These are attributes that _can_
be set on an object, but are not _required_ to be.

Because OptionalAttributes made the NewValue logic more complicated for
Objects, I wrote some tests for creating Objects with NewValue to test
the logic.

Finally, the new Object comparison logic was panicking during a
tfprotov5 / tfprotov6 test, because the Object had a nil AttributeTypes
map instead of an empty AttributeTypes map. I fixed it to use an empty
AttributeTypes map. In theory, I don't think we should ever see a nil
AttributeTypes map.

Fixes #48.