### PR TITLE
Fix panic in tftypes.Value.Equal.

### DIFF
--- a/.changelog/90.txt
+++ b/.changelog/90.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed a panic when comparing the empty value of a tftypes.Value to a non-empty value.
+```

--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -204,8 +204,14 @@ func (val Value) ApplyTerraform5AttributePathStep(step AttributePathStep) (inter
 // considered equal if their types are considered equal and if they represent
 // data that is considered equal.
 func (val Value) Equal(o Value) bool {
-	if val.typ == nil && o.typ == nil && val.value == nil && o.value == nil {
+	if val.Type() == nil && o.Type() == nil && val.value == nil && o.value == nil {
 		return true
+	}
+	if val.Type() == nil {
+		return false
+	}
+	if o.Type() == nil {
+		return false
 	}
 	if !val.Type().Is(o.Type()) {
 		return false

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -1053,6 +1053,15 @@ func TestValueEqual(t *testing.T) {
 			val2:  NewValue(String, "hello"),
 			equal: false,
 		},
+		"empty": {
+			val1:  Value{},
+			val2:  Value{},
+			equal: true,
+		},
+		"emptyDiff": {
+			val1: Value{},
+			val2: NewValue(String, "hello"),
+		},
 	}
 	for name, test := range tests {
 		name, test := name, test


### PR DESCRIPTION
If a non-empty tftypes.Value was compared to the empty value of a
tftypes.Value, it would cause a panic. Add tests to show the issue and
fix it.