### PR TITLE
.github/workflows: Remove obsolete golangci-lint-action input

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -26,8 +26,6 @@ jobs:
           go-version: ${{ steps.go-version.outputs.version }}
       - run: go mod download
       - uses: golangci/golangci-lint-action@v3.2.0
-        with:
-          skip-go-installation: true
   terraform-provider-corner-tfprotov5:
     defaults:
       run:


### PR DESCRIPTION
Reference: https://github.com/golangci/golangci-lint-action/releases/tag/v3.0.0

Removes this warning on invocation:

```
Warning: Unexpected input(s) 'skip-go-installation', valid inputs are ['version', 'args', 'working-directory', 'github-token', 'only-new-issues', 'skip-cache', 'skip-pkg-cache', 'skip-build-cache']
```