### PR TITLE
Propagate provider name into GRPCProviderPlugin

### DIFF
--- a/tfprotov5/tf5server/server.go
+++ b/tfprotov5/tf5server/server.go
@@ -258,6 +258,7 @@ func Serve(name string, serverFactory func() tfprotov5.ProviderServer, opts ...S
 		},
 		Plugins: plugin.PluginSet{
 			"provider": &GRPCProviderPlugin{
+				Name:         name,
 				GRPCProvider: serverFactory,
 			},
 		},


### PR DESCRIPTION
This resolves the bellow error message printed on provider startup:
```
2022/02/02 01:07:48 [ERROR] Error parsing provider name "": Invalid provider source string: The "source" attribute must be in the format "[hostname/][namespace/]name"

```