### PR TITLE
Better formatting for root AttributePaths.

### DIFF
--- a/.changelog/87.txt
+++ b/.changelog/87.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed AttributePaths pointing to the root of the value to be prefixed with `<root>:` instead of just with `:`.
+```

--- a/.changelog/87.txt
+++ b/.changelog/87.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Fixed AttributePaths pointing to the root of the value to be prefixed with `<root>:` instead of just with `:`.
+Fixed AttributePaths pointing to the root of the value to be omitted instead of prefixing the error with `: `.
 ```

--- a/tftypes/attribute_path_error.go
+++ b/tftypes/attribute_path_error.go
@@ -12,7 +12,13 @@ type AttributePathError struct {
 }
 
 func (a AttributePathError) Error() string {
-	return fmt.Sprintf("%s: %s", a.Path, a.err)
+	var path string
+	if len(a.Path.Steps()) > 0 {
+		path = a.Path.String()
+	} else {
+		path = "<root>"
+	}
+	return fmt.Sprintf("%s: %s", path, a.err)
 }
 
 func (a AttributePathError) Unwrap() error {

--- a/tftypes/attribute_path_error.go
+++ b/tftypes/attribute_path_error.go
@@ -14,7 +14,7 @@ type AttributePathError struct {
 func (a AttributePathError) Error() string {
 	var path string
 	if len(a.Path.Steps()) > 0 {
-		path = ":" + a.Path.String() + " "
+		path = a.Path.String() + ": "
 	}
 	return fmt.Sprintf("%s%s", path, a.err)
 }

--- a/tftypes/attribute_path_error.go
+++ b/tftypes/attribute_path_error.go
@@ -14,11 +14,9 @@ type AttributePathError struct {
 func (a AttributePathError) Error() string {
 	var path string
 	if len(a.Path.Steps()) > 0 {
-		path = a.Path.String()
-	} else {
-		path = "<root>"
+		path = ":" + a.Path.String() + " "
 	}
-	return fmt.Sprintf("%s: %s", path, a.err)
+	return fmt.Sprintf("%s%s", path, a.err)
 }
 
 func (a AttributePathError) Unwrap() error {


### PR DESCRIPTION
For empty AttributePaths (paths pointing to the root of the
type/whatever) don't prefix an empty colon, prefix it with `<root>:`.