### PR TITLE
Don't panic when String() is called on nil Value{}

### DIFF
--- a/.changelog/86.txt
+++ b/.changelog/86.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed a panic when `.String()` is called on an empty `tftypes.Value`.
+```

--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -46,6 +46,10 @@ type Value struct {
 func (val Value) String() string {
 	typ := val.Type()
 
+	if typ == nil {
+		return "tftypes.Value<>"
+	}
+
 	// null and unknown values we use static strings for
 	if val.IsNull() {
 		return typ.String() + "<null>"

--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -47,7 +47,7 @@ func (val Value) String() string {
 	typ := val.Type()
 
 	if typ == nil {
-		return "tftypes.Value<>"
+		return "invalid typeless tftypes.Value<>"
 	}
 
 	// null and unknown values we use static strings for

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -1536,3 +1536,160 @@ func TestValueWalkAttributePath(t *testing.T) {
 		})
 	}
 }
+
+func TestValueString(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		in       Value
+		expected string
+	}
+
+	tests := map[string]testCase{
+		"string": {
+			in:       NewValue(String, "hello"),
+			expected: "tftypes.String<\"hello\">",
+		},
+		"string-null": {
+			in:       NewValue(String, nil),
+			expected: "tftypes.String<null>",
+		},
+		"number": {
+			in:       NewValue(Number, big.NewFloat(123)),
+			expected: "tftypes.Number<\"123\">",
+		},
+		"number-null": {
+			in:       NewValue(Number, nil),
+			expected: "tftypes.Number<null>",
+		},
+		"bool": {
+			in:       NewValue(Bool, true),
+			expected: "tftypes.Bool<\"true\">",
+		},
+		"bool-null": {
+			in:       NewValue(Bool, nil),
+			expected: "tftypes.Bool<null>",
+		},
+		"map": {
+			in: NewValue(Map{AttributeType: String}, map[string]Value{
+				"hello": NewValue(String, "world"),
+			}),
+			expected: `tftypes.Map[tftypes.String]<"hello":tftypes.String<"world">>`,
+		},
+		"map-null": {
+			in:       NewValue(Map{AttributeType: String}, nil),
+			expected: "tftypes.Map[tftypes.String]<null>",
+		},
+		"list": {
+			in:       NewValue(List{ElementType: String}, []Value{NewValue(String, "hello")}),
+			expected: `tftypes.List[tftypes.String]<tftypes.String<"hello">>`,
+		},
+		"list-dynamic": {
+			in:       NewValue(List{ElementType: DynamicPseudoType}, []Value{NewValue(String, "hello")}),
+			expected: `tftypes.List[tftypes.DynamicPseudoType]<tftypes.String<"hello">>`,
+		},
+		"list-null": {
+			in:       NewValue(List{ElementType: String}, nil),
+			expected: "tftypes.List[tftypes.String]<null>",
+		},
+		"list-object": {
+			in: NewValue(List{ElementType: Object{AttributeTypes: map[string]Type{
+				"foo": String,
+				"bar": Number,
+				"baz": Bool,
+			}}}, []Value{NewValue(Object{AttributeTypes: map[string]Type{
+				"foo": String,
+				"bar": Number,
+				"baz": Bool,
+			}}, map[string]Value{
+				"foo": NewValue(String, "hello"),
+				"bar": NewValue(Number, big.NewFloat(123)),
+				"baz": NewValue(Bool, true),
+			})}),
+			expected: `tftypes.List[tftypes.Object["bar":tftypes.Number, "baz":tftypes.Bool, "foo":tftypes.String]]<tftypes.Object["bar":tftypes.Number, "baz":tftypes.Bool, "foo":tftypes.String]<"bar":tftypes.Number<"123">, "baz":tftypes.Bool<"true">, "foo":tftypes.String<"hello">>>`,
+		},
+		"set": {
+			in:       NewValue(Set{ElementType: String}, []Value{NewValue(String, "hello")}),
+			expected: `tftypes.Set[tftypes.String]<tftypes.String<"hello">>`,
+		},
+		"set-dynamic": {
+			in:       NewValue(Set{ElementType: DynamicPseudoType}, []Value{NewValue(String, "hello")}),
+			expected: `tftypes.Set[tftypes.DynamicPseudoType]<tftypes.String<"hello">>`,
+		},
+		"set-null": {
+			in:       NewValue(Set{ElementType: String}, nil),
+			expected: "tftypes.Set[tftypes.String]<null>",
+		},
+		"object": {
+			in: NewValue(Object{AttributeTypes: map[string]Type{
+				"foo": String,
+				"bar": Number,
+				"baz": Bool,
+			}}, map[string]Value{
+				"foo": NewValue(String, "hello"),
+				"bar": NewValue(Number, big.NewFloat(123)),
+				"baz": NewValue(Bool, true),
+			}),
+			expected: `tftypes.Object["bar":tftypes.Number, "baz":tftypes.Bool, "foo":tftypes.String]<"bar":tftypes.Number<"123">, "baz":tftypes.Bool<"true">, "foo":tftypes.String<"hello">>`,
+		},
+		"object-dynamic": {
+			in: NewValue(Object{AttributeTypes: map[string]Type{
+				"foo": DynamicPseudoType,
+				"bar": DynamicPseudoType,
+				"baz": DynamicPseudoType,
+			}}, map[string]Value{
+				"foo": NewValue(String, "hello"),
+				"bar": NewValue(Number, big.NewFloat(123)),
+				"baz": NewValue(Bool, true),
+			}),
+			expected: `tftypes.Object["bar":tftypes.DynamicPseudoType, "baz":tftypes.DynamicPseudoType, "foo":tftypes.DynamicPseudoType]<"bar":tftypes.Number<"123">, "baz":tftypes.Bool<"true">, "foo":tftypes.String<"hello">>`,
+		},
+		"object-null": {
+			in: NewValue(Object{AttributeTypes: map[string]Type{
+				"foo": String,
+				"bar": Number,
+				"baz": Bool,
+			}}, nil),
+			expected: `tftypes.Object["bar":tftypes.Number, "baz":tftypes.Bool, "foo":tftypes.String]<null>`,
+		},
+		"tuple": {
+			in: NewValue(Tuple{ElementTypes: []Type{
+				String, Number, Bool,
+			}}, []Value{
+				NewValue(String, "hello"),
+				NewValue(Number, big.NewFloat(123)),
+				NewValue(Bool, true),
+			}),
+			expected: `tftypes.Tuple[tftypes.String, tftypes.Number, tftypes.Bool]<tftypes.String<"hello">, tftypes.Number<"123">, tftypes.Bool<"true">>`,
+		},
+		"tuple-null": {
+			in: NewValue(Tuple{ElementTypes: []Type{
+				String, Number, Bool,
+			}}, nil),
+			expected: "tftypes.Tuple[tftypes.String, tftypes.Number, tftypes.Bool]<null>",
+		},
+		"object-list-dynamic": {
+			in: NewValue(Object{
+				AttributeTypes: map[string]Type{
+					"result": List{ElementType: DynamicPseudoType},
+				},
+			}, map[string]Value{
+				"result": NewValue(List{ElementType: Object{
+					AttributeTypes: map[string]Type{
+						"testcol": String,
+					},
+				}}, []Value{}),
+			}),
+			expected: `tftypes.Object["result":tftypes.List[tftypes.DynamicPseudoType]]<"result":tftypes.List[tftypes.Object["testcol":tftypes.String]]<>>`,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			str := test.in.String()
+			if diff := cmp.Diff(test.expected, str); diff != "" {
+				t.Errorf("Unexpected results (-wanted, +got): %s", diff)
+			}
+		})
+	}
+}

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -1547,7 +1547,7 @@ func TestValueString(t *testing.T) {
 	tests := map[string]testCase{
 		"nil": {
 			in:       Value{},
-			expected: "tftypes.Value<>",
+			expected: "invalid typeless tftypes.Value<>",
 		},
 		"string": {
 			in:       NewValue(String, "hello"),

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -1545,6 +1545,10 @@ func TestValueString(t *testing.T) {
 	}
 
 	tests := map[string]testCase{
+		"nil": {
+			in:       Value{},
+			expected: "",
+		},
 		"string": {
 			in:       NewValue(String, "hello"),
 			expected: "tftypes.String<\"hello\">",

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -1547,7 +1547,7 @@ func TestValueString(t *testing.T) {
 	tests := map[string]testCase{
 		"nil": {
 			in:       Value{},
-			expected: "",
+			expected: "tftypes.Value<>",
 		},
 		"string": {
 			in:       NewValue(String, "hello"),


### PR DESCRIPTION
While a `Value` without a `typ` will not be returned from `NewValue` except in case of error, `Value{}` is likely to appear in consumer code from time to time, e.g. in tests, as it is the nil value of the struct. 

This PR defines an arbitrary string representation for `Value{}`. The only non-trivial question here is what it should be.

Backwards-compatible because this was previously undefined behaviour.

### Bonus

This PR also adds lots of tests for `Value.String()`, which had little test coverage.