### PR TITLE
Fixing attribute path step bug

### DIFF
--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -133,7 +133,7 @@ func (val Value) ApplyTerraform5AttributePathStep(step AttributePathStep) (inter
 	}
 	switch s := step.(type) {
 	case AttributeName:
-		if !val.Type().Is(Object{}) {
+		if !val.Type().Is(Object{}) && !val.Type().Is(Map{}) {
 			return nil, ErrInvalidStep
 		}
 		o := map[string]Value{}


### PR DESCRIPTION
Hello. I'm using [hashicorp/terraform-provider-kubernetes](https://github.com/hashicorp/terraform-provider-kubernetes) provider with `wait_for` field customization. In some cases it will not work correctly. For example, I'm trying to install manifest for [zalando/postgres-operator](https://github.com/zalando/postgres-operator) and specify `wait_for` like this:
```
  wait_for = {
    fields = {
      "status.PostgresClusterStatus" = "Running"
    }
  }
```
In my case, `apply` will not finish even after field `.status.PostgresClusterStatus` is become in value `Running`.
As I understand correct, this patch should fix such behavior.