### PR TITLE
Implement protocol data logging

### DIFF
--- a/.changelog/135.txt
+++ b/.changelog/135.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+tfprotov5/tf5server: Added support for writing protocol data to disk by setting `TF_LOG_SDK_PROTO_DATA_DIR` environment variable
+```
+
+```release-note:enhancement
+tfprotov6/tf6server: Added support for writing protocol data to disk by setting `TF_LOG_SDK_PROTO_DATA_DIR` environment variable
+```

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ func main() {
 }
 ```
 
+To write raw protocol MessagePack or JSON data to disk, set the `TF_LOG_SDK_PROTO_DATA_DIR` environment variable.
+
 ## Documentation
 
 Documentation is a work in progress. The GoDoc for packages, types, functions,

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ func main() {
 }
 ```
 
-To write raw protocol MessagePack or JSON data to disk, set the `TF_LOG_SDK_PROTO_DATA_DIR` environment variable.
+### Protocol Data
+
+To write raw protocol MessagePack or JSON data to disk, set the `TF_LOG_SDK_PROTO_DATA_DIR` environment variable. During Terraform execution, this directory will get populated with `{TIME}_{RPC}_{MESSAGE}_{FIELD}.{EXTENSION}` named files. Tooling such as [`jq`](https://stedolan.github.io/jq/) can be used to inspect the JSON data. Tooling such as [`fq`](https://github.com/wader/fq) or [`msgpack2json`](https://pkg.go.dev/github.com/nokute78/msgpack-microscope/cmd/msgpack2json) can be used to inspect the MessagePack data.
 
 ## Documentation
 

--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -1,0 +1,80 @@
+package logging
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+// DataSourceContext injects the data source type into logger contexts.
+func DataSourceContext(ctx context.Context, dataSource string) context.Context {
+	ctx = tfsdklog.With(ctx, KeyDataSourceType, dataSource)
+	ctx = tfsdklog.SubsystemWith(ctx, SubsystemProto, KeyDataSourceType, dataSource)
+	ctx = tflog.With(ctx, KeyDataSourceType, dataSource)
+
+	return ctx
+}
+
+// InitContext creates SDK and provider logger contexts.
+func InitContext(ctx context.Context, sdkOpts tfsdklog.Options, providerOpts tflog.Options) context.Context {
+	ctx = tfsdklog.NewRootSDKLogger(ctx, append(tfsdklog.Options{
+		tfsdklog.WithLevelFromEnv(EnvTfLogSdk),
+	}, sdkOpts...)...)
+	ctx = tfsdklog.NewSubsystem(ctx, SubsystemProto, append(tfsdklog.Options{
+		tfsdklog.WithLevelFromEnv(EnvTfLogSdkProto),
+	}, sdkOpts...)...)
+	ctx = tfsdklog.NewRootProviderLogger(ctx, providerOpts...)
+
+	return ctx
+}
+
+// ProtocolVersionContext injects the protocol version into logger contexts.
+func ProtocolVersionContext(ctx context.Context, protocolVersion string) context.Context {
+	ctx = tfsdklog.SubsystemWith(ctx, SubsystemProto, KeyProtocolVersion, protocolVersion)
+
+	return ctx
+}
+
+// ProviderAddressContext injects the provider address into logger contexts.
+func ProviderAddressContext(ctx context.Context, providerAddress string) context.Context {
+	ctx = tfsdklog.With(ctx, KeyProviderAddress, providerAddress)
+	ctx = tfsdklog.SubsystemWith(ctx, SubsystemProto, KeyProviderAddress, providerAddress)
+	ctx = tflog.With(ctx, KeyProviderAddress, providerAddress)
+
+	return ctx
+}
+
+// RequestIdContext injects a unique request ID into logger contexts.
+func RequestIdContext(ctx context.Context) context.Context {
+	reqID, err := uuid.GenerateUUID()
+
+	if err != nil {
+		reqID = "unable to assign request ID: " + err.Error()
+	}
+
+	ctx = tfsdklog.With(ctx, KeyRequestID, reqID)
+	ctx = tfsdklog.SubsystemWith(ctx, SubsystemProto, KeyRequestID, reqID)
+	ctx = tflog.With(ctx, KeyRequestID, reqID)
+
+	return ctx
+}
+
+// ResourceContext injects the resource type into logger contexts.
+func ResourceContext(ctx context.Context, resource string) context.Context {
+	ctx = tfsdklog.With(ctx, KeyResourceType, resource)
+	ctx = tfsdklog.SubsystemWith(ctx, SubsystemProto, KeyResourceType, resource)
+	ctx = tflog.With(ctx, KeyResourceType, resource)
+
+	return ctx
+}
+
+// RpcContext injects the RPC name into logger contexts.
+func RpcContext(ctx context.Context, rpc string) context.Context {
+	ctx = tfsdklog.With(ctx, KeyRPC, rpc)
+	ctx = tfsdklog.SubsystemWith(ctx, SubsystemProto, KeyRPC, rpc)
+	ctx = tflog.With(ctx, KeyRPC, rpc)
+
+	return ctx
+}

--- a/internal/logging/doc.go
+++ b/internal/logging/doc.go
@@ -1,0 +1,2 @@
+// Package logging contains shared environment variable and log functionality.
+package logging

--- a/internal/logging/environment_variables.go
+++ b/internal/logging/environment_variables.go
@@ -1,0 +1,22 @@
+package logging
+
+// Environment variables.
+const (
+	// EnvTfLogProvider is the prefix of the environment variable that sets the
+	// logging level of the root provider logger for the provider being served.
+	// The suffix is an underscore and the parsed provider name. For example,
+	// registry.terraform.io/hashicorp/example becomes TF_LOG_PROVIDER_EXAMPLE.
+	EnvTfLogProvider = "TF_LOG_PROVIDER"
+
+	// EnvTfLogSdk is an environment variable that sets the root logging level
+	// of SDK loggers.
+	EnvTfLogSdk = "TF_LOG_SDK"
+
+	// EnvTfLogSdkProto is an environment variable that sets the logging level
+	// of SDK protocol loggers. Infers root SDK logging level, if unset.
+	EnvTfLogSdkProto = "TF_LOG_SDK_PROTO"
+
+	// EnvTfLogSdkProtoDataDir is an environment variable that sets the
+	// directory to write raw protocol data files for debugging purposes.
+	EnvTfLogSdkProtoDataDir = "TF_LOG_SDK_PROTO_DATA_DIR"
+)

--- a/internal/logging/keys.go
+++ b/internal/logging/keys.go
@@ -21,6 +21,9 @@ const (
 	// The type of data source being operated on, such as "archive_file"
 	KeyDataSourceType = "tf_data_source_type"
 
+	// Path to protocol data file, such as "/tmp/example.json"
+	KeyProtocolDataFile = "tf_proto_data_file"
+
 	// The protocol version being used, as a string, such as "6"
 	KeyProtocolVersion = "tf_proto_version"
 )

--- a/internal/logging/keys.go
+++ b/internal/logging/keys.go
@@ -1,0 +1,26 @@
+package logging
+
+// Global logging keys attached to all requests.
+//
+// Practitioners or tooling reading logs may be depending on these keys, so be
+// conscious of that when changing them.
+const (
+	// A unique ID for the RPC request
+	KeyRequestID = "tf_req_id"
+
+	// The full address of the provider, such as
+	// registry.terraform.io/hashicorp/random
+	KeyProviderAddress = "tf_provider_addr"
+
+	// The RPC being run, such as "ApplyResourceChange"
+	KeyRPC = "tf_rpc"
+
+	// The type of resource being operated on, such as "random_pet"
+	KeyResourceType = "tf_resource_type"
+
+	// The type of data source being operated on, such as "archive_file"
+	KeyDataSourceType = "tf_data_source_type"
+
+	// The protocol version being used, as a string, such as "6"
+	KeyProtocolVersion = "tf_proto_version"
+)

--- a/internal/logging/protocol.go
+++ b/internal/logging/protocol.go
@@ -1,0 +1,22 @@
+package logging
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+const (
+	// SubsystemProto is the tfsdklog subsystem name for protocol logging.
+	SubsystemProto = "proto"
+)
+
+// ProtocolError emits a protocol subsystem log at ERROR level.
+func ProtocolError(ctx context.Context, msg string, args ...interface{}) {
+	tfsdklog.SubsystemError(ctx, SubsystemProto, msg, args)
+}
+
+// ProtocolTrace emits a protocol subsystem log at TRACE level.
+func ProtocolTrace(ctx context.Context, msg string, args ...interface{}) {
+	tfsdklog.SubsystemTrace(ctx, SubsystemProto, msg, args)
+}

--- a/internal/logging/protocol_data.go
+++ b/internal/logging/protocol_data.go
@@ -1,0 +1,107 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+const (
+	// fileExtEmpty is the file extension for empty data.
+	// Empty data may be expected, depending on the RPC.
+	fileExtEmpty = "empty"
+
+	// fileExtJson is the file extension for JSON data.
+	fileExtJson = "json"
+
+	// fileExtMsgpack is the file extension for MessagePack data.
+	fileExtMsgpack = "msgpack"
+)
+
+var protocolDataSkippedLog sync.Once
+
+// ProtocolData emits raw protocol data to a file, if given a directory.
+//
+// The directory must exist and be writable, prior to invoking this function.
+//
+// File names are in the format: {TIME}_{RPC}_{MESSAGE}_{FIELD}.{EXT}
+func ProtocolData(ctx context.Context, dataDir string, rpc string, message string, field string, data interface{}) {
+	if dataDir == "" {
+		// Write a log, only once, that explains how to enable this functionality.
+		protocolDataSkippedLog.Do(func() {
+			ProtocolTrace(ctx, "Skipping protocol data file writing because no data directory is set. "+
+				fmt.Sprintf("Use the %s environment variable to enable this functionality.", EnvTfLogSdkProtoDataDir))
+		})
+
+		return
+	}
+
+	var fileContents []byte
+	var fileExtension string
+
+	switch data := data.(type) {
+	case *tfprotov5.DynamicValue:
+		fileExtension, fileContents = protocolDataDynamicValue5(ctx, data)
+	case *tfprotov6.DynamicValue:
+		fileExtension, fileContents = protocolDataDynamicValue6(ctx, data)
+	default:
+		ProtocolError(ctx, fmt.Sprintf("Skipping unknown protocol data type: %T", data))
+		return
+	}
+
+	fileName := fmt.Sprintf("%d_%s_%s_%s.%s", time.Now().Unix(), rpc, message, field, fileExtension)
+	filePath := path.Join(dataDir, fileName)
+
+	ProtocolTrace(ctx, "Writing protocol data file", KeyProtocolDataFile, filePath)
+
+	err := os.WriteFile(filePath, fileContents, 0644)
+
+	if err != nil {
+		ProtocolError(ctx, fmt.Sprintf("Unable to write protocol data file: %s", err), KeyProtocolDataFile, filePath)
+		return
+	}
+
+	ProtocolTrace(ctx, "Wrote protocol data file", KeyProtocolDataFile, filePath)
+}
+
+func protocolDataDynamicValue5(ctx context.Context, value *tfprotov5.DynamicValue) (string, []byte) {
+	if value == nil {
+		return fileExtEmpty, nil
+	}
+
+	// (tfprotov5.DynamicValue).Unmarshal() prefers JSON first, so prefer to
+	// output JSON if found.
+	if len(value.JSON) > 0 {
+		return fileExtJson, value.JSON
+	}
+
+	if len(value.MsgPack) > 0 {
+		return fileExtMsgpack, value.MsgPack
+	}
+
+	return fileExtEmpty, nil
+}
+
+func protocolDataDynamicValue6(ctx context.Context, value *tfprotov6.DynamicValue) (string, []byte) {
+	if value == nil {
+		return fileExtEmpty, nil
+	}
+
+	// (tfprotov6.DynamicValue).Unmarshal() prefers JSON first, so prefer to
+	// output JSON if found.
+	if len(value.JSON) > 0 {
+		return fileExtJson, value.JSON
+	}
+
+	if len(value.MsgPack) > 0 {
+		return fileExtMsgpack, value.MsgPack
+	}
+
+	return fileExtEmpty, nil
+}

--- a/internal/logging/provider.go
+++ b/internal/logging/provider.go
@@ -1,0 +1,19 @@
+package logging
+
+import (
+	"log"
+	"strings"
+
+	tfaddr "github.com/hashicorp/terraform-registry-address"
+)
+
+func ProviderLoggerName(providerAddress string) string {
+	provider, err := tfaddr.ParseRawProviderSourceString(providerAddress)
+
+	if err != nil {
+		log.Printf("[ERROR] Error parsing provider name %q: %s", providerAddress, err)
+		return ""
+	}
+
+	return strings.ReplaceAll(provider.Type, "-", "_")
+}

--- a/internal/logging/provider_test.go
+++ b/internal/logging/provider_test.go
@@ -1,0 +1,39 @@
+package logging
+
+import "testing"
+
+func TestProviderLoggerName(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		providerAddress string
+		expected        string
+	}{
+		"unparseable": {
+			providerAddress: "example.com/test",
+			expected:        "",
+		},
+		"basic": {
+			providerAddress: "example.com/user/test",
+			expected:        "test",
+		},
+		"hyphenated": {
+			providerAddress: "example.com/user/test-test",
+			expected:        "test_test",
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ProviderLoggerName(testCase.providerAddress)
+
+			if testCase.expected != got {
+				t.Errorf("wanted: %q, got: %q", testCase.expected, got)
+			}
+		})
+	}
+}

--- a/tfprotov5/tf5server/server.go
+++ b/tfprotov5/tf5server/server.go
@@ -426,7 +426,7 @@ func New(name string, serve tfprotov5.ProviderServer, opts ...ServeOpt) tfplugin
 		useTFLogSink:    conf.useLoggingSink != nil,
 		testHandle:      conf.useLoggingSink,
 		protocolDataDir: os.Getenv(logging.EnvTfLogSdkProtoDataDir),
-		protocolVersion: "6",
+		protocolVersion: "5",
 	}
 }
 

--- a/tfprotov5/tf5server/server.go
+++ b/tfprotov5/tf5server/server.go
@@ -27,6 +27,30 @@ import (
 )
 
 const (
+	// protocolVersionMajor represents the major version number of the protocol
+	// being served. This is used during the plugin handshake to validate the
+	// server and client are compatible.
+	//
+	// In the future, it may be possible to include this information directly
+	// in the protocol buffers rather than recreating a constant here.
+	protocolVersionMajor uint = 5
+
+	// protocolVersionMinor represents the minor version number of the protocol
+	// being served. Backwards compatible additions are possible in the
+	// protocol definitions, which is when this may be increased. While it is
+	// not used in plugin negotiation, it can be helpful to include this value
+	// for debugging, such as in logs.
+	//
+	// In the future, it may be possible to include this information directly
+	// in the protocol buffers rather than recreating a constant here.
+	protocolVersionMinor uint = 2
+)
+
+// protocolVersion represents the combined major and minor version numbers of
+// the protocol being served.
+var protocolVersion string = fmt.Sprintf("%d.%d", protocolVersionMajor, protocolVersionMinor)
+
+const (
 	// envTfReattachProviders is the environment variable used by Terraform CLI
 	// to directly connect to already running provider processes, such as those
 	// being inspected by debugging processes. When connecting to providers in
@@ -207,7 +231,7 @@ func Serve(name string, serverFactory func() tfprotov5.ProviderServer, opts ...S
 
 	serveConfig := &plugin.ServeConfig{
 		HandshakeConfig: plugin.HandshakeConfig{
-			ProtocolVersion:  5,
+			ProtocolVersion:  protocolVersionMajor,
 			MagicCookieKey:   "TF_PLUGIN_MAGIC_COOKIE",
 			MagicCookieValue: "d602bf8f470bc67ca7faa0386276bbdd4330efaf76d1a219cb4d6991ca9872b2",
 		},
@@ -426,7 +450,7 @@ func New(name string, serve tfprotov5.ProviderServer, opts ...ServeOpt) tfplugin
 		useTFLogSink:    conf.useLoggingSink != nil,
 		testHandle:      conf.useLoggingSink,
 		protocolDataDir: os.Getenv(logging.EnvTfLogSdkProtoDataDir),
-		protocolVersion: "5",
+		protocolVersion: protocolVersion,
 	}
 }
 

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -344,6 +344,10 @@ type server struct {
 	testHandle   testing.T
 	name         string
 
+	// protocolDataDir is a directory to store raw protocol data files for
+	// debugging purposes.
+	protocolDataDir string
+
 	// protocolVersion is the protocol version for the server.
 	protocolVersion string
 }
@@ -423,13 +427,15 @@ func New(name string, serve tfprotov6.ProviderServer, opts ...ServeOpt) tfplugin
 		name:            name,
 		useTFLogSink:    conf.useLoggingSink != nil,
 		testHandle:      conf.useLoggingSink,
+		protocolDataDir: os.Getenv(logging.EnvTfLogSdkProtoDataDir),
 		protocolVersion: "6",
 	}
 }
 
 func (s *server) GetProviderSchema(ctx context.Context, req *tfplugin6.GetProviderSchema_Request) (*tfplugin6.GetProviderSchema_Response, error) {
+	rpc := "GetProviderSchema"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "GetProviderSchema")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
 	defer logging.ProtocolTrace(ctx, "Served request")
@@ -454,8 +460,9 @@ func (s *server) GetProviderSchema(ctx context.Context, req *tfplugin6.GetProvid
 }
 
 func (s *server) ConfigureProvider(ctx context.Context, req *tfplugin6.ConfigureProvider_Request) (*tfplugin6.ConfigureProvider_Response, error) {
+	rpc := "ConfigureProvider"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "ConfigureProvider")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
 	defer logging.ProtocolTrace(ctx, "Served request")
@@ -464,6 +471,7 @@ func (s *server) ConfigureProvider(ctx context.Context, req *tfplugin6.Configure
 		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "Config", r.Config)
 	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ConfigureProvider(ctx, r)
 	if err != nil {
@@ -480,8 +488,9 @@ func (s *server) ConfigureProvider(ctx context.Context, req *tfplugin6.Configure
 }
 
 func (s *server) ValidateProviderConfig(ctx context.Context, req *tfplugin6.ValidateProviderConfig_Request) (*tfplugin6.ValidateProviderConfig_Response, error) {
+	rpc := "ValidateProviderConfig"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "ValidateProviderConfig")
+	ctx = logging.RpcContext(ctx, rpc)
 	logging.ProtocolTrace(ctx, "Received request")
 	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.ValidateProviderConfigRequest(req)
@@ -489,6 +498,7 @@ func (s *server) ValidateProviderConfig(ctx context.Context, req *tfplugin6.Vali
 		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "Config", r.Config)
 	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ValidateProviderConfig(ctx, r)
 	if err != nil {
@@ -518,8 +528,9 @@ func (s *server) stop() {
 }
 
 func (s *server) Stop(ctx context.Context, req *tfplugin6.StopProvider_Request) (*tfplugin6.StopProvider_Response, error) {
+	rpc := "StopProvider"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "Stop")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
 	defer logging.ProtocolTrace(ctx, "Served request")
@@ -547,8 +558,9 @@ func (s *server) Stop(ctx context.Context, req *tfplugin6.StopProvider_Request) 
 }
 
 func (s *server) ValidateDataResourceConfig(ctx context.Context, req *tfplugin6.ValidateDataResourceConfig_Request) (*tfplugin6.ValidateDataResourceConfig_Response, error) {
+	rpc := "ValidateDataResourceConfig"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "ValidateDataResourceConfig")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = logging.DataSourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
@@ -558,6 +570,7 @@ func (s *server) ValidateDataResourceConfig(ctx context.Context, req *tfplugin6.
 		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "Config", r.Config)
 	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ValidateDataResourceConfig(ctx, r)
 	if err != nil {
@@ -574,8 +587,9 @@ func (s *server) ValidateDataResourceConfig(ctx context.Context, req *tfplugin6.
 }
 
 func (s *server) ReadDataSource(ctx context.Context, req *tfplugin6.ReadDataSource_Request) (*tfplugin6.ReadDataSource_Response, error) {
+	rpc := "ReadDataSource"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "ReadDataSource")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = logging.DataSourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
@@ -585,6 +599,8 @@ func (s *server) ReadDataSource(ctx context.Context, req *tfplugin6.ReadDataSour
 		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "Config", r.Config)
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "ProviderMeta", r.ProviderMeta)
 	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ReadDataSource(ctx, r)
 	if err != nil {
@@ -592,6 +608,7 @@ func (s *server) ReadDataSource(ctx context.Context, req *tfplugin6.ReadDataSour
 		return nil, err
 	}
 	logging.ProtocolTrace(ctx, "Called downstream")
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "State", resp.State)
 	ret, err := toproto.ReadDataSource_Response(resp)
 	if err != nil {
 		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
@@ -601,8 +618,9 @@ func (s *server) ReadDataSource(ctx context.Context, req *tfplugin6.ReadDataSour
 }
 
 func (s *server) ValidateResourceConfig(ctx context.Context, req *tfplugin6.ValidateResourceConfig_Request) (*tfplugin6.ValidateResourceConfig_Response, error) {
+	rpc := "ValidateResourceConfig"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "ValidateResourceConfig")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
@@ -612,6 +630,7 @@ func (s *server) ValidateResourceConfig(ctx context.Context, req *tfplugin6.Vali
 		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "Config", r.Config)
 	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ValidateResourceConfig(ctx, r)
 	if err != nil {
@@ -628,8 +647,9 @@ func (s *server) ValidateResourceConfig(ctx context.Context, req *tfplugin6.Vali
 }
 
 func (s *server) UpgradeResourceState(ctx context.Context, req *tfplugin6.UpgradeResourceState_Request) (*tfplugin6.UpgradeResourceState_Response, error) {
+	rpc := "UpgradeResourceState"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "UpgradeResourceState")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
@@ -646,6 +666,7 @@ func (s *server) UpgradeResourceState(ctx context.Context, req *tfplugin6.Upgrad
 		return nil, err
 	}
 	logging.ProtocolTrace(ctx, "Called downstream")
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "UpgradedState", resp.UpgradedState)
 	ret, err := toproto.UpgradeResourceState_Response(resp)
 	if err != nil {
 		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
@@ -655,8 +676,9 @@ func (s *server) UpgradeResourceState(ctx context.Context, req *tfplugin6.Upgrad
 }
 
 func (s *server) ReadResource(ctx context.Context, req *tfplugin6.ReadResource_Request) (*tfplugin6.ReadResource_Response, error) {
+	rpc := "ReadResource"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "ReadResource")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
@@ -666,6 +688,8 @@ func (s *server) ReadResource(ctx context.Context, req *tfplugin6.ReadResource_R
 		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "CurrentState", r.CurrentState)
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "ProviderMeta", r.ProviderMeta)
 	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ReadResource(ctx, r)
 	if err != nil {
@@ -673,6 +697,7 @@ func (s *server) ReadResource(ctx context.Context, req *tfplugin6.ReadResource_R
 		return nil, err
 	}
 	logging.ProtocolTrace(ctx, "Called downstream")
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "NewState", resp.NewState)
 	ret, err := toproto.ReadResource_Response(resp)
 	if err != nil {
 		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
@@ -682,8 +707,9 @@ func (s *server) ReadResource(ctx context.Context, req *tfplugin6.ReadResource_R
 }
 
 func (s *server) PlanResourceChange(ctx context.Context, req *tfplugin6.PlanResourceChange_Request) (*tfplugin6.PlanResourceChange_Response, error) {
+	rpc := "PlanResourceChange"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "PlanResourceChange")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
@@ -693,6 +719,10 @@ func (s *server) PlanResourceChange(ctx context.Context, req *tfplugin6.PlanReso
 		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "Config", r.Config)
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "PriorState", r.PriorState)
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "ProposedNewState", r.ProposedNewState)
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "ProviderMeta", r.ProviderMeta)
 	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.PlanResourceChange(ctx, r)
 	if err != nil {
@@ -700,6 +730,7 @@ func (s *server) PlanResourceChange(ctx context.Context, req *tfplugin6.PlanReso
 		return nil, err
 	}
 	logging.ProtocolTrace(ctx, "Called downstream")
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "PlannedState", resp.PlannedState)
 	ret, err := toproto.PlanResourceChange_Response(resp)
 	if err != nil {
 		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
@@ -709,8 +740,9 @@ func (s *server) PlanResourceChange(ctx context.Context, req *tfplugin6.PlanReso
 }
 
 func (s *server) ApplyResourceChange(ctx context.Context, req *tfplugin6.ApplyResourceChange_Request) (*tfplugin6.ApplyResourceChange_Response, error) {
+	rpc := "ApplyResourceChange"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "ApplyResourceChange")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
@@ -720,6 +752,10 @@ func (s *server) ApplyResourceChange(ctx context.Context, req *tfplugin6.ApplyRe
 		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "Config", r.Config)
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "PlannedState", r.PlannedState)
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "Config", r.Config)
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Request", "Config", r.Config)
 	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ApplyResourceChange(ctx, r)
 	if err != nil {
@@ -727,6 +763,7 @@ func (s *server) ApplyResourceChange(ctx context.Context, req *tfplugin6.ApplyRe
 		return nil, err
 	}
 	logging.ProtocolTrace(ctx, "Called downstream")
+	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "NewState", resp.NewState)
 	ret, err := toproto.ApplyResourceChange_Response(resp)
 	if err != nil {
 		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
@@ -736,8 +773,9 @@ func (s *server) ApplyResourceChange(ctx context.Context, req *tfplugin6.ApplyRe
 }
 
 func (s *server) ImportResourceState(ctx context.Context, req *tfplugin6.ImportResourceState_Request) (*tfplugin6.ImportResourceState_Response, error) {
+	rpc := "ImportResourceState"
 	ctx = s.loggingContext(ctx)
-	ctx = logging.RpcContext(ctx, "ImportResourceState")
+	ctx = logging.RpcContext(ctx, rpc)
 	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
 	logging.ProtocolTrace(ctx, "Received request")
@@ -754,6 +792,9 @@ func (s *server) ImportResourceState(ctx context.Context, req *tfplugin6.ImportR
 		return nil, err
 	}
 	logging.ProtocolTrace(ctx, "Called downstream")
+	for _, importedResource := range resp.ImportedResources {
+		logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response_ImportedResource", "State", importedResource.State)
+	}
 	ret, err := toproto.ImportResourceState_Response(resp)
 	if err != nil {
 		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -27,6 +27,30 @@ import (
 )
 
 const (
+	// protocolVersionMajor represents the major version number of the protocol
+	// being served. This is used during the plugin handshake to validate the
+	// server and client are compatible.
+	//
+	// In the future, it may be possible to include this information directly
+	// in the protocol buffers rather than recreating a constant here.
+	protocolVersionMajor uint = 6
+
+	// protocolVersionMinor represents the minor version number of the protocol
+	// being served. Backwards compatible additions are possible in the
+	// protocol definitions, which is when this may be increased. While it is
+	// not used in plugin negotiation, it can be helpful to include this value
+	// for debugging, such as in logs.
+	//
+	// In the future, it may be possible to include this information directly
+	// in the protocol buffers rather than recreating a constant here.
+	protocolVersionMinor uint = 0
+)
+
+// protocolVersion represents the combined major and minor version numbers of
+// the protocol being served.
+var protocolVersion string = fmt.Sprintf("%d.%d", protocolVersionMajor, protocolVersionMinor)
+
+const (
 	// envTfReattachProviders is the environment variable used by Terraform CLI
 	// to directly connect to already running provider processes, such as those
 	// being inspected by debugging processes. When connecting to providers in
@@ -207,7 +231,7 @@ func Serve(name string, serverFactory func() tfprotov6.ProviderServer, opts ...S
 
 	serveConfig := &plugin.ServeConfig{
 		HandshakeConfig: plugin.HandshakeConfig{
-			ProtocolVersion:  6,
+			ProtocolVersion:  protocolVersionMajor,
 			MagicCookieKey:   "TF_PLUGIN_MAGIC_COOKIE",
 			MagicCookieValue: "d602bf8f470bc67ca7faa0386276bbdd4330efaf76d1a219cb4d6991ca9872b2",
 		},
@@ -428,7 +452,7 @@ func New(name string, serve tfprotov6.ProviderServer, opts ...ServeOpt) tfplugin
 		useTFLogSink:    conf.useLoggingSink != nil,
 		testHandle:      conf.useLoggingSink,
 		protocolDataDir: os.Getenv(logging.EnvTfLogSdkProtoDataDir),
-		protocolVersion: "6",
+		protocolVersion: protocolVersion,
 	}
 }
 

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"regexp"
@@ -14,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-go/internal/logging"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/fromproto"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6"
@@ -21,38 +21,9 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
-	tfaddr "github.com/hashicorp/terraform-registry-address"
 	testing "github.com/mitchellh/go-testing-interface"
-)
-
-const tflogSubsystemName = "proto"
-
-// Global logging keys attached to all requests.
-//
-// Practitioners or tooling reading logs may be depending on these keys, so be
-// conscious of that when changing them.
-const (
-	// A unique ID for the RPC request
-	logKeyRequestID = "tf_req_id"
-
-	// The full address of the provider, such as
-	// registry.terraform.io/hashicorp/random
-	logKeyProviderAddress = "tf_provider_addr"
-
-	// The RPC being run, such as "ApplyResourceChange"
-	logKeyRPC = "tf_rpc"
-
-	// The type of resource being operated on, such as "random_pet"
-	logKeyResourceType = "tf_resource_type"
-
-	// The type of data source being operated on, such as "archive_file"
-	logKeyDataSourceType = "tf_data_source_type"
-
-	// The protocol version being used, as a string, such as "6"
-	logKeyProtocolVersion = "tf_proto_version"
 )
 
 const (
@@ -372,6 +343,9 @@ type server struct {
 	useTFLogSink bool
 	testHandle   testing.T
 	name         string
+
+	// protocolVersion is the protocol version for the server.
+	protocolVersion string
 }
 
 func mergeStop(ctx context.Context, cancel context.CancelFunc, stopCh chan struct{}) {
@@ -404,50 +378,11 @@ func (s *server) loggingContext(ctx context.Context) context.Context {
 		ctx = tfsdklog.RegisterTestSink(ctx, s.testHandle)
 	}
 
-	// generate a request ID
-	reqID, err := uuid.GenerateUUID()
-	if err != nil {
-		reqID = "unable to assign request ID: " + err.Error()
-	}
+	ctx = logging.InitContext(ctx, s.tflogSDKOpts, s.tflogOpts)
+	ctx = logging.RequestIdContext(ctx)
+	ctx = logging.ProviderAddressContext(ctx, s.name)
+	ctx = logging.ProtocolVersionContext(ctx, s.protocolVersion)
 
-	// set up the logger SDK loggers are derived from
-	ctx = tfsdklog.NewRootSDKLogger(ctx, append(tfsdklog.Options{
-		tfsdklog.WithLevelFromEnv("TF_LOG_SDK"),
-	}, s.tflogSDKOpts...)...)
-	ctx = tfsdklog.With(ctx, logKeyRequestID, reqID)
-	ctx = tfsdklog.With(ctx, logKeyProviderAddress, s.name)
-
-	// set up our protocol-level subsystem logger
-	ctx = tfsdklog.NewSubsystem(ctx, tflogSubsystemName, append(tfsdklog.Options{
-		tfsdklog.WithLevelFromEnv("TF_LOG_SDK_PROTO"),
-	}, s.tflogSDKOpts...)...)
-	ctx = tfsdklog.SubsystemWith(ctx, tflogSubsystemName, logKeyProtocolVersion, "6")
-
-	// set up the provider logger
-	ctx = tfsdklog.NewRootProviderLogger(ctx, s.tflogOpts...)
-	ctx = tflog.With(ctx, logKeyRequestID, reqID)
-	ctx = tflog.With(ctx, logKeyProviderAddress, s.name)
-	return ctx
-}
-
-func rpcLoggingContext(ctx context.Context, rpc string) context.Context {
-	ctx = tfsdklog.With(ctx, logKeyRPC, rpc)
-	ctx = tfsdklog.SubsystemWith(ctx, tflogSubsystemName, logKeyRPC, rpc)
-	ctx = tflog.With(ctx, logKeyRPC, rpc)
-	return ctx
-}
-
-func resourceLoggingContext(ctx context.Context, resource string) context.Context {
-	ctx = tfsdklog.With(ctx, logKeyResourceType, resource)
-	ctx = tfsdklog.SubsystemWith(ctx, tflogSubsystemName, logKeyResourceType, resource)
-	ctx = tflog.With(ctx, logKeyResourceType, resource)
-	return ctx
-}
-
-func dataSourceLoggingContext(ctx context.Context, dataSource string) context.Context {
-	ctx = tfsdklog.With(ctx, logKeyDataSourceType, dataSource)
-	ctx = tfsdklog.SubsystemWith(ctx, tflogSubsystemName, logKeyDataSourceType, dataSource)
-	ctx = tflog.With(ctx, logKeyDataSourceType, dataSource)
 	return ctx
 }
 
@@ -475,97 +410,95 @@ func New(name string, serve tfprotov6.ProviderServer, opts ...ServeOpt) tfplugin
 	}
 	envVar := conf.envVar
 	if envVar == "" {
-		addr, err := tfaddr.ParseRawProviderSourceString(name)
-		if err != nil {
-			log.Printf("[ERROR] Error parsing provider name %q: %s", name, err)
-		} else {
-			envVar = addr.Type
-		}
+		envVar = logging.ProviderLoggerName(name)
 	}
-	envVar = strings.ReplaceAll(envVar, "-", "_")
 	if envVar != "" {
-		options = append(options, tfsdklog.WithLogName(envVar), tflog.WithLevelFromEnv("TF_LOG_PROVIDER", envVar))
+		options = append(options, tfsdklog.WithLogName(envVar), tflog.WithLevelFromEnv(logging.EnvTfLogProvider, envVar))
 	}
 	return &server{
-		downstream:   serve,
-		stopCh:       make(chan struct{}),
-		tflogOpts:    options,
-		tflogSDKOpts: sdkOptions,
-		name:         name,
-		useTFLogSink: conf.useLoggingSink != nil,
-		testHandle:   conf.useLoggingSink,
+		downstream:      serve,
+		stopCh:          make(chan struct{}),
+		tflogOpts:       options,
+		tflogSDKOpts:    sdkOptions,
+		name:            name,
+		useTFLogSink:    conf.useLoggingSink != nil,
+		testHandle:      conf.useLoggingSink,
+		protocolVersion: "6",
 	}
 }
 
 func (s *server) GetProviderSchema(ctx context.Context, req *tfplugin6.GetProviderSchema_Request) (*tfplugin6.GetProviderSchema_Response, error) {
-	ctx = rpcLoggingContext(s.loggingContext(ctx), "GetProviderSchema")
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "GetProviderSchema")
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.GetProviderSchemaRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.GetProviderSchema(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.GetProviderSchema_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
 }
 
 func (s *server) ConfigureProvider(ctx context.Context, req *tfplugin6.ConfigureProvider_Request) (*tfplugin6.ConfigureProvider_Response, error) {
-	ctx = rpcLoggingContext(s.loggingContext(ctx), "ConfigureProvider")
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "ConfigureProvider")
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.ConfigureProviderRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ConfigureProvider(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.Configure_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
 }
 
 func (s *server) ValidateProviderConfig(ctx context.Context, req *tfplugin6.ValidateProviderConfig_Request) (*tfplugin6.ValidateProviderConfig_Response, error) {
-	ctx = rpcLoggingContext(s.loggingContext(ctx), "ValidateProviderConfig")
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "ValidateProviderConfig")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.ValidateProviderConfigRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ValidateProviderConfig(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.ValidateProviderConfig_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
@@ -585,228 +518,245 @@ func (s *server) stop() {
 }
 
 func (s *server) Stop(ctx context.Context, req *tfplugin6.StopProvider_Request) (*tfplugin6.StopProvider_Response, error) {
-	ctx = rpcLoggingContext(s.loggingContext(ctx), "Stop")
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "Stop")
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.StopProviderRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.StopProvider(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Closing all our contexts")
+	logging.ProtocolTrace(ctx, "Called downstream")
+	logging.ProtocolTrace(ctx, "Closing all our contexts")
 	s.stop()
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Closed all our contexts")
+	logging.ProtocolTrace(ctx, "Closed all our contexts")
 	ret, err := toproto.Stop_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
 }
 
 func (s *server) ValidateDataResourceConfig(ctx context.Context, req *tfplugin6.ValidateDataResourceConfig_Request) (*tfplugin6.ValidateDataResourceConfig_Response, error) {
-	ctx = dataSourceLoggingContext(rpcLoggingContext(s.loggingContext(ctx), "ValidateDataResourceConfig"), req.TypeName)
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "ValidateDataResourceConfig")
+	ctx = logging.DataSourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.ValidateDataResourceConfigRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ValidateDataResourceConfig(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.ValidateDataResourceConfig_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
 }
 
 func (s *server) ReadDataSource(ctx context.Context, req *tfplugin6.ReadDataSource_Request) (*tfplugin6.ReadDataSource_Response, error) {
-	ctx = dataSourceLoggingContext(rpcLoggingContext(s.loggingContext(ctx), "ReadDataSource"), req.TypeName)
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "ReadDataSource")
+	ctx = logging.DataSourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.ReadDataSourceRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ReadDataSource(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.ReadDataSource_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
 }
 
 func (s *server) ValidateResourceConfig(ctx context.Context, req *tfplugin6.ValidateResourceConfig_Request) (*tfplugin6.ValidateResourceConfig_Response, error) {
-	ctx = resourceLoggingContext(rpcLoggingContext(s.loggingContext(ctx), "ValidateResourceConfig"), req.TypeName)
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "ValidateResourceConfig")
+	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.ValidateResourceConfigRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ValidateResourceConfig(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.ValidateResourceConfig_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
 }
 
 func (s *server) UpgradeResourceState(ctx context.Context, req *tfplugin6.UpgradeResourceState_Request) (*tfplugin6.UpgradeResourceState_Response, error) {
-	ctx = resourceLoggingContext(rpcLoggingContext(s.loggingContext(ctx), "UpgradeResourceState"), req.TypeName)
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "UpgradeResourceState")
+	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.UpgradeResourceStateRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.UpgradeResourceState(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.UpgradeResourceState_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
 }
 
 func (s *server) ReadResource(ctx context.Context, req *tfplugin6.ReadResource_Request) (*tfplugin6.ReadResource_Response, error) {
-	ctx = resourceLoggingContext(rpcLoggingContext(s.loggingContext(ctx), "ReadResource"), req.TypeName)
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "ReadResource")
+	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.ReadResourceRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ReadResource(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.ReadResource_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
 }
 
 func (s *server) PlanResourceChange(ctx context.Context, req *tfplugin6.PlanResourceChange_Request) (*tfplugin6.PlanResourceChange_Response, error) {
-	ctx = resourceLoggingContext(rpcLoggingContext(s.loggingContext(ctx), "PlanResourceChange"), req.TypeName)
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "PlanResourceChange")
+	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.PlanResourceChangeRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.PlanResourceChange(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.PlanResourceChange_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
 }
 
 func (s *server) ApplyResourceChange(ctx context.Context, req *tfplugin6.ApplyResourceChange_Request) (*tfplugin6.ApplyResourceChange_Response, error) {
-	ctx = resourceLoggingContext(rpcLoggingContext(s.loggingContext(ctx), "ApplyResourceChange"), req.TypeName)
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "ApplyResourceChange")
+	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.ApplyResourceChangeRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ApplyResourceChange(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.ApplyResourceChange_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil
 }
 
 func (s *server) ImportResourceState(ctx context.Context, req *tfplugin6.ImportResourceState_Request) (*tfplugin6.ImportResourceState_Response, error) {
-	ctx = resourceLoggingContext(rpcLoggingContext(s.loggingContext(ctx), "ImportResourceState"), req.TypeName)
+	ctx = s.loggingContext(ctx)
+	ctx = logging.RpcContext(ctx, "ImportResourceState")
+	ctx = logging.ResourceContext(ctx, req.TypeName)
 	ctx = s.stoppableContext(ctx)
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Received request")
-	defer tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Served request")
+	logging.ProtocolTrace(ctx, "Received request")
+	defer logging.ProtocolTrace(ctx, "Served request")
 	r, err := fromproto.ImportResourceStateRequest(req)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting request from protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting request from protobuf", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Calling downstream")
+	logging.ProtocolTrace(ctx, "Calling downstream")
 	resp, err := s.downstream.ImportResourceState(ctx, r)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error from downstream", "error", err)
+		logging.ProtocolError(ctx, "Error from downstream", "error", err)
 		return nil, err
 	}
-	tfsdklog.SubsystemTrace(ctx, tflogSubsystemName, "Called downstream")
+	logging.ProtocolTrace(ctx, "Called downstream")
 	ret, err := toproto.ImportResourceState_Response(resp)
 	if err != nil {
-		tfsdklog.SubsystemError(ctx, tflogSubsystemName, "Error converting response to protobuf", "error", err)
+		logging.ProtocolError(ctx, "Error converting response to protobuf", "error", err)
 		return nil, err
 	}
 	return ret, nil


### PR DESCRIPTION
Closes #107

This changeset refactors the `tf5server` and `tf6server` logging implementations into a shared internal package to reduce code duplication. The protocol data handling utilizes the `TF_LOG_SDK_PROTO_DATA_DIR` environment variable to enable writing individual data field files to disk. In the future, this may need to be offered as a server configuration so it can work better in conjunction with testing frameworks (e.g. `t.TempDir()`), but there should not be too much preventing that as a later enhancement as necessary.

Without `TF_LOG_SDK_PROTO_DATA_DIR` set (once):

```text
2022-01-06T16:04:54.787-0500 [TRACE] provider.terraform-provider-framework: Skipping protocol data file writing because no data directory is set. Use the TF_LOG_SDK_PROTO_DATA_DIR environment variable to enable this functionality.: tf_req_id=105b9e19-be94-411d-2f52-ca84c14f951e tf_resource_type=framework_optional_types tf_rpc=ValidateResourceConfig @caller=/Users/bflad/src/github.com/hashicorp/terraform-plugin-go/internal/logging/protocol.go:21 @module=sdk.proto EXTRA_VALUE_AT_END=<nil> tf_provider_addr=registry.terraform.io/bflad/framework tf_proto_version=6 timestamp=2022-01-06T16:04:54.786-0500
```

With `TF_LOG_SDK_PROTO_DATA_DIR` set (per `DynamicValue` field):

```text
2022-01-06T16:06:36.079-0500 [TRACE] provider.terraform-provider-framework: Writing protocol data file: EXTRA_VALUE_AT_END=[tf_proto_data_file, 1641503196_ValidateResourceConfig_Request_Config.msgpack] tf_rpc=ValidateResourceConfig @module=sdk.proto tf_proto_version=6 tf_provider_addr=registry.terraform.io/bflad/framework tf_req_id=9084bc21-f6d1-bcc8-b916-fe75595375d2 tf_resource_type=framework_optional_types @caller=/Users/bflad/src/github.com/hashicorp/terraform-plugin-go/internal/logging/protocol.go:21 timestamp=2022-01-06T16:06:36.079-0500
```

Viewing example MessagePack file contents:

```console
$ go install github.com/nokute78/msgpack-microscope/cmd/msgpack2json@latest
$ msgpack2json 1641503196_PlanResourceChange_Request_Config.msgpack | jq .
{
  "format": "fixmap",
  "header": "0x85",
  "length": 5,
  "raw": "0x85a26964c0b36f7074696f6e616c5f74797065735f626f6f6cc0b66f7074696f6e616c5f74797065735f666c6f61743634c0b46f7074696f6e616c5f74797065735f696e743634c0b56f7074696f6e616c5f74797065735f737472696e67c0",
  "value": [
    {
      "key": {
        "format": "fixstr",
        "header": "0xa2",
        "raw": "0xa26964",
        "value": "id"
      },
      "value": {
        "format": "nil",
        "header": "0xc0",
        "raw": "0xc0",
        "value": null
      }
    },
    {
      "key": {
        "format": "fixstr",
        "header": "0xb3",
        "raw": "0xb36f7074696f6e616c5f74797065735f626f6f6c",
        "value": "optional_types_bool"
      },
      "value": {
        "format": "nil",
        "header": "0xc0",
        "raw": "0xc0",
        "value": null
      }
    },
    {
      "key": {
        "format": "fixstr",
        "header": "0xb6",
        "raw": "0xb66f7074696f6e616c5f74797065735f666c6f61743634",
        "value": "optional_types_float64"
      },
      "value": {
        "format": "nil",
        "header": "0xc0",
        "raw": "0xc0",
        "value": null
      }
    },
    {
      "key": {
        "format": "fixstr",
        "header": "0xb4",
        "raw": "0xb46f7074696f6e616c5f74797065735f696e743634",
        "value": "optional_types_int64"
      },
      "value": {
        "format": "nil",
        "header": "0xc0",
        "raw": "0xc0",
        "value": null
      }
    },
    {
      "key": {
        "format": "fixstr",
        "header": "0xb5",
        "raw": "0xb56f7074696f6e616c5f74797065735f737472696e67",
        "value": "optional_types_string"
      },
      "value": {
        "format": "nil",
        "header": "0xc0",
        "raw": "0xc0",
        "value": null
      }
    }
  ]
}
```
