### PR TITLE
Accept objects with DynamicPseudoType with null values

### DIFF
--- a/.changelog/116.txt
+++ b/.changelog/116.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed a panic when using DynamicPseudoType attributes in an object.
+```

--- a/tftypes/object.go
+++ b/tftypes/object.go
@@ -183,7 +183,7 @@ func valueFromObject(types map[string]Type, optionalAttrs map[string]struct{}, i
 				if v.Type() == nil {
 					return Value{}, NewAttributePath().WithAttributeName(k).NewErrorf("missing value type")
 				}
-				if v.Type().Is(DynamicPseudoType) && v.IsKnown() {
+				if v.Type().Is(DynamicPseudoType) && v.IsKnown() && !v.IsNull() {
 					return Value{}, NewAttributePath().WithAttributeName(k).NewErrorf("invalid value %s for %s", v, v.Type())
 				} else if !v.Type().Is(DynamicPseudoType) && !v.Type().UsableAs(typ) {
 					return Value{}, NewAttributePath().WithAttributeName(k).NewErrorf("can't use %s as %s", v.Type(), typ)

--- a/tftypes/value_msgpack_test.go
+++ b/tftypes/value_msgpack_test.go
@@ -447,6 +447,21 @@ func TestValueFromMsgPack(t *testing.T) {
 			value: NewValue(DynamicPseudoType, nil),
 			typ:   DynamicPseudoType,
 		},
+		"object-dynamic-null": {
+			hex: "81a161c0",
+			value: NewValue(Object{
+				AttributeTypes: map[string]Type{
+					"a": DynamicPseudoType,
+				},
+			}, map[string]Value{
+				"a": NewValue(DynamicPseudoType, nil),
+			}),
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"a": DynamicPseudoType,
+				},
+			},
+		},
 		"dynamic-unknown": {
 			hex:   "d40000",
 			value: NewValue(DynamicPseudoType, UnknownValue),


### PR DESCRIPTION
The value of a `DynamicPseudoType` should be allowed to be either unknown or null. The check for the latter was missing and this PR adds it. Let me know if there are any more tests needed.

Solves #115