### PR TITLE
Fix NewValue checks to be properly recursive

### DIFF
--- a/tftypes/list.go
+++ b/tftypes/list.go
@@ -67,6 +67,7 @@ func valueFromList(typ Type, in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case []Value:
 		for pos, v := range value {
+			//TODO: this needs to be a recursive check to allow for nested dynamic
 			if !v.Type().Is(typ) && !typ.Is(DynamicPseudoType) {
 				return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value in position %d of %s; expected type is %s", v.Type(), pos, List{ElementType: typ}, typ)
 			}

--- a/tftypes/list.go
+++ b/tftypes/list.go
@@ -66,9 +66,16 @@ func (l List) supportedGoTypes() []string {
 func valueFromList(typ Type, in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case []Value:
+		var valType Type
 		for pos, v := range value {
 			if err := useTypeAs(v.Type(), typ, NewAttributePath().WithElementKeyInt(int64(pos))); err != nil {
 				return Value{}, err
+			}
+			if valType == nil {
+				valType = v.Type()
+			}
+			if !v.Type().equals(valType, true) {
+				return Value{}, fmt.Errorf("lists must only contain one type of element, saw %s and %s", valType, v.Type())
 			}
 		}
 		return Value{

--- a/tftypes/list.go
+++ b/tftypes/list.go
@@ -67,9 +67,8 @@ func valueFromList(typ Type, in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case []Value:
 		for pos, v := range value {
-			//TODO: this needs to be a recursive check to allow for nested dynamic
-			if !v.Type().Is(typ) && !typ.Is(DynamicPseudoType) {
-				return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value in position %d of %s; expected type is %s", v.Type(), pos, List{ElementType: typ}, typ)
+			if err := useTypeAs(v.Type(), typ, NewAttributePath().WithElementKeyInt(int64(pos))); err != nil {
+				return Value{}, err
 			}
 		}
 		return Value{

--- a/tftypes/map.go
+++ b/tftypes/map.go
@@ -76,6 +76,7 @@ func valueFromMap(typ Type, in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case map[string]Value:
 		for k, v := range value {
+			//TODO: this needs to be a recursive check to allow for nested dynamic
 			if !v.Type().Is(typ) && !typ.Is(DynamicPseudoType) {
 				// TODO: make this an attribute path error?
 				return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value for %q in %s; expected type is %s", v.Type(), k, Map{AttributeType: typ}, typ)

--- a/tftypes/map.go
+++ b/tftypes/map.go
@@ -76,10 +76,8 @@ func valueFromMap(typ Type, in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case map[string]Value:
 		for k, v := range value {
-			//TODO: this needs to be a recursive check to allow for nested dynamic
-			if !v.Type().Is(typ) && !typ.Is(DynamicPseudoType) {
-				// TODO: make this an attribute path error?
-				return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value for %q in %s; expected type is %s", v.Type(), k, Map{AttributeType: typ}, typ)
+			if err := useTypeAs(v.Type(), typ, NewAttributePath().WithElementKeyString(k)); err != nil {
+				return Value{}, err
 			}
 		}
 		return Value{

--- a/tftypes/map.go
+++ b/tftypes/map.go
@@ -1,6 +1,9 @@
 package tftypes
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // Map is a Terraform type representing an unordered collection of elements,
 // all of the same type, each identifiable with a unique string key.
@@ -75,9 +78,22 @@ func (m Map) MarshalJSON() ([]byte, error) {
 func valueFromMap(typ Type, in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case map[string]Value:
-		for k, v := range value {
+		keys := make([]string, 0, len(value))
+		for k := range value {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var elType Type
+		for _, k := range keys {
+			v := value[k]
 			if err := useTypeAs(v.Type(), typ, NewAttributePath().WithElementKeyString(k)); err != nil {
 				return Value{}, err
+			}
+			if elType == nil {
+				elType = v.Type()
+			}
+			if !elType.equals(v.Type(), true) {
+				return Value{}, fmt.Errorf("maps must only contain one type of element, saw %s and %s", elType, v.Type())
 			}
 		}
 		return Value{

--- a/tftypes/object.go
+++ b/tftypes/object.go
@@ -169,9 +169,9 @@ func valueFromObject(types map[string]Type, optionalAttrs map[string]struct{}, i
 				if !ok {
 					return Value{}, fmt.Errorf("can't set a value on %q in tftypes.NewValue, key not part of the object type %s", k, Object{AttributeTypes: types})
 				}
-				//TODO: this needs to be a recursive check to allow for nested dynamic
-				if !v.Type().Is(types[k]) && !types[k].Is(DynamicPseudoType) {
-					return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value for %q in %s; expected type is %s", v.Type(), k, Object{AttributeTypes: types}, typ)
+				err := useTypeAs(v.Type(), typ, NewAttributePath().WithAttributeName(k))
+				if err != nil {
+					return Value{}, err
 				}
 			}
 		}

--- a/tftypes/object.go
+++ b/tftypes/object.go
@@ -169,6 +169,7 @@ func valueFromObject(types map[string]Type, optionalAttrs map[string]struct{}, i
 				if !ok {
 					return Value{}, fmt.Errorf("can't set a value on %q in tftypes.NewValue, key not part of the object type %s", k, Object{AttributeTypes: types})
 				}
+				//TODO: this needs to be a recursive check to allow for nested dynamic
 				if !v.Type().Is(types[k]) && !types[k].Is(DynamicPseudoType) {
 					return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value for %q in %s; expected type is %s", v.Type(), k, Object{AttributeTypes: types}, typ)
 				}

--- a/tftypes/set.go
+++ b/tftypes/set.go
@@ -67,6 +67,7 @@ func valueFromSet(typ Type, in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case []Value:
 		for pos, v := range value {
+			//TODO: this needs to be a recursive check to allow for nested dynamic
 			if !v.Type().Is(typ) && !typ.Is(DynamicPseudoType) {
 				return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value in position %d of %s; expected type is %s", v.Type(), pos, Set{ElementType: typ}, typ)
 			}

--- a/tftypes/set.go
+++ b/tftypes/set.go
@@ -66,10 +66,9 @@ func (s Set) supportedGoTypes() []string {
 func valueFromSet(typ Type, in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case []Value:
-		for pos, v := range value {
-			//TODO: this needs to be a recursive check to allow for nested dynamic
-			if !v.Type().Is(typ) && !typ.Is(DynamicPseudoType) {
-				return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value in position %d of %s; expected type is %s", v.Type(), pos, Set{ElementType: typ}, typ)
+		for _, v := range value {
+			if err := useTypeAs(v.Type(), typ, NewAttributePath().WithElementKeyValue(v)); err != nil {
+				return Value{}, err
 			}
 		}
 		return Value{

--- a/tftypes/set.go
+++ b/tftypes/set.go
@@ -66,9 +66,16 @@ func (s Set) supportedGoTypes() []string {
 func valueFromSet(typ Type, in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case []Value:
+		var elType Type
 		for _, v := range value {
 			if err := useTypeAs(v.Type(), typ, NewAttributePath().WithElementKeyValue(v)); err != nil {
 				return Value{}, err
+			}
+			if elType == nil {
+				elType = v.Type()
+			}
+			if !elType.equals(v.Type(), true) {
+				return Value{}, fmt.Errorf("sets must only contain one type of element, saw %s and %s", elType, v.Type())
 			}
 		}
 		return Value{

--- a/tftypes/tuple.go
+++ b/tftypes/tuple.go
@@ -102,9 +102,9 @@ func valueFromTuple(types []Type, in interface{}) (Value, error) {
 			}
 			for pos, v := range value {
 				typ := types[pos]
-				//TODO: this needs to be a recursive check to allow for nested dynamic
-				if !v.Type().Is(typ) && !typ.Is(DynamicPseudoType) {
-					return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value at position %d in %s; expected type is %s", v.Type(), pos, Tuple{ElementTypes: types}, typ)
+				err := useTypeAs(v.Type(), typ, NewAttributePath().WithElementKeyInt(int64(pos)))
+				if err != nil {
+					return Value{}, err
 				}
 			}
 		}

--- a/tftypes/tuple.go
+++ b/tftypes/tuple.go
@@ -102,6 +102,7 @@ func valueFromTuple(types []Type, in interface{}) (Value, error) {
 			}
 			for pos, v := range value {
 				typ := types[pos]
+				//TODO: this needs to be a recursive check to allow for nested dynamic
 				if !v.Type().Is(typ) && !typ.Is(DynamicPseudoType) {
 					return Value{}, fmt.Errorf("tftypes.NewValue can't use type %s as a value at position %d in %s; expected type is %s", v.Type(), pos, Tuple{ElementTypes: types}, typ)
 				}

--- a/tftypes/type.go
+++ b/tftypes/type.go
@@ -118,7 +118,7 @@ func useTypeAs(candidate, usedAs Type, path *AttributePath) error {
 		for attr, uAttr := range usedAs.(Object).AttributeTypes {
 			cAttr, ok := candidate.(Object).AttributeTypes[attr]
 			if !ok {
-				path.NewErrorf("can't use %s as %s", candidate, usedAs)
+				return path.NewErrorf("can't use %s as %s", candidate, usedAs)
 			}
 			err := useTypeAs(cAttr, uAttr, path.WithAttributeName(attr))
 			if err != nil {

--- a/tftypes/type.go
+++ b/tftypes/type.go
@@ -60,6 +60,75 @@ func TypeFromElements(elements []Value) (Type, error) {
 	return typ, nil
 }
 
+func useTypeAs(candidate, usedAs Type, path *AttributePath) error {
+	switch {
+	case usedAs.Is(DynamicPseudoType):
+		return nil
+	case usedAs.Is(String), usedAs.Is(Bool), usedAs.Is(Number):
+		if candidate.Is(usedAs) {
+			return nil
+		}
+		return path.NewErrorf("can't use %s as %s", candidate, usedAs)
+	case usedAs.Is(List{}):
+		if !candidate.Is(List{}) {
+			return path.NewErrorf("can't use %s as %s", candidate, usedAs)
+		}
+		return useTypeAs(candidate.(List).ElementType, usedAs.(List).ElementType, path.WithElementKeyInt(0))
+	case usedAs.Is(Set{}):
+		if !candidate.Is(Set{}) {
+			return path.NewErrorf("can't use %s as %s", candidate, usedAs)
+		}
+		return useTypeAs(candidate.(Set).ElementType, usedAs.(Set).ElementType, path.WithElementKeyValue(NewValue(DynamicPseudoType, UnknownValue)))
+	case usedAs.Is(Map{}):
+		if !candidate.Is(Map{}) {
+			return path.NewErrorf("can't use %s as %s", candidate, usedAs)
+		}
+		return useTypeAs(candidate.(Map).AttributeType, usedAs.(Map).AttributeType, path.WithElementKeyString(""))
+	case usedAs.Is(Tuple{}):
+		if !candidate.Is(Tuple{}) {
+			return path.NewErrorf("can't use %s as %s", candidate, usedAs)
+		}
+		cElems := candidate.(Tuple).ElementTypes
+		uElems := usedAs.(Tuple).ElementTypes
+		if len(cElems) != len(uElems) {
+			return path.NewErrorf("can't use %s as %s", candidate, usedAs)
+		}
+		for pos, cElem := range cElems {
+			uElem := uElems[pos]
+			err := useTypeAs(cElem, uElem, path.WithElementKeyInt(int64(pos)))
+			if err != nil {
+				return err
+			}
+		}
+	case usedAs.Is(Object{}):
+		if !candidate.Is(Object{}) {
+			return path.NewErrorf("can't use %s as %s", candidate, usedAs)
+		}
+		if len(candidate.(Object).OptionalAttributes) != len(usedAs.(Object).OptionalAttributes) {
+			return path.NewErrorf("can't use %s as %s", candidate, usedAs)
+		}
+		for attr := range usedAs.(Object).OptionalAttributes {
+			if !candidate.(Object).attrIsOptional(attr) {
+				return path.NewErrorf("can't use %s as %s", candidate, usedAs)
+			}
+		}
+		if len(candidate.(Object).AttributeTypes) != len(usedAs.(Object).AttributeTypes) {
+			return path.NewErrorf("can't use %s as %s", candidate, usedAs)
+		}
+		for attr, uAttr := range usedAs.(Object).AttributeTypes {
+			cAttr, ok := candidate.(Object).AttributeTypes[attr]
+			if !ok {
+				path.NewErrorf("can't use %s as %s", candidate, usedAs)
+			}
+			err := useTypeAs(cAttr, uAttr, path.WithAttributeName(attr))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 type jsonType struct {
 	t Type
 }

--- a/tftypes/value_list_test.go
+++ b/tftypes/value_list_test.go
@@ -1,0 +1,94 @@
+package tftypes
+
+import (
+	"regexp"
+	"testing"
+)
+
+func Test_newValue_list(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		typ      Type
+		val      interface{}
+		err      *regexp.Regexp
+		expected Value
+	}
+	tests := map[string]testCase{
+		"normal": {
+			typ: List{ElementType: String},
+			val: []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+			},
+			expected: Value{
+				typ: List{ElementType: String},
+				value: []Value{
+					{
+						typ:   String,
+						value: "hello",
+					},
+					{
+						typ:   String,
+						value: "world",
+					},
+				},
+			},
+			err: nil,
+		},
+		"dynamic": {
+			typ: List{ElementType: DynamicPseudoType},
+			val: []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+			},
+			expected: Value{
+				typ: List{ElementType: DynamicPseudoType},
+				value: []Value{
+					{
+						typ:   String,
+						value: "hello",
+					},
+					{
+						typ:   String,
+						value: "world",
+					},
+				},
+			},
+			err: nil,
+		},
+		"dynamic-different-types": {
+			typ: List{ElementType: DynamicPseudoType},
+			val: []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, 123),
+			},
+			err: regexp.MustCompile(`lists must only contain one type of element, saw tftypes.String and tftypes.Number`),
+		},
+		"wrong-type": {
+			typ: List{ElementType: String},
+			val: []Value{
+				NewValue(String, "foo"),
+				NewValue(Number, 123),
+			},
+			err: regexp.MustCompile(`ElementKeyInt\(1\): can't use tftypes.Number as tftypes.String`),
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := newValue(test.typ, test.val)
+			if err == nil && test.err != nil {
+				t.Errorf("Expected error to match %q, got nil", test.err)
+			} else if err != nil && test.err == nil {
+				t.Errorf("Expected error to be nil, got %q", err)
+			} else if err != nil && test.err != nil && !test.err.MatchString(err.Error()) {
+				t.Errorf("Expected error to match %q, got %q", test.err, err.Error())
+			}
+			if !res.Equal(test.expected) {
+				t.Errorf("Expected value to be %s, got %s", test.expected, res)
+			}
+		})
+	}
+}

--- a/tftypes/value_map_test.go
+++ b/tftypes/value_map_test.go
@@ -1,0 +1,94 @@
+package tftypes
+
+import (
+	"regexp"
+	"testing"
+)
+
+func Test_newValue_map(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		typ      Type
+		val      interface{}
+		err      *regexp.Regexp
+		expected Value
+	}
+	tests := map[string]testCase{
+		"normal": {
+			typ: Map{AttributeType: String},
+			val: map[string]Value{
+				"a": NewValue(String, "hello"),
+				"b": NewValue(String, "world"),
+			},
+			expected: Value{
+				typ: Map{AttributeType: String},
+				value: map[string]Value{
+					"a": {
+						typ:   String,
+						value: "hello",
+					},
+					"b": {
+						typ:   String,
+						value: "world",
+					},
+				},
+			},
+			err: nil,
+		},
+		"dynamic": {
+			typ: Map{AttributeType: DynamicPseudoType},
+			val: map[string]Value{
+				"a": NewValue(String, "hello"),
+				"b": NewValue(String, "world"),
+			},
+			expected: Value{
+				typ: Map{AttributeType: DynamicPseudoType},
+				value: map[string]Value{
+					"a": {
+						typ:   String,
+						value: "hello",
+					},
+					"b": {
+						typ:   String,
+						value: "world",
+					},
+				},
+			},
+			err: nil,
+		},
+		"dynamic-different-types": {
+			typ: Map{AttributeType: DynamicPseudoType},
+			val: map[string]Value{
+				"a": NewValue(String, "hello"),
+				"b": NewValue(Number, 123),
+			},
+			err: regexp.MustCompile(`maps must only contain one type of element, saw tftypes.String and tftypes.Number`),
+		},
+		"wrong-type": {
+			typ: Map{AttributeType: String},
+			val: map[string]Value{
+				"a": NewValue(String, "foo"),
+				"b": NewValue(Number, 123),
+			},
+			err: regexp.MustCompile(`ElementKeyString\("b"\): can't use tftypes.Number as tftypes.String`),
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := newValue(test.typ, test.val)
+			if err == nil && test.err != nil {
+				t.Errorf("Expected error to match %q, got nil", test.err)
+			} else if err != nil && test.err == nil {
+				t.Errorf("Expected error to be nil, got %q", err)
+			} else if err != nil && test.err != nil && !test.err.MatchString(err.Error()) {
+				t.Errorf("Expected error to match %q, got %q", test.err, err.Error())
+			}
+			if !res.Equal(test.expected) {
+				t.Errorf("Expected value to be %s, got %s", test.expected, res)
+			}
+		})
+	}
+}

--- a/tftypes/value_object_test.go
+++ b/tftypes/value_object_test.go
@@ -177,6 +177,42 @@ func Test_newValue_object(t *testing.T) {
 			},
 			err: regexp.MustCompile(`AttributeName\("c"\): can't use tftypes.String as tftypes.Bool`),
 		},
+		"dynamic-attribute": {
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": DynamicPseudoType,
+				},
+			},
+			val: map[string]Value{
+				"a": NewValue(String, "foo"),
+				"b": NewValue(Number, 123),
+				"c": NewValue(String, "false"),
+			},
+			expected: Value{
+				typ: Object{AttributeTypes: map[string]Type{
+					"a": String,
+					"b": Number,
+					"c": DynamicPseudoType,
+				}},
+				value: map[string]Value{
+					"a": {
+						typ:   String,
+						value: "foo",
+					},
+					"b": {
+						typ:   Number,
+						value: big.NewFloat(123),
+					},
+					"c": {
+						typ:   String,
+						value: "false",
+					},
+				},
+			},
+			err: nil,
+		},
 	}
 	for name, test := range tests {
 		name, test := name, test

--- a/tftypes/value_object_test.go
+++ b/tftypes/value_object_test.go
@@ -175,7 +175,7 @@ func Test_newValue_object(t *testing.T) {
 				"b": NewValue(Number, 123),
 				"c": NewValue(String, "false"),
 			},
-			err: regexp.MustCompile(`can't use type tftypes.String as a value for "c" in tftypes.Object\["a":tftypes.String, "b":tftypes.Number, "c":tftypes.Bool\]; expected type is tftypes.Bool`),
+			err: regexp.MustCompile(`AttributeName\("c"\): can't use tftypes.String as tftypes.Bool`),
 		},
 	}
 	for name, test := range tests {
@@ -189,7 +189,7 @@ func Test_newValue_object(t *testing.T) {
 			} else if err != nil && test.err == nil {
 				t.Errorf("Expected error to be nil, got %q", err)
 			} else if err != nil && test.err != nil && !test.err.MatchString(err.Error()) {
-				t.Errorf("Expected error to match %s, got %q", test.err, err.Error())
+				t.Errorf("Expected error to match %q, got %q", test.err, err.Error())
 			}
 			if !res.Equal(test.expected) {
 				t.Errorf("Expected value to be %s, got %s", test.expected, res)

--- a/tftypes/value_set_test.go
+++ b/tftypes/value_set_test.go
@@ -1,0 +1,94 @@
+package tftypes
+
+import (
+	"regexp"
+	"testing"
+)
+
+func Test_newValue_set(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		typ      Type
+		val      interface{}
+		err      *regexp.Regexp
+		expected Value
+	}
+	tests := map[string]testCase{
+		"normal": {
+			typ: Set{ElementType: String},
+			val: []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+			},
+			expected: Value{
+				typ: Set{ElementType: String},
+				value: []Value{
+					{
+						typ:   String,
+						value: "hello",
+					},
+					{
+						typ:   String,
+						value: "world",
+					},
+				},
+			},
+			err: nil,
+		},
+		"dynamic": {
+			typ: Set{ElementType: DynamicPseudoType},
+			val: []Value{
+				NewValue(String, "hello"),
+				NewValue(String, "world"),
+			},
+			expected: Value{
+				typ: Set{ElementType: DynamicPseudoType},
+				value: []Value{
+					{
+						typ:   String,
+						value: "hello",
+					},
+					{
+						typ:   String,
+						value: "world",
+					},
+				},
+			},
+			err: nil,
+		},
+		"dynamic-different-types": {
+			typ: Set{ElementType: DynamicPseudoType},
+			val: []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, 123),
+			},
+			err: regexp.MustCompile(`sets must only contain one type of element, saw tftypes.String and tftypes.Number`),
+		},
+		"wrong-type": {
+			typ: Set{ElementType: String},
+			val: []Value{
+				NewValue(String, "foo"),
+				NewValue(Number, 123),
+			},
+			err: regexp.MustCompile(`ElementKeyValue\(tftypes.Number<\"123\">\): can't use tftypes.Number as tftypes.String`),
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := newValue(test.typ, test.val)
+			if err == nil && test.err != nil {
+				t.Errorf("Expected error to match %q, got nil", test.err)
+			} else if err != nil && test.err == nil {
+				t.Errorf("Expected error to be nil, got %q", err)
+			} else if err != nil && test.err != nil && !test.err.MatchString(err.Error()) {
+				t.Errorf("Expected error to match %q, got %q", test.err, err.Error())
+			}
+			if !res.Equal(test.expected) {
+				t.Errorf("Expected value to be %s, got %s", test.expected, res)
+			}
+		})
+	}
+}

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -165,6 +165,11 @@ func TestValueAs(t *testing.T) {
 			as:       slicePointer([]Value{}),
 			expected: slicePointer([]Value{NewValue(String, "hello")}),
 		},
+		"list-dynamic": {
+			in:       NewValue(List{ElementType: DynamicPseudoType}, []Value{NewValue(String, "hello")}),
+			as:       slicePointer([]Value{}),
+			expected: slicePointer([]Value{NewValue(String, "hello")}),
+		},
 		"list-null": {
 			in:       NewValue(List{ElementType: String}, nil),
 			as:       slicePointer([]Value{NewValue(String, "hello")}),
@@ -180,8 +185,38 @@ func TestValueAs(t *testing.T) {
 			as:       slicePointerPointer(slicePointer([]Value{NewValue(String, "hello")})),
 			expected: slicePointerPointer(nil),
 		},
+		"list-object": {
+			in: NewValue(List{ElementType: Object{AttributeTypes: map[string]Type{
+				"foo": String,
+				"bar": Number,
+				"baz": Bool,
+			}}}, []Value{NewValue(Object{AttributeTypes: map[string]Type{
+				"foo": String,
+				"bar": Number,
+				"baz": Bool,
+			}}, map[string]Value{
+				"foo": NewValue(String, "hello"),
+				"bar": NewValue(Number, big.NewFloat(123)),
+				"baz": NewValue(Bool, true),
+			})}),
+			as: slicePointer([]Value{}),
+			expected: slicePointer([]Value{NewValue(Object{AttributeTypes: map[string]Type{
+				"foo": String,
+				"bar": Number,
+				"baz": Bool,
+			}}, map[string]Value{
+				"foo": NewValue(String, "hello"),
+				"bar": NewValue(Number, big.NewFloat(123)),
+				"baz": NewValue(Bool, true),
+			})}),
+		},
 		"set": {
 			in:       NewValue(Set{ElementType: String}, []Value{NewValue(String, "hello")}),
+			as:       slicePointer([]Value{}),
+			expected: slicePointer([]Value{NewValue(String, "hello")}),
+		},
+		"set-dynamic": {
+			in:       NewValue(Set{ElementType: DynamicPseudoType}, []Value{NewValue(String, "hello")}),
 			as:       slicePointer([]Value{}),
 			expected: slicePointer([]Value{NewValue(String, "hello")}),
 		},
@@ -205,6 +240,23 @@ func TestValueAs(t *testing.T) {
 				"foo": String,
 				"bar": Number,
 				"baz": Bool,
+			}}, map[string]Value{
+				"foo": NewValue(String, "hello"),
+				"bar": NewValue(Number, big.NewFloat(123)),
+				"baz": NewValue(Bool, true),
+			}),
+			as: mapPointer(map[string]Value{}),
+			expected: mapPointer(map[string]Value{
+				"foo": NewValue(String, "hello"),
+				"bar": NewValue(Number, big.NewFloat(123)),
+				"baz": NewValue(Bool, true),
+			}),
+		},
+		"object-dynamic": {
+			in: NewValue(Object{AttributeTypes: map[string]Type{
+				"foo": DynamicPseudoType,
+				"bar": DynamicPseudoType,
+				"baz": DynamicPseudoType,
 			}}, map[string]Value{
 				"foo": NewValue(String, "hello"),
 				"bar": NewValue(Number, big.NewFloat(123)),
@@ -311,6 +363,28 @@ func TestValueAs(t *testing.T) {
 				NewValue(Bool, true),
 			})),
 			expected: slicePointerPointer(nil),
+		},
+
+		"object-list-dynamic": {
+			in: NewValue(Object{
+				AttributeTypes: map[string]Type{
+					"result": List{ElementType: DynamicPseudoType},
+				},
+			}, map[string]Value{
+				"result": NewValue(List{ElementType: Object{
+					AttributeTypes: map[string]Type{
+						"testcol": String,
+					},
+				}}, []Value{}),
+			}),
+			as: mapPointer(map[string]Value{}),
+			expected: mapPointer(map[string]Value{
+				"result": NewValue(List{ElementType: Object{
+					AttributeTypes: map[string]Type{
+						"testcol": String,
+					},
+				}}, []Value{}),
+			}),
 		},
 	}
 

--- a/tftypes/value_tuple_test.go
+++ b/tftypes/value_tuple_test.go
@@ -1,0 +1,152 @@
+package tftypes
+
+import (
+	"math/big"
+	"regexp"
+	"testing"
+)
+
+func Test_newValue_tuple(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		typ      Type
+		val      interface{}
+		err      *regexp.Regexp
+		expected Value
+	}
+	tests := map[string]testCase{
+		"normal": {
+			typ: Tuple{ElementTypes: []Type{
+				String,
+				Number,
+				Bool,
+			}},
+			val: []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, 123),
+				NewValue(Bool, true),
+			},
+			expected: Value{
+				typ: Tuple{ElementTypes: []Type{
+					String,
+					Number,
+					Bool,
+				}},
+				value: []Value{
+					{
+						typ:   String,
+						value: "hello",
+					},
+					{
+						typ:   Number,
+						value: big.NewFloat(123),
+					},
+					{
+						typ:   Bool,
+						value: true,
+					},
+				},
+			},
+			err: nil,
+		},
+		"missing-element": {
+			typ: Tuple{
+				ElementTypes: []Type{
+					String,
+					Number,
+					Bool,
+				},
+			},
+			val: []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, 123),
+			},
+			err: regexp.MustCompile(`can't create a tftypes.Value with 2 elements, type tftypes.Tuple\[tftypes.String, tftypes.Number, tftypes.Bool\] requires 3 elements`),
+		},
+		"extra-element": {
+			typ: Tuple{
+				ElementTypes: []Type{
+					String,
+					Number,
+					Bool,
+				},
+			},
+			val: []Value{
+				NewValue(String, "foo"),
+				NewValue(Number, 123),
+				NewValue(Bool, false),
+				NewValue(Bool, true),
+			},
+			err: regexp.MustCompile(`can't create a tftypes.Value with 4 elements, type tftypes.Tuple\[tftypes.String, tftypes.Number, tftypes.Bool\] requires 3 elements`),
+		},
+		"element-wrong-type": {
+			typ: Tuple{
+				ElementTypes: []Type{
+					String,
+					Number,
+					Bool,
+				},
+			},
+			val: []Value{
+				NewValue(String, "foo"),
+				NewValue(Number, 123),
+				NewValue(String, "false"),
+			},
+			err: regexp.MustCompile(`ElementKeyInt\(2\): can't use tftypes.String as tftypes.Bool`),
+		},
+		"dynamic-element": {
+			typ: Tuple{
+				ElementTypes: []Type{
+					String,
+					Number,
+					DynamicPseudoType,
+				},
+			},
+			val: []Value{
+				NewValue(String, "foo"),
+				NewValue(Number, 123),
+				NewValue(String, "false"),
+			},
+			expected: Value{
+				typ: Tuple{ElementTypes: []Type{
+					String,
+					Number,
+					DynamicPseudoType,
+				}},
+				value: []Value{
+					{
+						typ:   String,
+						value: "foo",
+					},
+					{
+						typ:   Number,
+						value: big.NewFloat(123),
+					},
+					{
+						typ:   String,
+						value: "false",
+					},
+				},
+			},
+			err: nil,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := newValue(test.typ, test.val)
+			if err == nil && test.err != nil {
+				t.Errorf("Expected error to match %q, got nil", test.err)
+			} else if err != nil && test.err == nil {
+				t.Errorf("Expected error to be nil, got %q", err)
+			} else if err != nil && test.err != nil && !test.err.MatchString(err.Error()) {
+				t.Errorf("Expected error to match %q, got %q", test.err, err.Error())
+			}
+			if !res.Equal(test.expected) {
+				t.Errorf("Expected value to be %s, got %s", test.expected, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix the checks that NewValue runs to ensure that a value can be used
with a Type to properly handle DynamicPseudoTypes nested in complex
types. Builds on and supersedes #76.

Should we make this part of the behavior for `.Is`? My gut says "no",
because `Is` is supposed to be about checking whether a type is
semantically similar, not that it can be used as another type. Maybe we
want a `Fulfills` method, similar to Is, that does this? I don't know
that this behavior needs to be exported, though...

Fixes a bug in #74 that would panic for complex types containing
DynamicPseudoTypes.