### PR TITLE
Fix panic for Value.As(**big.Float).

### DIFF
--- a/.changelog/85.txt
+++ b/.changelog/85.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed a panic when calling `tftypes.Value.As` and passing a pointer to an uninstantiated *big.Float.
+```

--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -432,6 +432,9 @@ func (val Value) As(dst interface{}) error {
 			*target = nil
 			return nil
 		}
+		if *target == nil {
+			*target = big.NewFloat(0)
+		}
 		return val.As(*target)
 	case *bool:
 		if val.IsNull() {

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -93,6 +93,11 @@ func TestValueAs(t *testing.T) {
 			as:       numberPointerPointer(big.NewFloat(0)),
 			expected: numberPointerPointer(big.NewFloat(123)),
 		},
+		"uninstantiated-number-pointer": {
+			in:       NewValue(Number, big.NewFloat(123)),
+			as:       numberPointerPointer(nil),
+			expected: numberPointerPointer(big.NewFloat(123)),
+		},
 		"number-pointer-null": {
 			in:       NewValue(Number, nil),
 			as:       numberPointerPointer(big.NewFloat(123)),


### PR DESCRIPTION
*big.Float is a pointer type that will never really appear as anything
except a pointer. So when using code like this:

```go
var foo *big.Float
err := value.As(&foo)
```

the target of `As` is actually a **big.Float. But our code dereferences
it and calls `As` on the target of the pointer, but the target of the
pointer is actually a nil pointer.

This code fixes that by instantiating a new value for the pointer to
point to, setting the pointer to that, and then calling `As` on the new
value.