### PR TITLE
The Great Renaming of Map.AttributeType.

### DIFF
--- a/.changelog/105.txt
+++ b/.changelog/105.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+The `AttributeType` property of `tftypes.Map` has been renamed to `ElementType`.
+```

--- a/tfprotov5/schema.go
+++ b/tfprotov5/schema.go
@@ -29,7 +29,7 @@ const (
 	// SchemaNestedBlockNestingModeMap indicates that multiple instances of
 	// the nested block should be permitted, each with a single label, and
 	// that they should be represented in state and config values as a
-	// tftypes.Map, with an AttributeType of tftypes.Object. The labels on
+	// tftypes.Map, with an ElementType of tftypes.Object. The labels on
 	// the blocks will be used as the map keys. It is an error, therefore,
 	// to use the same label value on multiple block instances.
 	SchemaNestedBlockNestingModeMap SchemaNestedBlockNestingMode = 4

--- a/tfprotov6/schema.go
+++ b/tfprotov6/schema.go
@@ -29,7 +29,7 @@ const (
 	// SchemaNestedBlockNestingModeMap indicates that multiple instances of
 	// the nested block should be permitted, each with a single label, and
 	// that they should be represented in state and config values as a
-	// tftypes.Map, with an AttributeType of tftypes.Object. The labels on
+	// tftypes.Map, with an ElementType of tftypes.Object. The labels on
 	// the blocks will be used as the map keys. It is an error, therefore,
 	// to use the same label value on multiple block instances.
 	SchemaNestedBlockNestingModeMap SchemaNestedBlockNestingMode = 4
@@ -73,7 +73,7 @@ const (
 
 	// SchemaObjectNestingModeMap indicates that multiple instances of the
 	// nested type should be permitted, and that they should be appear in state
-	// and config values as a tftypes.Map, with an AttributeType of
+	// and config values as a tftypes.Map, with an ElementType of
 	// tftypes.Object.
 	SchemaObjectNestingModeMap SchemaObjectNestingMode = 4
 )

--- a/tftypes/list_test.go
+++ b/tftypes/list_test.go
@@ -224,7 +224,7 @@ func TestListUsableAs(t *testing.T) {
 		},
 		"list-string-map": {
 			list:     List{ElementType: String},
-			other:    Map{AttributeType: String},
+			other:    Map{ElementType: String},
 			expected: false,
 		},
 		"list-string-object": {

--- a/tftypes/map.go
+++ b/tftypes/map.go
@@ -8,7 +8,7 @@ import (
 // Map is a Terraform type representing an unordered collection of elements,
 // all of the same type, each identifiable with a unique string key.
 type Map struct {
-	AttributeType Type
+	ElementType Type
 
 	// used to make this type uncomparable
 	// see https://golang.org/ref/spec#Comparison_operators
@@ -17,26 +17,26 @@ type Map struct {
 }
 
 // Equal returns true if the two Maps are exactly equal. Unlike Is, passing in
-// a Map with no AttributeType will always return false.
+// a Map with no ElementType will always return false.
 func (m Map) Equal(o Type) bool {
 	v, ok := o.(Map)
 	if !ok {
 		return false
 	}
-	if v.AttributeType == nil || m.AttributeType == nil {
+	if v.ElementType == nil || m.ElementType == nil {
 		// when doing exact comparisons, we can't compare types that
 		// don't have element types set, so we just consider them not
 		// equal
 		return false
 	}
-	return m.AttributeType.Equal(v.AttributeType)
+	return m.ElementType.Equal(v.ElementType)
 }
 
 // UsableAs returns whether the two Maps are type compatible.
 //
 // If the other type is DynamicPseudoType, it will return true.
 // If the other type is not a Map, it will return false.
-// If the other Map does not have a type compatible AttributeType, it will
+// If the other Map does not have a type compatible ElementType, it will
 // return false.
 func (m Map) UsableAs(o Type) bool {
 	if o.Is(DynamicPseudoType) {
@@ -46,18 +46,18 @@ func (m Map) UsableAs(o Type) bool {
 	if !ok {
 		return false
 	}
-	return m.AttributeType.UsableAs(v.AttributeType)
+	return m.ElementType.UsableAs(v.ElementType)
 }
 
 // Is returns whether `t` is a Map type or not. It does not perform any
-// AttributeType checks.
+// ElementType checks.
 func (m Map) Is(t Type) bool {
 	_, ok := t.(Map)
 	return ok
 }
 
 func (m Map) String() string {
-	return "tftypes.Map[" + m.AttributeType.String() + "]"
+	return "tftypes.Map[" + m.ElementType.String() + "]"
 }
 
 func (m Map) private() {}
@@ -67,13 +67,13 @@ func (m Map) supportedGoTypes() []string {
 }
 
 // MarshalJSON returns a JSON representation of the full type signature of `m`,
-// including its AttributeType.
+// including its ElementType.
 //
 // Deprecated: this is not meant to be called by third-party code.
 func (m Map) MarshalJSON() ([]byte, error) {
-	attributeType, err := m.AttributeType.MarshalJSON()
+	attributeType, err := m.ElementType.MarshalJSON()
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling tftypes.Map's attribute type %T to JSON: %w", m.AttributeType, err)
+		return nil, fmt.Errorf("error marshaling tftypes.Map's attribute type %T to JSON: %w", m.ElementType, err)
 	}
 	return []byte(`["map",` + string(attributeType) + `]`), nil
 }
@@ -102,7 +102,7 @@ func valueFromMap(typ Type, in interface{}) (Value, error) {
 			}
 		}
 		return Value{
-			typ:   Map{AttributeType: typ},
+			typ:   Map{ElementType: typ},
 			value: value,
 		}, nil
 	default:

--- a/tftypes/map_test.go
+++ b/tftypes/map_test.go
@@ -12,22 +12,22 @@ func TestMapEqual(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"equal": {
-			m1:    Map{AttributeType: String},
-			m2:    Map{AttributeType: String},
+			m1:    Map{ElementType: String},
+			m2:    Map{ElementType: String},
 			equal: true,
 		},
 		"unequal": {
-			m1:    Map{AttributeType: String},
-			m2:    Map{AttributeType: Number},
+			m1:    Map{ElementType: String},
+			m2:    Map{ElementType: Number},
 			equal: false,
 		},
 		"equal-complex": {
-			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m1: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
 			}}},
-			m2: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m2: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
@@ -35,12 +35,12 @@ func TestMapEqual(t *testing.T) {
 			equal: true,
 		},
 		"unequal-complex": {
-			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m1: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
 			}}},
-			m2: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m2: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
@@ -49,17 +49,17 @@ func TestMapEqual(t *testing.T) {
 			equal: false,
 		},
 		"unequal-empty": {
-			m1:    Map{AttributeType: String},
+			m1:    Map{ElementType: String},
 			m2:    Map{},
 			equal: false,
 		},
 		"unequal-complex-empty": {
-			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m1: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
 			}}},
-			m2:    Map{AttributeType: Object{}},
+			m2:    Map{ElementType: Object{}},
 			equal: false,
 		},
 	}
@@ -90,22 +90,22 @@ func TestMapIs(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"equal": {
-			m1:    Map{AttributeType: String},
-			m2:    Map{AttributeType: String},
+			m1:    Map{ElementType: String},
+			m2:    Map{ElementType: String},
 			equal: true,
 		},
 		"different-attributetype": {
-			m1:    Map{AttributeType: String},
-			m2:    Map{AttributeType: Number},
+			m1:    Map{ElementType: String},
+			m2:    Map{ElementType: Number},
 			equal: true,
 		},
 		"equal-complex": {
-			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m1: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
 			}}},
-			m2: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m2: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
@@ -113,12 +113,12 @@ func TestMapIs(t *testing.T) {
 			equal: true,
 		},
 		"different-attributetype-complex": {
-			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m1: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
 			}}},
-			m2: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m2: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
@@ -127,21 +127,21 @@ func TestMapIs(t *testing.T) {
 			equal: true,
 		},
 		"equal-empty": {
-			m1:    Map{AttributeType: String},
+			m1:    Map{ElementType: String},
 			m2:    Map{},
 			equal: true,
 		},
 		"equal-complex-empty": {
-			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m1: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
 			}}},
-			m2:    Map{AttributeType: Object{}},
+			m2:    Map{ElementType: Object{}},
 			equal: true,
 		},
 		"equal-complex-nil": {
-			m1: Map{AttributeType: Object{AttributeTypes: map[string]Type{
+			m1: Map{ElementType: Object{AttributeTypes: map[string]Type{
 				"a": Number,
 				"b": String,
 				"c": Bool,
@@ -173,72 +173,72 @@ func TestMapUsableAs(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"map-map-string-map-string": {
-			m:        Map{AttributeType: Map{AttributeType: String}},
-			other:    Map{AttributeType: String},
+			m:        Map{ElementType: Map{ElementType: String}},
+			other:    Map{ElementType: String},
 			expected: false,
 		},
 		"map-map-string-map-map-string": {
-			m:        Map{AttributeType: Map{AttributeType: String}},
-			other:    Map{AttributeType: Map{AttributeType: String}},
+			m:        Map{ElementType: Map{ElementType: String}},
+			other:    Map{ElementType: Map{ElementType: String}},
 			expected: true,
 		},
 		"map-map-string-dpt": {
-			m:        Map{AttributeType: Map{AttributeType: String}},
+			m:        Map{ElementType: Map{ElementType: String}},
 			other:    DynamicPseudoType,
 			expected: true,
 		},
 		"map-map-string-map-dpt": {
-			m:        Map{AttributeType: Map{AttributeType: String}},
-			other:    Map{AttributeType: DynamicPseudoType},
+			m:        Map{ElementType: Map{ElementType: String}},
+			other:    Map{ElementType: DynamicPseudoType},
 			expected: true,
 		},
 		"map-map-string-map-map-dpt": {
-			m:        Map{AttributeType: Map{AttributeType: String}},
-			other:    Map{AttributeType: Map{AttributeType: DynamicPseudoType}},
+			m:        Map{ElementType: Map{ElementType: String}},
+			other:    Map{ElementType: Map{ElementType: DynamicPseudoType}},
 			expected: true,
 		},
 		"map-string-dpt": {
-			m:        Map{AttributeType: String},
+			m:        Map{ElementType: String},
 			other:    DynamicPseudoType,
 			expected: true,
 		},
 		"map-string-list-string": {
-			m:        Map{AttributeType: String},
+			m:        Map{ElementType: String},
 			other:    List{ElementType: String},
 			expected: false,
 		},
 		"map-string-map-bool": {
-			m:        Map{AttributeType: String},
-			other:    Map{AttributeType: Bool},
+			m:        Map{ElementType: String},
+			other:    Map{ElementType: Bool},
 			expected: false,
 		},
 		"map-string-map-dpt": {
-			m:        Map{AttributeType: String},
-			other:    Map{AttributeType: DynamicPseudoType},
+			m:        Map{ElementType: String},
+			other:    Map{ElementType: DynamicPseudoType},
 			expected: true,
 		},
 		"map-string-map-string": {
-			m:        Map{AttributeType: String},
-			other:    Map{AttributeType: String},
+			m:        Map{ElementType: String},
+			other:    Map{ElementType: String},
 			expected: true,
 		},
 		"map-string-object": {
-			m:        Map{AttributeType: String},
+			m:        Map{ElementType: String},
 			other:    Object{AttributeTypes: map[string]Type{"test": String}},
 			expected: false,
 		},
 		"map-string-primitive": {
-			m:        Map{AttributeType: String},
+			m:        Map{ElementType: String},
 			other:    String,
 			expected: false,
 		},
 		"map-string-set-string": {
-			m:        Map{AttributeType: String},
+			m:        Map{ElementType: String},
 			other:    Set{ElementType: String},
 			expected: false,
 		},
 		"map-string-tuple-string": {
-			m:        Map{AttributeType: String},
+			m:        Map{ElementType: String},
 			other:    Tuple{ElementTypes: []Type{String}},
 			expected: false,
 		},

--- a/tftypes/object.go
+++ b/tftypes/object.go
@@ -85,7 +85,7 @@ func (o Object) Equal(other Type) bool {
 // If the other type is not a Object, it will return false.
 // If the other Object does not have matching AttributeTypes length, it will
 // return false.
-// If the other Object does not have a type compatible AttributeType for every
+// If the other Object does not have a type compatible ElementType for every
 // nested attribute, it will return false.
 //
 // If the current type contains OptionalAttributes, it will panic.

--- a/tftypes/set_test.go
+++ b/tftypes/set_test.go
@@ -219,7 +219,7 @@ func TestSetUsableAs(t *testing.T) {
 		},
 		"set-string-map": {
 			set:      Set{ElementType: String},
-			other:    Map{AttributeType: String},
+			other:    Map{ElementType: String},
 			expected: false,
 		},
 		"set-string-object": {

--- a/tftypes/tuple_test.go
+++ b/tftypes/tuple_test.go
@@ -219,7 +219,7 @@ func TestTupleUsableAs(t *testing.T) {
 		},
 		"tuple-string-map": {
 			tuple:    Tuple{ElementTypes: []Type{String}},
-			other:    Map{AttributeType: String},
+			other:    Map{ElementType: String},
 			expected: false,
 		},
 		"tuple-string-object": {

--- a/tftypes/type.go
+++ b/tftypes/type.go
@@ -143,7 +143,7 @@ func (t *jsonType) UnmarshalJSON(buf []byte) error {
 				return err
 			}
 			t.t = Map{
-				AttributeType: ety.t,
+				ElementType: ety.t,
 			}
 		case "set":
 			var ety jsonType

--- a/tftypes/type_json_test.go
+++ b/tftypes/type_json_test.go
@@ -41,7 +41,7 @@ func TestTypeJSON(t *testing.T) {
 		},
 		"map-string": {
 			json: `["map","string"]`,
-			typ:  Map{AttributeType: String},
+			typ:  Map{ElementType: String},
 		},
 		"object-string_number_bool": {
 			json: `["object",{"foo":"string","bar":"number","baz":"bool"}]`,

--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -328,7 +328,7 @@ func newValue(t Type, val interface{}) (Value, error) {
 		}
 		return v, nil
 	case t.Is(Map{}):
-		v, err := valueFromMap(t.(Map).AttributeType, val)
+		v, err := valueFromMap(t.(Map).ElementType, val)
 		if err != nil {
 			return Value{}, err
 		}

--- a/tftypes/value_json.go
+++ b/tftypes/value_json.go
@@ -53,7 +53,7 @@ func jsonUnmarshal(buf []byte, typ Type, p *AttributePath) (Value, error) {
 		return jsonUnmarshalSet(buf, typ.(Set).ElementType, p)
 
 	case typ.Is(Map{}):
-		return jsonUnmarshalMap(buf, typ.(Map).AttributeType, p)
+		return jsonUnmarshalMap(buf, typ.(Map).ElementType, p)
 	case typ.Is(Tuple{}):
 		return jsonUnmarshalTuple(buf, typ.(Tuple).ElementTypes, p)
 	case typ.Is(Object{}):
@@ -368,7 +368,7 @@ func jsonUnmarshalMap(buf []byte, attrType Type, p *AttributePath) (Value, error
 	}
 
 	return NewValue(Map{
-		AttributeType: elTyp,
+		ElementType: elTyp,
 	}, vals), nil
 }
 

--- a/tftypes/value_json_test.go
+++ b/tftypes/value_json_test.go
@@ -172,31 +172,31 @@ func TestValueFromJSON(t *testing.T) {
 		// Maps
 		"map-empty": {
 			value: NewValue(Map{
-				AttributeType: Bool,
+				ElementType: Bool,
 			}, map[string]Value{}),
 			typ: Map{
-				AttributeType: Bool,
+				ElementType: Bool,
 			},
 			json: `{}`,
 		},
 		"map-of-bools": {
 			value: NewValue(Map{
-				AttributeType: Bool,
+				ElementType: Bool,
 			}, map[string]Value{
 				"yes": NewValue(Bool, true),
 				"no":  NewValue(Bool, false),
 			}),
 			typ: Map{
-				AttributeType: Bool,
+				ElementType: Bool,
 			},
 			json: `{"no":false,"yes":true}`,
 		},
 		"map-null": {
 			value: NewValue(Map{
-				AttributeType: Bool,
+				ElementType: Bool,
 			}, nil),
 			typ: Map{
-				AttributeType: Bool,
+				ElementType: Bool,
 			},
 			json: `null`,
 		},
@@ -314,7 +314,7 @@ func TestValueFromJSON(t *testing.T) {
 		},
 		"dynamic-map-of-bools": {
 			value: NewValue(Map{
-				AttributeType: Bool,
+				ElementType: Bool,
 			}, map[string]Value{
 				"true":  NewValue(Bool, true),
 				"false": NewValue(Bool, false),
@@ -324,13 +324,13 @@ func TestValueFromJSON(t *testing.T) {
 		},
 		"map-of-dynamic-bools": {
 			value: NewValue(Map{
-				AttributeType: Bool,
+				ElementType: Bool,
 			}, map[string]Value{
 				"true":  NewValue(Bool, true),
 				"false": NewValue(Bool, false),
 			}),
 			typ: Map{
-				AttributeType: DynamicPseudoType,
+				ElementType: DynamicPseudoType,
 			},
 			json: `{"true":{"value":true,"type":"bool"},"false":{"value":false,"type":"bool"}}`,
 		},

--- a/tftypes/value_map_test.go
+++ b/tftypes/value_map_test.go
@@ -15,13 +15,13 @@ func Test_newValue_map(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"normal": {
-			typ: Map{AttributeType: String},
+			typ: Map{ElementType: String},
 			val: map[string]Value{
 				"a": NewValue(String, "hello"),
 				"b": NewValue(String, "world"),
 			},
 			expected: Value{
-				typ: Map{AttributeType: String},
+				typ: Map{ElementType: String},
 				value: map[string]Value{
 					"a": {
 						typ:   String,
@@ -36,13 +36,13 @@ func Test_newValue_map(t *testing.T) {
 			err: nil,
 		},
 		"dynamic": {
-			typ: Map{AttributeType: DynamicPseudoType},
+			typ: Map{ElementType: DynamicPseudoType},
 			val: map[string]Value{
 				"a": NewValue(String, "hello"),
 				"b": NewValue(String, "world"),
 			},
 			expected: Value{
-				typ: Map{AttributeType: DynamicPseudoType},
+				typ: Map{ElementType: DynamicPseudoType},
 				value: map[string]Value{
 					"a": {
 						typ:   String,
@@ -57,7 +57,7 @@ func Test_newValue_map(t *testing.T) {
 			err: nil,
 		},
 		"dynamic-different-types": {
-			typ: Map{AttributeType: DynamicPseudoType},
+			typ: Map{ElementType: DynamicPseudoType},
 			val: map[string]Value{
 				"a": NewValue(String, "hello"),
 				"b": NewValue(Number, 123),
@@ -65,7 +65,7 @@ func Test_newValue_map(t *testing.T) {
 			err: regexp.MustCompile(`maps must only contain one type of element, saw tftypes.String and tftypes.Number`),
 		},
 		"wrong-type": {
-			typ: Map{AttributeType: String},
+			typ: Map{ElementType: String},
 			val: map[string]Value{
 				"a": NewValue(String, "foo"),
 				"b": NewValue(Number, 123),

--- a/tftypes/value_msgpack.go
+++ b/tftypes/value_msgpack.go
@@ -122,7 +122,7 @@ func msgpackUnmarshal(dec *msgpack.Decoder, typ Type, path *AttributePath) (Valu
 	case typ.Is(Set{}):
 		return msgpackUnmarshalSet(dec, typ.(Set).ElementType, path)
 	case typ.Is(Map{}):
-		return msgpackUnmarshalMap(dec, typ.(Map).AttributeType, path)
+		return msgpackUnmarshalMap(dec, typ.(Map).ElementType, path)
 	case typ.Is(Tuple{}):
 		return msgpackUnmarshalTuple(dec, typ.(Tuple).ElementTypes, path)
 	case typ.Is(Object{}):
@@ -217,11 +217,11 @@ func msgpackUnmarshalMap(dec *msgpack.Decoder, typ Type, path *AttributePath) (V
 	switch {
 	case length < 0:
 		return NewValue(Map{
-			AttributeType: typ,
+			ElementType: typ,
 		}, nil), nil
 	case length == 0:
 		return NewValue(Map{
-			AttributeType: typ,
+			ElementType: typ,
 		}, map[string]Value{}), nil
 	}
 
@@ -256,7 +256,7 @@ func msgpackUnmarshalMap(dec *msgpack.Decoder, typ Type, path *AttributePath) (V
 	}
 
 	return NewValue(Map{
-		AttributeType: elTyp,
+		ElementType: elTyp,
 	}, vals), nil
 }
 
@@ -529,7 +529,7 @@ func marshalMsgPackMap(val Value, typ Type, p *AttributePath, enc *msgpack.Encod
 		if err != nil {
 			return p.NewErrorf("error encoding map key: %w", err)
 		}
-		err = marshalMsgPack(v, typ.(Map).AttributeType, p, enc)
+		err = marshalMsgPack(v, typ.(Map).ElementType, p, enc)
 		if err != nil {
 			return err
 		}

--- a/tftypes/value_msgpack_test.go
+++ b/tftypes/value_msgpack_test.go
@@ -112,7 +112,7 @@ func TestValueFromMsgPack(t *testing.T) {
 		"dynamic-map": {
 			hex: "92c4105b226d6170222c22737472696e67225d81a568656c6c6fa568656c6c6f",
 			value: NewValue(Map{
-				AttributeType: String,
+				ElementType: String,
 			}, map[string]Value{
 				"hello": NewValue(String, "hello"),
 			}),
@@ -248,45 +248,45 @@ func TestValueFromMsgPack(t *testing.T) {
 		"map-dynamic": {
 			hex: "81a86772656574696e6792c40822737472696e6722a568656c6c6f",
 			value: NewValue(Map{
-				AttributeType: String,
+				ElementType: String,
 			}, map[string]Value{
 				"greeting": NewValue(String, "hello"),
 			}),
-			typ: Map{AttributeType: DynamicPseudoType},
+			typ: Map{ElementType: DynamicPseudoType},
 		},
 		"map-string-hello": {
 			hex: "81a86772656574696e67a568656c6c6f",
 			value: NewValue(Map{
-				AttributeType: String,
+				ElementType: String,
 			}, map[string]Value{
 				"greeting": NewValue(String, "hello"),
 			}),
-			typ: Map{AttributeType: String},
+			typ: Map{ElementType: String},
 		},
 		"map-string-unknown": {
 			hex: "81a86772656574696e67d40000",
 			value: NewValue(Map{
-				AttributeType: String,
+				ElementType: String,
 			}, map[string]Value{
 				"greeting": NewValue(String, UnknownValue),
 			}),
-			typ: Map{AttributeType: String},
+			typ: Map{ElementType: String},
 		},
 		"map-string-null": {
 			hex: "81a86772656574696e67c0",
 			value: NewValue(Map{
-				AttributeType: String,
+				ElementType: String,
 			}, map[string]Value{
 				"greeting": NewValue(String, nil),
 			}),
-			typ: Map{AttributeType: String},
+			typ: Map{ElementType: String},
 		},
 		"map-string-empty": {
 			hex: "80",
 			value: NewValue(Map{
-				AttributeType: String,
+				ElementType: String,
 			}, map[string]Value{}),
-			typ: Map{AttributeType: String},
+			typ: Map{ElementType: String},
 		},
 		"tuple-dynamic": {
 			hex: "9292c40822737472696e6722a568656c6c6f92c40822737472696e6722a5776f726c64",

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -144,7 +144,7 @@ func TestValueAs(t *testing.T) {
 			expected: boolPointerPointer(boolPointer(true)),
 		},
 		"map": {
-			in: NewValue(Map{AttributeType: String}, map[string]Value{
+			in: NewValue(Map{ElementType: String}, map[string]Value{
 				"hello": NewValue(String, "world"),
 			}),
 			as: mapPointer(map[string]Value{}),
@@ -153,14 +153,14 @@ func TestValueAs(t *testing.T) {
 			}),
 		},
 		"map-null": {
-			in: NewValue(Map{AttributeType: String}, nil),
+			in: NewValue(Map{ElementType: String}, nil),
 			as: mapPointer(map[string]Value{
 				"a": NewValue(String, "this should be removed"),
 			}),
 			expected: mapPointer(map[string]Value{}),
 		},
 		"map-pointer": {
-			in: NewValue(Map{AttributeType: String}, map[string]Value{
+			in: NewValue(Map{ElementType: String}, map[string]Value{
 				"hello": NewValue(String, "world"),
 			}),
 			as: mapPointerPointer(mapPointer(map[string]Value{})),
@@ -169,14 +169,14 @@ func TestValueAs(t *testing.T) {
 			})),
 		},
 		"map-pointer-null": {
-			in: NewValue(Map{AttributeType: String}, nil),
+			in: NewValue(Map{ElementType: String}, nil),
 			as: mapPointerPointer(mapPointer(map[string]Value{
 				"a": NewValue(String, "this should be removed"),
 			})),
 			expected: mapPointerPointer(nil),
 		},
 		"uninstantiated-map-pointer": {
-			in: NewValue(Map{AttributeType: String}, map[string]Value{
+			in: NewValue(Map{ElementType: String}, map[string]Value{
 				"hello": NewValue(String, "world"),
 			}),
 			as: mapPointerPointer(nil),
@@ -506,17 +506,17 @@ func TestValueIsKnown(t *testing.T) {
 			fullyKnown: false,
 		},
 		"map-string-known": {
-			value:      NewValue(Map{AttributeType: String}, map[string]Value{"foo": NewValue(String, "hello")}),
+			value:      NewValue(Map{ElementType: String}, map[string]Value{"foo": NewValue(String, "hello")}),
 			known:      true,
 			fullyKnown: true,
 		},
 		"map-string-partially-known": {
-			value:      NewValue(Map{AttributeType: String}, map[string]Value{"foo": NewValue(String, UnknownValue)}),
+			value:      NewValue(Map{ElementType: String}, map[string]Value{"foo": NewValue(String, UnknownValue)}),
 			known:      true,
 			fullyKnown: false,
 		},
 		"map-string-unknown": {
-			value:      NewValue(Map{AttributeType: String}, UnknownValue),
+			value:      NewValue(Map{ElementType: String}, UnknownValue),
 			known:      false,
 			fullyKnown: false,
 		},
@@ -588,29 +588,29 @@ func TestValueIsKnown(t *testing.T) {
 			value: NewValue(Object{AttributeTypes: map[string]Type{
 				"foo": Tuple{ElementTypes: []Type{
 					String, Bool, List{ElementType: Map{
-						AttributeType: String,
+						ElementType: String,
 					}},
 				}},
 			}}, map[string]Value{
 				"foo": NewValue(Tuple{ElementTypes: []Type{
 					String, Bool, List{ElementType: Map{
-						AttributeType: String,
+						ElementType: String,
 					}},
 				}}, []Value{
 					NewValue(String, "hello"),
 					NewValue(Bool, false),
 					NewValue(List{ElementType: Map{
-						AttributeType: String,
+						ElementType: String,
 					}}, []Value{
 						NewValue(Map{
-							AttributeType: String,
+							ElementType: String,
 						}, map[string]Value{
 							"red":    NewValue(String, "orange"),
 							"yellow": NewValue(String, "green"),
 							"blue":   NewValue(String, nil),
 						}),
 						NewValue(Map{
-							AttributeType: String,
+							ElementType: String,
 						}, map[string]Value{
 							"a": NewValue(String, "apple"),
 							"b": NewValue(String, "banana"),
@@ -626,29 +626,29 @@ func TestValueIsKnown(t *testing.T) {
 			value: NewValue(Object{AttributeTypes: map[string]Type{
 				"foo": Tuple{ElementTypes: []Type{
 					String, Bool, List{ElementType: Map{
-						AttributeType: String,
+						ElementType: String,
 					}},
 				}},
 			}}, map[string]Value{
 				"foo": NewValue(Tuple{ElementTypes: []Type{
 					String, Bool, List{ElementType: Map{
-						AttributeType: String,
+						ElementType: String,
 					}},
 				}}, []Value{
 					NewValue(String, "hello"),
 					NewValue(Bool, false),
 					NewValue(List{ElementType: Map{
-						AttributeType: String,
+						ElementType: String,
 					}}, []Value{
 						NewValue(Map{
-							AttributeType: String,
+							ElementType: String,
 						}, map[string]Value{
 							"red":    NewValue(String, "orange"),
 							"yellow": NewValue(String, "green"),
 							"blue":   NewValue(String, nil),
 						}),
 						NewValue(Map{
-							AttributeType: String,
+							ElementType: String,
 						}, map[string]Value{
 							"a": NewValue(String, "apple"),
 							"b": NewValue(String, UnknownValue),
@@ -673,7 +673,7 @@ func TestValueIsKnown(t *testing.T) {
 			fullyKnown: true,
 		},
 		"map-null": {
-			value:      NewValue(Map{AttributeType: String}, nil),
+			value:      NewValue(Map{ElementType: String}, nil),
 			known:      true,
 			fullyKnown: true,
 		},
@@ -916,12 +916,12 @@ func TestValueEqual(t *testing.T) {
 			equal: false,
 		},
 		"mapEqual": {
-			val1: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val1: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(3)),
 			}),
-			val2: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val2: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(3)),
@@ -929,24 +929,24 @@ func TestValueEqual(t *testing.T) {
 			equal: true,
 		},
 		"mapDiffLength": {
-			val1: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val1: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(3)),
 			}),
-			val2: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val2: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"three": NewValue(Number, big.NewFloat(3)),
 			}),
 			equal: false,
 		},
 		"mapDiffValue": {
-			val1: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val1: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(3)),
 			}),
-			val2: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val2: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(4)),
@@ -954,12 +954,12 @@ func TestValueEqual(t *testing.T) {
 			equal: false,
 		},
 		"mapDiffKeys": {
-			val1: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val1: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(3)),
 			}),
-			val2: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val2: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":  NewValue(Number, big.NewFloat(1)),
 				"two":  NewValue(Number, big.NewFloat(2)),
 				"four": NewValue(Number, big.NewFloat(3)),
@@ -1410,7 +1410,7 @@ func TestValueApplyTerraform5AttributePathStep(t *testing.T) {
 			err:  ErrInvalidStep,
 		},
 		"map_attr": {
-			val: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(3)),
@@ -1419,7 +1419,7 @@ func TestValueApplyTerraform5AttributePathStep(t *testing.T) {
 			err:  ErrInvalidStep,
 		},
 		"map_eki": {
-			val: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(3)),
@@ -1428,7 +1428,7 @@ func TestValueApplyTerraform5AttributePathStep(t *testing.T) {
 			err:  ErrInvalidStep,
 		},
 		"map_eks": {
-			val: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(3)),
@@ -1437,7 +1437,7 @@ func TestValueApplyTerraform5AttributePathStep(t *testing.T) {
 			res:  NewValue(Number, big.NewFloat(2)),
 		},
 		"map_eks_invalid_key": {
-			val: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(3)),
@@ -1446,7 +1446,7 @@ func TestValueApplyTerraform5AttributePathStep(t *testing.T) {
 			err:  ErrInvalidStep,
 		},
 		"map_ekv": {
-			val: NewValue(Map{AttributeType: Number}, map[string]Value{
+			val: NewValue(Map{ElementType: Number}, map[string]Value{
 				"one":   NewValue(Number, big.NewFloat(1)),
 				"two":   NewValue(Number, big.NewFloat(2)),
 				"three": NewValue(Number, big.NewFloat(3)),
@@ -1499,7 +1499,7 @@ func TestValueWalkAttributePath(t *testing.T) {
 			expected: NewValue(String, "bar"),
 		},
 		"map": {
-			val: NewValue(Map{AttributeType: String}, map[string]Value{
+			val: NewValue(Map{ElementType: String}, map[string]Value{
 				"a": NewValue(String, "foo"),
 				"b": NewValue(String, "bar"),
 			}),
@@ -1621,13 +1621,13 @@ func TestValueString(t *testing.T) {
 			expected: "tftypes.DynamicPseudoType<null>",
 		},
 		"map": {
-			in: NewValue(Map{AttributeType: String}, map[string]Value{
+			in: NewValue(Map{ElementType: String}, map[string]Value{
 				"hello": NewValue(String, "world"),
 			}),
 			expected: `tftypes.Map[tftypes.String]<"hello":tftypes.String<"world">>`,
 		},
 		"map-null": {
-			in:       NewValue(Map{AttributeType: String}, nil),
+			in:       NewValue(Map{ElementType: String}, nil),
 			expected: "tftypes.Map[tftypes.String]<null>",
 		},
 		"list": {

--- a/tftypes/walk_test.go
+++ b/tftypes/walk_test.go
@@ -43,12 +43,12 @@ func TestWalk(t *testing.T) {
 			"set_empty":    Set{ElementType: Bool},
 			"tuple":        Tuple{ElementTypes: []Type{Bool}},
 			"tuple_empty":  Tuple{ElementTypes: []Type{}},
-			"map":          Map{AttributeType: Bool},
-			"map_empty":    Map{AttributeType: Bool},
+			"map":          Map{ElementType: Bool},
+			"map_empty":    Map{ElementType: Bool},
 			"object":       Object{AttributeTypes: map[string]Type{"true": Bool}},
 			"object_empty": Object{AttributeTypes: map[string]Type{}},
 			"null":         List{ElementType: String},
-			"unknown":      Map{AttributeType: Bool},
+			"unknown":      Map{ElementType: Bool},
 		},
 	}
 	listContent := []Value{NewValue(Bool, true)}
@@ -1038,12 +1038,12 @@ func TestTransform(t *testing.T) {
 			val: NewValue(
 				Object{
 					AttributeTypes: map[string]Type{
-						"map": Map{AttributeType: Bool},
+						"map": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
 					"map": NewValue(
-						Map{AttributeType: Bool},
+						Map{ElementType: Bool},
 						map[string]Value{
 							"true": NewValue(Bool, true),
 						},
@@ -1053,17 +1053,17 @@ func TestTransform(t *testing.T) {
 			f: func(path *AttributePath, v Value) (Value, error) {
 				target := NewAttributePath().WithAttributeName("map")
 				if path.Equal(target) {
-					return NewValue(Map{AttributeType: Bool}, nil), nil
+					return NewValue(Map{ElementType: Bool}, nil), nil
 				}
 				return v, nil
 			},
 			diffs: []ValueDiff{
 				{
 					Path: NewAttributePath().WithAttributeName("map"),
-					Value1: newValuePointer(Map{AttributeType: Bool}, map[string]Value{
+					Value1: newValuePointer(Map{ElementType: Bool}, map[string]Value{
 						"true": NewValue(Bool, true),
 					}),
-					Value2: newValuePointer(Map{AttributeType: Bool}, nil),
+					Value2: newValuePointer(Map{ElementType: Bool}, nil),
 				},
 				{
 					Path:   NewAttributePath().WithAttributeName("map").WithElementKeyString("true"),
@@ -1076,12 +1076,12 @@ func TestTransform(t *testing.T) {
 			val: NewValue(
 				Object{
 					AttributeTypes: map[string]Type{
-						"map": Map{AttributeType: Bool},
+						"map": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
 					"map": NewValue(
-						Map{AttributeType: Bool},
+						Map{ElementType: Bool},
 						map[string]Value{
 							"true": NewValue(Bool, true),
 						},
@@ -1091,17 +1091,17 @@ func TestTransform(t *testing.T) {
 			f: func(path *AttributePath, v Value) (Value, error) {
 				target := NewAttributePath().WithAttributeName("map")
 				if path.Equal(target) {
-					return NewValue(Map{AttributeType: Bool}, UnknownValue), nil
+					return NewValue(Map{ElementType: Bool}, UnknownValue), nil
 				}
 				return v, nil
 			},
 			diffs: []ValueDiff{
 				{
 					Path: NewAttributePath().WithAttributeName("map"),
-					Value1: newValuePointer(Map{AttributeType: Bool}, map[string]Value{
+					Value1: newValuePointer(Map{ElementType: Bool}, map[string]Value{
 						"true": NewValue(Bool, true),
 					}),
-					Value2: newValuePointer(Map{AttributeType: Bool}, UnknownValue),
+					Value2: newValuePointer(Map{ElementType: Bool}, UnknownValue),
 				},
 				{
 					Path:   NewAttributePath().WithAttributeName("map").WithElementKeyString("true"),
@@ -1114,12 +1114,12 @@ func TestTransform(t *testing.T) {
 			val: NewValue(
 				Object{
 					AttributeTypes: map[string]Type{
-						"map": Map{AttributeType: Bool},
+						"map": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
 					"map": NewValue(
-						Map{AttributeType: Bool},
+						Map{ElementType: Bool},
 						map[string]Value{
 							"true": NewValue(Bool, true),
 						},
@@ -1145,12 +1145,12 @@ func TestTransform(t *testing.T) {
 			val: NewValue(
 				Object{
 					AttributeTypes: map[string]Type{
-						"map": Map{AttributeType: Bool},
+						"map": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
 					"map": NewValue(
-						Map{AttributeType: Bool},
+						Map{ElementType: Bool},
 						map[string]Value{
 							"true": NewValue(Bool, true),
 						},
@@ -1176,12 +1176,12 @@ func TestTransform(t *testing.T) {
 			val: NewValue(
 				Object{
 					AttributeTypes: map[string]Type{
-						"map": Map{AttributeType: Bool},
+						"map": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
 					"map": NewValue(
-						Map{AttributeType: Bool},
+						Map{ElementType: Bool},
 						map[string]Value{
 							"true": NewValue(Bool, true),
 						},
@@ -1207,12 +1207,12 @@ func TestTransform(t *testing.T) {
 			val: NewValue(
 				Object{
 					AttributeTypes: map[string]Type{
-						"map": Map{AttributeType: Bool},
+						"map": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
 					"map": NewValue(
-						Map{AttributeType: Bool},
+						Map{ElementType: Bool},
 						map[string]Value{
 							"true": NewValue(Bool, true),
 						},
@@ -1222,7 +1222,7 @@ func TestTransform(t *testing.T) {
 			f: func(path *AttributePath, v Value) (Value, error) {
 				target := NewAttributePath().WithAttributeName("map")
 				if path.Equal(target) {
-					return NewValue(Map{AttributeType: Bool}, map[string]Value{
+					return NewValue(Map{ElementType: Bool}, map[string]Value{
 						"true":  NewValue(Bool, true),
 						"false": NewValue(Bool, false),
 					}), nil
@@ -1232,10 +1232,10 @@ func TestTransform(t *testing.T) {
 			diffs: []ValueDiff{
 				{
 					Path: NewAttributePath().WithAttributeName("map"),
-					Value1: newValuePointer(Map{AttributeType: Bool}, map[string]Value{
+					Value1: newValuePointer(Map{ElementType: Bool}, map[string]Value{
 						"true": NewValue(Bool, true),
 					}),
-					Value2: newValuePointer(Map{AttributeType: Bool}, map[string]Value{
+					Value2: newValuePointer(Map{ElementType: Bool}, map[string]Value{
 						"true":  NewValue(Bool, true),
 						"false": NewValue(Bool, false),
 					}),
@@ -1251,12 +1251,12 @@ func TestTransform(t *testing.T) {
 			val: NewValue(
 				Object{
 					AttributeTypes: map[string]Type{
-						"map": Map{AttributeType: Bool},
+						"map": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
 					"map": NewValue(
-						Map{AttributeType: Bool},
+						Map{ElementType: Bool},
 						map[string]Value{
 							"true": NewValue(Bool, true),
 						},
@@ -1266,17 +1266,17 @@ func TestTransform(t *testing.T) {
 			f: func(path *AttributePath, v Value) (Value, error) {
 				target := NewAttributePath().WithAttributeName("map")
 				if path.Equal(target) {
-					return NewValue(Map{AttributeType: Bool}, map[string]Value{}), nil
+					return NewValue(Map{ElementType: Bool}, map[string]Value{}), nil
 				}
 				return v, nil
 			},
 			diffs: []ValueDiff{
 				{
 					Path: NewAttributePath().WithAttributeName("map"),
-					Value1: newValuePointer(Map{AttributeType: Bool}, map[string]Value{
+					Value1: newValuePointer(Map{ElementType: Bool}, map[string]Value{
 						"true": NewValue(Bool, true),
 					}),
-					Value2: newValuePointer(Map{AttributeType: Bool}, map[string]Value{}),
+					Value2: newValuePointer(Map{ElementType: Bool}, map[string]Value{}),
 				},
 				{
 					Path:   NewAttributePath().WithAttributeName("map").WithElementKeyString("true"),
@@ -1289,12 +1289,12 @@ func TestTransform(t *testing.T) {
 			val: NewValue(
 				Object{
 					AttributeTypes: map[string]Type{
-						"map_empty": Map{AttributeType: Bool},
+						"map_empty": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
 					"map_empty": NewValue(
-						Map{AttributeType: Bool},
+						Map{ElementType: Bool},
 						map[string]Value{},
 					),
 				},
@@ -1302,7 +1302,7 @@ func TestTransform(t *testing.T) {
 			f: func(path *AttributePath, v Value) (Value, error) {
 				target := NewAttributePath().WithAttributeName("map_empty")
 				if path.Equal(target) {
-					return NewValue(Map{AttributeType: Bool}, map[string]Value{
+					return NewValue(Map{ElementType: Bool}, map[string]Value{
 						"foo": NewValue(Bool, true),
 					}), nil
 				}
@@ -1311,8 +1311,8 @@ func TestTransform(t *testing.T) {
 			diffs: []ValueDiff{
 				{
 					Path:   NewAttributePath().WithAttributeName("map_empty"),
-					Value1: newValuePointer(Map{AttributeType: Bool}, map[string]Value{}),
-					Value2: newValuePointer(Map{AttributeType: Bool}, map[string]Value{
+					Value1: newValuePointer(Map{ElementType: Bool}, map[string]Value{}),
+					Value2: newValuePointer(Map{ElementType: Bool}, map[string]Value{
 						"foo": NewValue(Bool, true),
 					}),
 				},
@@ -1547,25 +1547,25 @@ func TestTransform(t *testing.T) {
 			val: NewValue(
 				Object{
 					AttributeTypes: map[string]Type{
-						"unknown": Map{AttributeType: Bool},
+						"unknown": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
-					"unknown": NewValue(Map{AttributeType: Bool}, UnknownValue),
+					"unknown": NewValue(Map{ElementType: Bool}, UnknownValue),
 				},
 			),
 			f: func(path *AttributePath, v Value) (Value, error) {
 				target := NewAttributePath().WithAttributeName("unknown")
 				if path.Equal(target) {
-					return NewValue(Map{AttributeType: Bool}, nil), nil
+					return NewValue(Map{ElementType: Bool}, nil), nil
 				}
 				return v, nil
 			},
 			diffs: []ValueDiff{
 				{
 					Path:   NewAttributePath().WithAttributeName("unknown"),
-					Value1: newValuePointer(Map{AttributeType: Bool}, UnknownValue),
-					Value2: newValuePointer(Map{AttributeType: Bool}, nil),
+					Value1: newValuePointer(Map{ElementType: Bool}, UnknownValue),
+					Value2: newValuePointer(Map{ElementType: Bool}, nil),
 				},
 			},
 		},
@@ -1573,17 +1573,17 @@ func TestTransform(t *testing.T) {
 			val: NewValue(
 				Object{
 					AttributeTypes: map[string]Type{
-						"unknown": Map{AttributeType: Bool},
+						"unknown": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
-					"unknown": NewValue(Map{AttributeType: Bool}, UnknownValue),
+					"unknown": NewValue(Map{ElementType: Bool}, UnknownValue),
 				},
 			),
 			f: func(path *AttributePath, v Value) (Value, error) {
 				target := NewAttributePath().WithAttributeName("unknown")
 				if path.Equal(target) {
-					return NewValue(Map{AttributeType: Bool}, map[string]Value{
+					return NewValue(Map{ElementType: Bool}, map[string]Value{
 						"testing": NewValue(Bool, true),
 					}), nil
 				}
@@ -1592,8 +1592,8 @@ func TestTransform(t *testing.T) {
 			diffs: []ValueDiff{
 				{
 					Path:   NewAttributePath().WithAttributeName("unknown"),
-					Value1: newValuePointer(Map{AttributeType: Bool}, UnknownValue),
-					Value2: newValuePointer(Map{AttributeType: Bool}, map[string]Value{
+					Value1: newValuePointer(Map{ElementType: Bool}, UnknownValue),
+					Value2: newValuePointer(Map{ElementType: Bool}, map[string]Value{
 						"testing": NewValue(Bool, true),
 					}),
 				},
@@ -1609,12 +1609,12 @@ func TestTransform(t *testing.T) {
 				Object{
 					AttributeTypes: map[string]Type{
 						"null":    List{ElementType: String},
-						"unknown": Map{AttributeType: Bool},
+						"unknown": Map{ElementType: Bool},
 					},
 				},
 				map[string]Value{
 					"null":    NewValue(List{ElementType: String}, nil),
-					"unknown": NewValue(Map{AttributeType: Bool}, UnknownValue),
+					"unknown": NewValue(Map{ElementType: Bool}, UnknownValue),
 				},
 			),
 			f: func(_ *AttributePath, v Value) (Value, error) {
@@ -1629,8 +1629,8 @@ func TestTransform(t *testing.T) {
 			diffs: []ValueDiff{
 				{
 					Path:   NewAttributePath().WithAttributeName("unknown"),
-					Value1: newValuePointer(Map{AttributeType: Bool}, UnknownValue),
-					Value2: newValuePointer(Map{AttributeType: Bool}, nil),
+					Value1: newValuePointer(Map{ElementType: Bool}, UnknownValue),
+					Value2: newValuePointer(Map{ElementType: Bool}, nil),
 				},
 				{
 					Path:   NewAttributePath().WithAttributeName("null"),


### PR DESCRIPTION
Maps don't have an AttributeType in cty. They have an ElementType. In my
wayward youth of like a year ago, I decided this was A Mistake and in my
great and everlasting wisdom, I changed it to AttributeType. I think my
rationale was that elements are integer-indexed and attributes are
string-indexed.

My hubris has bitten me. This was a bad take. It makes diagnostics weird
(why am I using an ElementKeyString instead of an AttributeName if it's
an attribute?) and deviates with basically no value.

Worse, it's just... wrong. Attributes are structural in nature, like
properties in Go structs. They're defined by the provider developer.
Elements aren't structural, like Go maps. The type has no constraint on
what keys or how many keys can be used. Maps are obviously this second
thing.

This is the great renaming, that will break everything but will finally,
finally correct my blunder.