### PR TITLE
Increase gRPC maximum message size send and receive limits to 256MB

### DIFF
--- a/.changelog/139.txt
+++ b/.changelog/139.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+tfprotov5/tf5server: Increased maximum gRPC send and receive message size limit to 256MB
+```
+
+```release-note:enhancement
+tfprotov6/tf6server: Increased maximum gRPC send and receive message size limit to 256MB
+```

--- a/tfprotov5/tf5server/server.go
+++ b/tfprotov5/tf5server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/fromproto"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/toproto"
+	"google.golang.org/grpc"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
@@ -57,6 +58,26 @@ const (
 	// this manner, Terraform CLI disables certain plugin handshake checks and
 	// will not stop the provider process.
 	envTfReattachProviders = "TF_REATTACH_PROVIDERS"
+)
+
+const (
+	// grpcMaxMessageSize is the maximum gRPC send and receive message sizes
+	// for the server.
+	//
+	// This 256MB value is arbitrarily raised from the default message sizes of
+	// 4MB to account for advanced use cases, but arbitrarily lowered from
+	// MaxInt32 (or similar) to prevent incorrect server implementations from
+	// exhausting resources in common execution environments. Receiving a gRPC
+	// message size error is preferable for troubleshooting over determining
+	// why an execution environment may have terminated the process via its
+	// memory management processes, such as oom-killer on Linux.
+	//
+	// This value is kept as constant over allowing server configurability
+	// since there are many factors that influence message size, such as
+	// Terraform configuration and state data. If larger message size use
+	// cases appear, other gRPC options should be explored, such as
+	// implementing streaming RPCs and messages.
+	grpcMaxMessageSize = 256 << 20
 )
 
 // ServeOpt is an interface for defining options that can be passed to the
@@ -240,7 +261,12 @@ func Serve(name string, serverFactory func() tfprotov5.ProviderServer, opts ...S
 				GRPCProvider: serverFactory,
 			},
 		},
-		GRPCServer: plugin.DefaultGRPCServer,
+		GRPCServer: func(opts []grpc.ServerOption) *grpc.Server {
+			opts = append(opts, grpc.MaxRecvMsgSize(grpcMaxMessageSize))
+			opts = append(opts, grpc.MaxSendMsgSize(grpcMaxMessageSize))
+
+			return grpc.NewServer(opts...)
+		},
 	}
 
 	if conf.logger != nil {


### PR DESCRIPTION
Closes #106

The rationale for choosing this particular value and making it a constant, rather than configurable, is included in the code.