### PR TITLE
Invalid plan arising from integer rounding

### DIFF
--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -440,7 +440,7 @@ func (val Value) As(dst interface{}) error {
 		if !ok {
 			return fmt.Errorf("can't unmarshal %s into %T, expected *big.Float", val.Type(), dst)
 		}
-		target.Set(v)
+		target.Copy(v)
 		return nil
 	case **big.Float:
 		if val.IsNull() {

--- a/tftypes/value_msgpack.go
+++ b/tftypes/value_msgpack.go
@@ -74,7 +74,7 @@ func msgpackUnmarshal(dec *msgpack.Decoder, typ Type, path *AttributePath) (Valu
 			if err != nil {
 				return Value{}, path.NewErrorf("couldn't decode number as int64: %w", err)
 			}
-			return NewValue(Number, big.NewFloat(float64(rv))), nil
+			return NewValue(Number, new(big.Float).SetInt64(rv)), nil
 		}
 		switch peek {
 		case msgpackCodes.Int8, msgpackCodes.Int16, msgpackCodes.Int32, msgpackCodes.Int64:
@@ -82,13 +82,13 @@ func msgpackUnmarshal(dec *msgpack.Decoder, typ Type, path *AttributePath) (Valu
 			if err != nil {
 				return Value{}, path.NewErrorf("couldn't decode number as int64: %w", err)
 			}
-			return NewValue(Number, big.NewFloat(float64(rv))), nil
+			return NewValue(Number, new(big.Float).SetInt64(rv)), nil
 		case msgpackCodes.Uint8, msgpackCodes.Uint16, msgpackCodes.Uint32, msgpackCodes.Uint64:
 			rv, err := dec.DecodeUint64()
 			if err != nil {
 				return Value{}, path.NewErrorf("couldn't decode number as uint64: %w", err)
 			}
-			return NewValue(Number, big.NewFloat(float64(rv))), nil
+			return NewValue(Number, new(big.Float).SetUint64(rv)), nil
 		case msgpackCodes.Float, msgpackCodes.Double:
 			rv, err := dec.DecodeFloat64()
 			if err != nil {

--- a/tftypes/value_msgpack_test.go
+++ b/tftypes/value_msgpack_test.go
@@ -70,9 +70,24 @@ func TestValueFromMsgPack(t *testing.T) {
 			value: NewValue(Number, big.NewFloat(1)),
 			typ:   Number,
 		},
+		"int64-number": {
+			hex:   "cf7fffffffffffffff",
+			value: NewValue(Number, new(big.Float).SetInt64(math.MaxInt64)),
+			typ:   Number,
+		},
+		"uint64-number": {
+			hex:   "b43138343436373434303733373039353531363135",
+			value: NewValue(Number, new(big.Float).SetUint64(math.MaxUint64)),
+			typ:   Number,
+		},
 		"float-number": {
 			hex:   "cb3ff8000000000000",
 			value: NewValue(Number, big.NewFloat(1.5)),
+			typ:   Number,
+		},
+		"float64-number": {
+			hex:   "cb7fefffffffffffff",
+			value: NewValue(Number, new(big.Float).SetFloat64(math.MaxFloat64)),
 			typ:   Number,
 		},
 		"big-number": {


### PR DESCRIPTION
### Overview
#### Issue 1
A lossy conversion between int64 and uint64 can arise because of the use of `float64()`, which uses a float64 with a precision of 53.

This issue arises in the following locations:
- [value_msgpack.go#L77](https://github.com/hashicorp/terraform-plugin-go/blob/main/tftypes/value_msgpack.go#L77)
- [value_msgpack.go#L85](https://github.com/hashicorp/terraform-plugin-go/blob/main/tftypes/value_msgpack.go#L85)
- [value_msgpack.go#L91](https://github.com/hashicorp/terraform-plugin-go/blob/main/tftypes/value_msgpack.go#L91)

Taking the form:
```go
return NewValue(Number, big.NewFloat(float64(rv))), nil
```

#### Issue 2
Another potential lossy operation can arise from the usage of `big.Float.Set`.

This issue arises in the following location:
-   [value.go#L443](https://github.com/hashicorp/terraform-plugin-go/blob/main/tftypes/value.go#L443)

This is a consequence of the following:
```go
v, ok := val.value.(*big.Float)
if !ok {
	return fmt.Errorf("can't unmarshal %s into %T, expected *big.Float", val.Type(), dst)
}
target.Set(v)
```

Because `v` uses the default precision of 53 of `big.Float`

An additional consequence of using `target.Set(v)` is that the tests within [value_msgpack_test.go](https://github.com/hashicorp/terraform-plugin-go/blob/main/tftypes/value_msgpack_test.go) would not detect this form of rounding.

### Fixes
- `new(big.Float).SetInt64()` or `new(big.Float).SetUint64()` is used as appropriate in [value_msgpack.go](https://github.com/hashicorp/terraform-plugin-go/blob/main/tftypes/value_msgpack.go).
- `big.Float.Copy` instead of `big.Float.Set` is used within [value.go](https://github.com/hashicorp/terraform-plugin-go/blob/main/tftypes/value.go).
- Tests within [value_msgpack_test.go](https://github.com/hashicorp/terraform-plugin-go/blob/main/tftypes/value_msgpack_test.go) have been updated to check for rounding.

### Related Issues
- Closes #189 