### PR TITLE
tftypes: Return null Number when NewValue receives (*big.Float)(nil)

### DIFF
--- a/.changelog/pending.txt
+++ b/.changelog/pending.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+tftypes: Return null `Number` when `NewValue` receives `(*big.Float)(nil)`
+```

--- a/tftypes/primitive.go
+++ b/tftypes/primitive.go
@@ -156,6 +156,12 @@ func valueFromBool(in interface{}) (Value, error) {
 func valueFromNumber(in interface{}) (Value, error) {
 	switch value := in.(type) {
 	case *big.Float:
+		if value == nil {
+			return Value{
+				typ:   Number,
+				value: nil,
+			}, nil
+		}
 		return Value{
 			typ:   Number,
 			value: value,

--- a/tftypes/value_number_test.go
+++ b/tftypes/value_number_test.go
@@ -89,6 +89,10 @@ func TestNewValue_number(t *testing.T) {
 			expected: Value{typ: Number, value: nil},
 			result:   NewValue(Number, nil),
 		},
+		"*big.Float-nil": {
+			expected: Value{typ: Number, value: nil},
+			result:   NewValue(Number, (*big.Float)(nil)),
+		},
 		"*big.Float": {
 			expected: Value{typ: Number, value: big.NewFloat(123)},
 			result:   NewValue(Number, big.NewFloat(123)),


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/89

This matches the consistency of other pointer types in the `valueFromNumber` function and can prevent unexpected panics.