### PR TITLE
Allow ignoring undefined attributes during unmarshalling

### DIFF
--- a/.changelog/213.txt
+++ b/.changelog/213.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-tfprotov5/state: Added `UnmarshalWithOpts` func to facilitate configurable behaviour during unmarshalling
+tfprotov5: Added `RawState` type `UnmarshalWithOpts` method to facilitate configurable behaviour during unmarshalling
 ```
 
 ```release-note:enhancement
-tfprotov6/state: Added `UnmarshalWithOpts` func to facilitate configurable behaviour during unmarshalling
+tfprotov6: Added `RawState` type `UnmarshalWithOpts` method to facilitate configurable behaviour during unmarshalling
 ```

--- a/.changelog/213.txt
+++ b/.changelog/213.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+tfprotov5/state: Added `UnmarshalWithOpts` func to facilitate configurable behaviour during unmarshalling
+```
+
+```release-note:enhancement
+tfprotov6/state: Added `UnmarshalWithOpts` func to facilitate configurable behaviour during unmarshalling
+```

--- a/tfprotov5/state.go
+++ b/tfprotov5/state.go
@@ -82,7 +82,7 @@ func (s RawState) Unmarshal(typ tftypes.Type) (tftypes.Value, error) {
 // options that can be used to modify the behaviour when unmarshalling JSON or Flatmap.
 func (s RawState) UnmarshalWithOpts(typ tftypes.Type, opts tftypes.UnmarshalOpts) (tftypes.Value, error) {
 	if s.JSON != nil {
-		return tftypes.ValueFromJSONWithOpts(s.JSON, typ, opts.JsonOpts) //nolint:staticcheck
+		return tftypes.ValueFromJSONWithOpts(s.JSON, typ, opts.JSONOpts) //nolint:staticcheck
 	}
 	if s.Flatmap != nil {
 		return tftypes.Value{}, fmt.Errorf("flatmap states cannot be unmarshaled, only states written by Terraform 0.12 and higher can be unmarshaled")

--- a/tfprotov5/state.go
+++ b/tfprotov5/state.go
@@ -77,3 +77,15 @@ func (s RawState) Unmarshal(typ tftypes.Type) (tftypes.Value, error) {
 	}
 	return tftypes.Value{}, ErrUnknownRawStateType
 }
+
+// UnmarshalWithOpts is identical to Unmarshal but also accepts a tftypes.UnmarshalOpts which contains
+// options that can be used to modify the behaviour when unmarshalling JSON or Flatmap.
+func (s RawState) UnmarshalWithOpts(typ tftypes.Type, opts tftypes.UnmarshalOpts) (tftypes.Value, error) {
+	if s.JSON != nil {
+		return tftypes.ValueFromJSONWithOpts(s.JSON, typ, opts.JsonOpts) //nolint:staticcheck
+	}
+	if s.Flatmap != nil {
+		return tftypes.Value{}, fmt.Errorf("flatmap states cannot be unmarshaled, only states written by Terraform 0.12 and higher can be unmarshaled")
+	}
+	return tftypes.Value{}, ErrUnknownRawStateType
+}

--- a/tfprotov5/state.go
+++ b/tfprotov5/state.go
@@ -78,11 +78,18 @@ func (s RawState) Unmarshal(typ tftypes.Type) (tftypes.Value, error) {
 	return tftypes.Value{}, ErrUnknownRawStateType
 }
 
+// UnmarshalOpts contains options that can be used to modify the behaviour when
+// unmarshalling. Currently, this only contains a struct for opts for JSON but
+// could have a field for Flatmap in the future.
+type UnmarshalOpts struct {
+	ValueFromJSONOpts tftypes.ValueFromJSONOpts
+}
+
 // UnmarshalWithOpts is identical to Unmarshal but also accepts a tftypes.UnmarshalOpts which contains
 // options that can be used to modify the behaviour when unmarshalling JSON or Flatmap.
-func (s RawState) UnmarshalWithOpts(typ tftypes.Type, opts tftypes.UnmarshalOpts) (tftypes.Value, error) {
+func (s RawState) UnmarshalWithOpts(typ tftypes.Type, opts UnmarshalOpts) (tftypes.Value, error) {
 	if s.JSON != nil {
-		return tftypes.ValueFromJSONWithOpts(s.JSON, typ, opts.JSONOpts) //nolint:staticcheck
+		return tftypes.ValueFromJSONWithOpts(s.JSON, typ, opts.ValueFromJSONOpts) //nolint:staticcheck
 	}
 	if s.Flatmap != nil {
 		return tftypes.Value{}, fmt.Errorf("flatmap states cannot be unmarshaled, only states written by Terraform 0.12 and higher can be unmarshaled")

--- a/tfprotov5/state_test.go
+++ b/tfprotov5/state_test.go
@@ -1,0 +1,83 @@
+package tfprotov5_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestRawStateUnmarshalWithOpts(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		rawState tfprotov5.RawState
+		value    tftypes.Value
+		typ      tftypes.Type
+		opts     tfprotov5.UnmarshalOpts
+	}
+	tests := map[string]testCase{
+		"object-of-bool-number": {
+			rawState: tfprotov5.RawState{
+				JSON: []byte(`{"bool":true,"number":0}`),
+			},
+			value: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"bool":   tftypes.Bool,
+					"number": tftypes.Number,
+				},
+			}, map[string]tftypes.Value{
+				"bool":   tftypes.NewValue(tftypes.Bool, true),
+				"number": tftypes.NewValue(tftypes.Number, big.NewFloat(0)),
+			}),
+			typ: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"bool":   tftypes.Bool,
+					"number": tftypes.Number,
+				},
+			},
+		},
+		"object-with-missing-attribute": {
+			rawState: tfprotov5.RawState{
+				JSON: []byte(`{"bool":true,"number":0,"unknown":"whatever"}`),
+			},
+			value: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"bool":   tftypes.Bool,
+					"number": tftypes.Number,
+				},
+			}, map[string]tftypes.Value{
+				"bool":   tftypes.NewValue(tftypes.Bool, true),
+				"number": tftypes.NewValue(tftypes.Number, big.NewFloat(0)),
+			}),
+			typ: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"bool":   tftypes.Bool,
+					"number": tftypes.Number,
+				},
+			},
+			opts: tfprotov5.UnmarshalOpts{
+				ValueFromJSONOpts: tftypes.ValueFromJSONOpts{
+					IgnoreUndefinedAttributes: true,
+				},
+			},
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			val, err := test.rawState.UnmarshalWithOpts(test.typ, test.opts)
+			if err != nil {
+				t.Fatalf("unexpected error unmarshaling: %s", err)
+			}
+
+			if diff := cmp.Diff(test.value, val); diff != "" {
+				t.Errorf("Unexpected results (-wanted +got): %s", diff)
+			}
+		})
+	}
+}

--- a/tfprotov6/state.go
+++ b/tfprotov6/state.go
@@ -82,7 +82,7 @@ func (s RawState) Unmarshal(typ tftypes.Type) (tftypes.Value, error) {
 // options that can be used to modify the behaviour when unmarshalling JSON or Flatmap.
 func (s RawState) UnmarshalWithOpts(typ tftypes.Type, opts tftypes.UnmarshalOpts) (tftypes.Value, error) {
 	if s.JSON != nil {
-		return tftypes.ValueFromJSONWithOpts(s.JSON, typ, opts.JsonOpts) //nolint:staticcheck
+		return tftypes.ValueFromJSONWithOpts(s.JSON, typ, opts.JSONOpts) //nolint:staticcheck
 	}
 	if s.Flatmap != nil {
 		return tftypes.Value{}, fmt.Errorf("flatmap states cannot be unmarshaled, only states written by Terraform 0.12 and higher can be unmarshaled")

--- a/tfprotov6/state.go
+++ b/tfprotov6/state.go
@@ -77,3 +77,15 @@ func (s RawState) Unmarshal(typ tftypes.Type) (tftypes.Value, error) {
 	}
 	return tftypes.Value{}, ErrUnknownRawStateType
 }
+
+// UnmarshalWithOpts is identical to Unmarshal but also accepts a tftypes.UnmarshalOpts which contains
+// options that can be used to modify the behaviour when unmarshalling JSON or Flatmap.
+func (s RawState) UnmarshalWithOpts(typ tftypes.Type, opts tftypes.UnmarshalOpts) (tftypes.Value, error) {
+	if s.JSON != nil {
+		return tftypes.ValueFromJSONWithOpts(s.JSON, typ, opts.JsonOpts) //nolint:staticcheck
+	}
+	if s.Flatmap != nil {
+		return tftypes.Value{}, fmt.Errorf("flatmap states cannot be unmarshaled, only states written by Terraform 0.12 and higher can be unmarshaled")
+	}
+	return tftypes.Value{}, ErrUnknownRawStateType
+}

--- a/tfprotov6/state.go
+++ b/tfprotov6/state.go
@@ -78,11 +78,18 @@ func (s RawState) Unmarshal(typ tftypes.Type) (tftypes.Value, error) {
 	return tftypes.Value{}, ErrUnknownRawStateType
 }
 
+// UnmarshalOpts contains options that can be used to modify the behaviour when
+// unmarshalling. Currently, this only contains a struct for opts for JSON but
+// could have a field for Flatmap in the future.
+type UnmarshalOpts struct {
+	ValueFromJSONOpts tftypes.ValueFromJSONOpts
+}
+
 // UnmarshalWithOpts is identical to Unmarshal but also accepts a tftypes.UnmarshalOpts which contains
 // options that can be used to modify the behaviour when unmarshalling JSON or Flatmap.
-func (s RawState) UnmarshalWithOpts(typ tftypes.Type, opts tftypes.UnmarshalOpts) (tftypes.Value, error) {
+func (s RawState) UnmarshalWithOpts(typ tftypes.Type, opts UnmarshalOpts) (tftypes.Value, error) {
 	if s.JSON != nil {
-		return tftypes.ValueFromJSONWithOpts(s.JSON, typ, opts.JSONOpts) //nolint:staticcheck
+		return tftypes.ValueFromJSONWithOpts(s.JSON, typ, opts.ValueFromJSONOpts) //nolint:staticcheck
 	}
 	if s.Flatmap != nil {
 		return tftypes.Value{}, fmt.Errorf("flatmap states cannot be unmarshaled, only states written by Terraform 0.12 and higher can be unmarshaled")

--- a/tfprotov6/state_test.go
+++ b/tfprotov6/state_test.go
@@ -1,0 +1,83 @@
+package tfprotov6_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestRawStateUnmarshalWithOpts(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		rawState tfprotov6.RawState
+		value    tftypes.Value
+		typ      tftypes.Type
+		opts     tfprotov6.UnmarshalOpts
+	}
+	tests := map[string]testCase{
+		"object-of-bool-number": {
+			rawState: tfprotov6.RawState{
+				JSON: []byte(`{"bool":true,"number":0}`),
+			},
+			value: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"bool":   tftypes.Bool,
+					"number": tftypes.Number,
+				},
+			}, map[string]tftypes.Value{
+				"bool":   tftypes.NewValue(tftypes.Bool, true),
+				"number": tftypes.NewValue(tftypes.Number, big.NewFloat(0)),
+			}),
+			typ: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"bool":   tftypes.Bool,
+					"number": tftypes.Number,
+				},
+			},
+		},
+		"object-with-missing-attribute": {
+			rawState: tfprotov6.RawState{
+				JSON: []byte(`{"bool":true,"number":0,"unknown":"whatever"}`),
+			},
+			value: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"bool":   tftypes.Bool,
+					"number": tftypes.Number,
+				},
+			}, map[string]tftypes.Value{
+				"bool":   tftypes.NewValue(tftypes.Bool, true),
+				"number": tftypes.NewValue(tftypes.Number, big.NewFloat(0)),
+			}),
+			typ: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"bool":   tftypes.Bool,
+					"number": tftypes.Number,
+				},
+			},
+			opts: tfprotov6.UnmarshalOpts{
+				ValueFromJSONOpts: tftypes.ValueFromJSONOpts{
+					IgnoreUndefinedAttributes: true,
+				},
+			},
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			val, err := test.rawState.UnmarshalWithOpts(test.typ, test.opts)
+			if err != nil {
+				t.Fatalf("unexpected error unmarshaling: %s", err)
+			}
+
+			if diff := cmp.Diff(test.value, val); diff != "" {
+				t.Errorf("Unexpected results (-wanted +got): %s", diff)
+			}
+		})
+	}
+}

--- a/tftypes/value_json.go
+++ b/tftypes/value_json.go
@@ -23,7 +23,7 @@ func ValueFromJSON(data []byte, typ Type) (Value, error) {
 // unmarshalling. Currently, this only contains a struct for opts for JSON but
 // could have a field for Flatmap in the future.
 type UnmarshalOpts struct {
-	JsonOpts JSONOpts
+	JSONOpts JSONOpts
 }
 
 // JSONOpts contains options that can be used to modify the behaviour when

--- a/tftypes/value_json.go
+++ b/tftypes/value_json.go
@@ -16,27 +16,24 @@ import (
 // terraform-plugin-go.  Third parties should not use it, and its behavior is
 // not covered under the API compatibility guarantees. Don't use this.
 func ValueFromJSON(data []byte, typ Type) (Value, error) {
-	return jsonUnmarshal(data, typ, NewAttributePath(), JSONOpts{})
+	return jsonUnmarshal(data, typ, NewAttributePath(), ValueFromJSONOpts{})
 }
 
-// UnmarshalOpts contains options that can be used to modify the behaviour when
-// unmarshalling. Currently, this only contains a struct for opts for JSON but
-// could have a field for Flatmap in the future.
-type UnmarshalOpts struct {
-	JSONOpts JSONOpts
-}
-
-// JSONOpts contains options that can be used to modify the behaviour when
+// ValueFromJSONOpts contains options that can be used to modify the behaviour when
 // unmarshalling JSON.
-type JSONOpts struct {
+//
+// IgnoreUndefinedAttributes is used to ignore any attributes which appear in the
+// JSON but do not have a corresponding entry in the schema. For example, raw state
+// where an attribute has been removed from the schema.
+type ValueFromJSONOpts struct {
 	IgnoreUndefinedAttributes bool
 }
 
 // ValueFromJSONWithOpts is identical to ValueFromJSON with the exception that it
-// accepts JSONOpts which can be used to modify the unmarshalling behaviour, such
+// accepts ValueFromJSONOpts which can be used to modify the unmarshalling behaviour, such
 // as ignoring undefined attributes, for instance. This can occur when the JSON
 // being unmarshalled does not have a corresponding attribute in the schema.
-func ValueFromJSONWithOpts(data []byte, typ Type, opts JSONOpts) (Value, error) {
+func ValueFromJSONWithOpts(data []byte, typ Type, opts ValueFromJSONOpts) (Value, error) {
 	return jsonUnmarshal(data, typ, NewAttributePath(), opts)
 }
 
@@ -47,7 +44,7 @@ func jsonByteDecoder(buf []byte) *json.Decoder {
 	return dec
 }
 
-func jsonUnmarshal(buf []byte, typ Type, p *AttributePath, opts JSONOpts) (Value, error) {
+func jsonUnmarshal(buf []byte, typ Type, p *AttributePath, opts ValueFromJSONOpts) (Value, error) {
 	dec := jsonByteDecoder(buf)
 
 	tok, err := dec.Token()
@@ -160,7 +157,7 @@ func jsonUnmarshalBool(buf []byte, _ Type, p *AttributePath) (Value, error) {
 	return Value{}, p.NewErrorf("unsupported type %T sent as %s", tok, Bool)
 }
 
-func jsonUnmarshalDynamicPseudoType(buf []byte, _ Type, p *AttributePath, opts JSONOpts) (Value, error) {
+func jsonUnmarshalDynamicPseudoType(buf []byte, _ Type, p *AttributePath, opts ValueFromJSONOpts) (Value, error) {
 	dec := jsonByteDecoder(buf)
 	tok, err := dec.Token()
 	if err != nil {
@@ -213,7 +210,7 @@ func jsonUnmarshalDynamicPseudoType(buf []byte, _ Type, p *AttributePath, opts J
 	return jsonUnmarshal(valBody, t, p, opts)
 }
 
-func jsonUnmarshalList(buf []byte, elementType Type, p *AttributePath, opts JSONOpts) (Value, error) {
+func jsonUnmarshalList(buf []byte, elementType Type, p *AttributePath, opts ValueFromJSONOpts) (Value, error) {
 	dec := jsonByteDecoder(buf)
 
 	tok, err := dec.Token()
@@ -274,7 +271,7 @@ func jsonUnmarshalList(buf []byte, elementType Type, p *AttributePath, opts JSON
 	}, vals), nil
 }
 
-func jsonUnmarshalSet(buf []byte, elementType Type, p *AttributePath, opts JSONOpts) (Value, error) {
+func jsonUnmarshalSet(buf []byte, elementType Type, p *AttributePath, opts ValueFromJSONOpts) (Value, error) {
 	dec := jsonByteDecoder(buf)
 
 	tok, err := dec.Token()
@@ -330,7 +327,7 @@ func jsonUnmarshalSet(buf []byte, elementType Type, p *AttributePath, opts JSONO
 	}, vals), nil
 }
 
-func jsonUnmarshalMap(buf []byte, attrType Type, p *AttributePath, opts JSONOpts) (Value, error) {
+func jsonUnmarshalMap(buf []byte, attrType Type, p *AttributePath, opts ValueFromJSONOpts) (Value, error) {
 	dec := jsonByteDecoder(buf)
 
 	tok, err := dec.Token()
@@ -380,7 +377,7 @@ func jsonUnmarshalMap(buf []byte, attrType Type, p *AttributePath, opts JSONOpts
 	}, vals), nil
 }
 
-func jsonUnmarshalTuple(buf []byte, elementTypes []Type, p *AttributePath, opts JSONOpts) (Value, error) {
+func jsonUnmarshalTuple(buf []byte, elementTypes []Type, p *AttributePath, opts ValueFromJSONOpts) (Value, error) {
 	dec := jsonByteDecoder(buf)
 
 	tok, err := dec.Token()
@@ -444,9 +441,7 @@ func jsonUnmarshalTuple(buf []byte, elementTypes []Type, p *AttributePath, opts 
 
 // jsonUnmarshalObject attempts to decode JSON object structure to tftypes.Value object.
 // opts contains fields that can be used to modify the behaviour of JSON unmarshalling.
-// ignoreUndefinedAttributes is used to ignore any attributes which appear in the JSON but do not have a corresponding
-// entry in the schema. For example, raw state where an attribute has been removed from the schema.
-func jsonUnmarshalObject(buf []byte, attrTypes map[string]Type, p *AttributePath, opts JSONOpts) (Value, error) {
+func jsonUnmarshalObject(buf []byte, attrTypes map[string]Type, p *AttributePath, opts ValueFromJSONOpts) (Value, error) {
 	dec := jsonByteDecoder(buf)
 
 	tok, err := dec.Token()

--- a/tftypes/value_json.go
+++ b/tftypes/value_json.go
@@ -21,11 +21,10 @@ func ValueFromJSON(data []byte, typ Type) (Value, error) {
 
 // ValueFromJSONOpts contains options that can be used to modify the behaviour when
 // unmarshalling JSON.
-//
-// IgnoreUndefinedAttributes is used to ignore any attributes which appear in the
-// JSON but do not have a corresponding entry in the schema. For example, raw state
-// where an attribute has been removed from the schema.
 type ValueFromJSONOpts struct {
+	// IgnoreUndefinedAttributes is used to ignore any attributes which appear in the
+	// JSON but do not have a corresponding entry in the schema. For example, raw state
+	// where an attribute has been removed from the schema.
 	IgnoreUndefinedAttributes bool
 }
 

--- a/tftypes/value_json_test.go
+++ b/tftypes/value_json_test.go
@@ -389,6 +389,24 @@ func TestValueFromJSONWithOpts(t *testing.T) {
 		json  string
 	}
 	tests := map[string]testCase{
+		"object-of-bool-number": {
+			value: NewValue(Object{
+				AttributeTypes: map[string]Type{
+					"bool":   Bool,
+					"number": Number,
+				},
+			}, map[string]Value{
+				"bool":   NewValue(Bool, true),
+				"number": NewValue(Number, big.NewFloat(0)),
+			}),
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"bool":   Bool,
+					"number": Number,
+				},
+			},
+			json: `{"bool":true,"number":0}`,
+		},
 		"object-with-missing-attribute": {
 			value: NewValue(Object{
 				AttributeTypes: map[string]Type{
@@ -412,7 +430,7 @@ func TestValueFromJSONWithOpts(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			val, err := ValueFromJSONWithOpts([]byte(test.json), test.typ, JSONOpts{
+			val, err := ValueFromJSONWithOpts([]byte(test.json), test.typ, ValueFromJSONOpts{
 				IgnoreUndefinedAttributes: true,
 			})
 			if err != nil {

--- a/tftypes/value_json_test.go
+++ b/tftypes/value_json_test.go
@@ -380,3 +380,47 @@ func TestValueFromJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestValueFromJSONWithOpts(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		value Value
+		typ   Type
+		json  string
+	}
+	tests := map[string]testCase{
+		"object-with-missing-attribute": {
+			value: NewValue(Object{
+				AttributeTypes: map[string]Type{
+					"bool":   Bool,
+					"number": Number,
+				},
+			}, map[string]Value{
+				"bool":   NewValue(Bool, true),
+				"number": NewValue(Number, big.NewFloat(0)),
+			}),
+			typ: Object{
+				AttributeTypes: map[string]Type{
+					"bool":   Bool,
+					"number": Number,
+				},
+			},
+			json: `{"bool":true,"number":0,"unknown":"whatever"}`,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			val, err := ValueFromJSONWithOpts([]byte(test.json), test.typ, JSONOpts{
+				IgnoreUndefinedAttributes: true,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error unmarshaling: %s", err)
+			}
+			if diff := cmp.Diff(test.value, val); diff != "" {
+				t.Errorf("Unexpected results (-wanted +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes: #212 

An error is generated when unmarshalling JSON that contains fields that do not have a corresponding attribute.

This PR adds an additional function, `UnmarshalWithOpts` that allows supplying of options that modify unmarshalling behaviour. Specifically, ignoring of undefined attributes is configurable.  