### PR TITLE
.github: Add github-actions management to dependabot and ignore go-hclog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "gomod"
     directory: "/"
+    ignore:
+      # go-hclog should only be updated via terraform-plugin-log
+      - dependency-name: "github.com/hashicorp/go-hclog"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-providers-devex-internal/issues/79
Reference: https://github.com/hashicorp/terraform-plugin-sdk/blob/aeb1360e9c212819eefc4c5576eb513ad027af6e/.github/dependabot.yml#L9-L10