### PR TITLE
Update GPG usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,9 @@ workflows:
                 - main
           type: approval
       - "docker-go115 release":
+          context:
+            - releases-gpg-private-signing-key
+            - releases-gpg-public-signing-key
           filters:
             branches:
               only:

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -22,9 +22,8 @@ function init {
   START_DIR=`pwd`
 
   if [ "$CI" = true ] ; then
-    GPG_KEY_ID=C6DC8F8C8E78B36A
-    gpg --import <(echo -e "${GPG_PUBLIC_KEY}")
-    gpg --import <(echo -e "${GPG_PRIVATE_KEY}")
+    gpg --batch --import <(echo -e "${RELEASES_GPG_PUB_KEY}")
+    gpg --batch --import <(echo -e "${RELEASES_GPG_PRIV_KEY}")
     git config --global user.email hashibot-feedback+tf-sdk-circleci@hashicorp.com
     git config --global user.name "Terraform SDK CircleCI"
   fi
@@ -62,8 +61,11 @@ function commitChanges {
   git add CHANGELOG.md
 
   if [ "$CI" = true ] ; then
-      git commit --gpg-sign="${GPG_KEY_ID}" -m "v${TARGET_VERSION} [skip ci]"
-      git tag -a -m "v${TARGET_VERSION}" -s -u "${GPG_KEY_ID}" "v${TARGET_VERSION}"
+      # load GPG passphrase into gpg-agent for reuse when git calls gpg
+      gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${RELEASES_GPG_PASSPHRASE}" <(echo)
+
+      git commit --gpg-sign="${RELEASES_GPG_KEY_ID}" -m "v${TARGET_VERSION} [skip ci]"
+      git tag -a -m "v${TARGET_VERSION}" -s -u "${RELEASES_GPG_KEY_ID}" "v${TARGET_VERSION}"
   else
       git commit -m "v${TARGET_VERSION} [skip ci]"
       git tag -a -m "v${TARGET_VERSION}" -s "v${TARGET_VERSION}"


### PR DESCRIPTION
As part of rotating the GPG key used for signing products, we are also moving the GPG bits into a dedicated CircleCI context.  This PR renames the GPG env vars to match those from the new context and applies the context to the job that uses the key.