### PR TITLE
ci: added `forcetypeassert` and `misspell` lint rules 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,14 +5,15 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - durationcheck
     - errcheck
     - exportloopref
+    - forcetypeassert
     - gofmt
     - gosimple
     - ineffassign
     - makezero
+    - misspell
     - nilerr
     # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14
     - predeclared
@@ -20,5 +21,5 @@ linters:
     - tenv
     - unconvert
     - unparam
-    - varcheck
+    - unused
     - vet

--- a/tfprotov5/dynamic_value.go
+++ b/tfprotov5/dynamic_value.go
@@ -35,7 +35,7 @@ func NewDynamicValue(t tftypes.Type, v tftypes.Value) (DynamicValue, error) {
 
 // DynamicValue represents a nested encoding value that came from the protocol.
 // The only way providers should ever interact with it is by calling its
-// `Unmarshal` method to retrive a `tftypes.Value`. Although the type system
+// `Unmarshal` method to retrieve a `tftypes.Value`. Although the type system
 // allows for other interactions, they are explicitly not supported, and will
 // not be considered when evaluating for breaking changes. Treat this type as
 // an opaque value, and *only* call its `Unmarshal` method.

--- a/tfprotov6/dynamic_value.go
+++ b/tfprotov6/dynamic_value.go
@@ -35,7 +35,7 @@ func NewDynamicValue(t tftypes.Type, v tftypes.Value) (DynamicValue, error) {
 
 // DynamicValue represents a nested encoding value that came from the protocol.
 // The only way providers should ever interact with it is by calling its
-// `Unmarshal` method to retrive a `tftypes.Value`. Although the type system
+// `Unmarshal` method to retrieve a `tftypes.Value`. Although the type system
 // allows for other interactions, they are explicitly not supported, and will
 // not be considered when evaluating for breaking changes. Treat this type as
 // an opaque value, and *only* call its `Unmarshal` method.

--- a/tftypes/attribute_path.go
+++ b/tftypes/attribute_path.go
@@ -324,17 +324,17 @@ func builtinAttributePathStepper(in interface{}) (AttributePathStepper, bool) {
 type mapStringInterfaceAttributePathStepper map[string]interface{}
 
 func (m mapStringInterfaceAttributePathStepper) ApplyTerraform5AttributePathStep(step AttributePathStep) (interface{}, error) {
-	_, isAttributeName := step.(AttributeName)
-	_, isElementKeyString := step.(ElementKeyString)
+	attributeName, isAttributeName := step.(AttributeName)
+	elementKeyString, isElementKeyString := step.(ElementKeyString)
 	if !isAttributeName && !isElementKeyString {
 		return nil, ErrInvalidStep
 	}
 	var stepValue string
 	if isAttributeName {
-		stepValue = string(step.(AttributeName))
+		stepValue = string(attributeName)
 	}
 	if isElementKeyString {
-		stepValue = string(step.(ElementKeyString))
+		stepValue = string(elementKeyString)
 	}
 	v, ok := m[stepValue]
 	if !ok {

--- a/tftypes/diff.go
+++ b/tftypes/diff.go
@@ -123,6 +123,7 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 		}
 
 		// convert from an interface{} to a Value
+		// TODO: Not sure the best resolution?
 		value2 := value2I.(Value)
 
 		// if they're both unknown, no need to continue

--- a/tftypes/diff.go
+++ b/tftypes/diff.go
@@ -122,9 +122,10 @@ func (val1 Value) Diff(val2 Value) ([]ValueDiff, error) {
 			return true, nil
 		}
 
-		// convert from an interface{} to a Value
-		// TODO: Not sure the best resolution?
-		value2 := value2I.(Value)
+		value2, ok := value2I.(Value)
+		if !ok {
+			return false, fmt.Errorf("unexpected type %T in Diff", value2I)
+		}
 
 		// if they're both unknown, no need to continue
 		if !value1.IsKnown() && !value2.IsKnown() {

--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -540,6 +540,7 @@ func (val Value) IsFullyKnown() bool {
 	case primitive:
 		return true
 	case List, Set, Tuple:
+		//nolint:forcetypeassert // NewValue func validates the type
 		for _, v := range val.value.([]Value) {
 			if !v.IsFullyKnown() {
 				return false
@@ -547,6 +548,7 @@ func (val Value) IsFullyKnown() bool {
 		}
 		return true
 	case Map, Object:
+		//nolint:forcetypeassert // NewValue func validates the type
 		for _, v := range val.value.(map[string]Value) {
 			if !v.IsFullyKnown() {
 				return false

--- a/tftypes/value_json.go
+++ b/tftypes/value_json.go
@@ -65,14 +65,19 @@ func jsonUnmarshal(buf []byte, typ Type, p *AttributePath, opts ValueFromJSONOpt
 	case typ.Is(DynamicPseudoType):
 		return jsonUnmarshalDynamicPseudoType(buf, typ, p, opts)
 	case typ.Is(List{}):
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
 		return jsonUnmarshalList(buf, typ.(List).ElementType, p, opts)
 	case typ.Is(Set{}):
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
 		return jsonUnmarshalSet(buf, typ.(Set).ElementType, p, opts)
 	case typ.Is(Map{}):
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
 		return jsonUnmarshalMap(buf, typ.(Map).ElementType, p, opts)
 	case typ.Is(Tuple{}):
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
 		return jsonUnmarshalTuple(buf, typ.(Tuple).ElementTypes, p, opts)
 	case typ.Is(Object{}):
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
 		return jsonUnmarshalObject(buf, typ.(Object).AttributeTypes, p, opts)
 	}
 	return Value{}, p.NewErrorf("unknown type %s", typ)

--- a/tftypes/value_msgpack.go
+++ b/tftypes/value_msgpack.go
@@ -118,14 +118,19 @@ func msgpackUnmarshal(dec *msgpack.Decoder, typ Type, path *AttributePath) (Valu
 		}
 		return NewValue(Bool, rv), nil
 	case typ.Is(List{}):
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
 		return msgpackUnmarshalList(dec, typ.(List).ElementType, path)
 	case typ.Is(Set{}):
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
 		return msgpackUnmarshalSet(dec, typ.(Set).ElementType, path)
 	case typ.Is(Map{}):
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
 		return msgpackUnmarshalMap(dec, typ.(Map).ElementType, path)
 	case typ.Is(Tuple{}):
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
 		return msgpackUnmarshalTuple(dec, typ.(Tuple).ElementTypes, path)
 	case typ.Is(Object{}):
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
 		return msgpackUnmarshalObject(dec, typ.(Object).AttributeTypes, path)
 	}
 	return Value{}, path.NewErrorf("unsupported type %s", typ.String())

--- a/tftypes/value_msgpack.go
+++ b/tftypes/value_msgpack.go
@@ -369,15 +369,20 @@ func marshalMsgPack(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder)
 	case typ.Is(Bool):
 		return marshalMsgPackBool(val, typ, p, enc)
 	case typ.Is(List{}):
-		return marshalMsgPackList(val, typ, p, enc)
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
+		return marshalMsgPackList(val, typ.(List), p, enc)
 	case typ.Is(Set{}):
-		return marshalMsgPackSet(val, typ, p, enc)
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
+		return marshalMsgPackSet(val, typ.(Set), p, enc)
 	case typ.Is(Map{}):
-		return marshalMsgPackMap(val, typ, p, enc)
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
+		return marshalMsgPackMap(val, typ.(Map), p, enc)
 	case typ.Is(Tuple{}):
-		return marshalMsgPackTuple(val, typ, p, enc)
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
+		return marshalMsgPackTuple(val, typ.(Tuple), p, enc)
 	case typ.Is(Object{}):
-		return marshalMsgPackObject(val, typ, p, enc)
+		//nolint:forcetypeassert // Is func above guarantees this type assertion
+		return marshalMsgPackObject(val, typ.(Object), p, enc)
 	}
 	return fmt.Errorf("unknown type %s", typ)
 }
@@ -464,7 +469,7 @@ func marshalMsgPackBool(val Value, typ Type, p *AttributePath, enc *msgpack.Enco
 	return nil
 }
 
-func marshalMsgPackList(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackList(val Value, typ List, p *AttributePath, enc *msgpack.Encoder) error {
 	l, ok := val.value.([]Value)
 	if !ok {
 		return unexpectedValueTypeError(p, l, val.value, typ)
@@ -474,7 +479,7 @@ func marshalMsgPackList(val Value, typ Type, p *AttributePath, enc *msgpack.Enco
 		return p.NewErrorf("error encoding list length: %w", err)
 	}
 	for pos, i := range l {
-		err := marshalMsgPack(i, typ.(List).ElementType, p.WithElementKeyInt(pos), enc)
+		err := marshalMsgPack(i, typ.ElementType, p.WithElementKeyInt(pos), enc)
 		if err != nil {
 			return err
 		}
@@ -482,7 +487,7 @@ func marshalMsgPackList(val Value, typ Type, p *AttributePath, enc *msgpack.Enco
 	return nil
 }
 
-func marshalMsgPackSet(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackSet(val Value, typ Set, p *AttributePath, enc *msgpack.Encoder) error {
 	s, ok := val.value.([]Value)
 	if !ok {
 		return unexpectedValueTypeError(p, s, val.value, typ)
@@ -492,7 +497,7 @@ func marshalMsgPackSet(val Value, typ Type, p *AttributePath, enc *msgpack.Encod
 		return p.NewErrorf("error encoding set length: %w", err)
 	}
 	for _, i := range s {
-		err := marshalMsgPack(i, typ.(Set).ElementType, p.WithElementKeyValue(i), enc)
+		err := marshalMsgPack(i, typ.ElementType, p.WithElementKeyValue(i), enc)
 		if err != nil {
 			return err
 		}
@@ -500,7 +505,7 @@ func marshalMsgPackSet(val Value, typ Type, p *AttributePath, enc *msgpack.Encod
 	return nil
 }
 
-func marshalMsgPackMap(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackMap(val Value, typ Map, p *AttributePath, enc *msgpack.Encoder) error {
 	m, ok := val.value.(map[string]Value)
 	if !ok {
 		return unexpectedValueTypeError(p, m, val.value, typ)
@@ -514,7 +519,7 @@ func marshalMsgPackMap(val Value, typ Type, p *AttributePath, enc *msgpack.Encod
 		if err != nil {
 			return p.NewErrorf("error encoding map key: %w", err)
 		}
-		err = marshalMsgPack(v, typ.(Map).ElementType, p, enc)
+		err = marshalMsgPack(v, typ.ElementType, p, enc)
 		if err != nil {
 			return err
 		}
@@ -522,12 +527,12 @@ func marshalMsgPackMap(val Value, typ Type, p *AttributePath, enc *msgpack.Encod
 	return nil
 }
 
-func marshalMsgPackTuple(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackTuple(val Value, typ Tuple, p *AttributePath, enc *msgpack.Encoder) error {
 	t, ok := val.value.([]Value)
 	if !ok {
 		return unexpectedValueTypeError(p, t, val.value, typ)
 	}
-	types := typ.(Tuple).ElementTypes
+	types := typ.ElementTypes
 	err := enc.EncodeArrayLen(len(types))
 	if err != nil {
 		return p.NewErrorf("error encoding tuple length: %w", err)
@@ -542,12 +547,12 @@ func marshalMsgPackTuple(val Value, typ Type, p *AttributePath, enc *msgpack.Enc
 	return nil
 }
 
-func marshalMsgPackObject(val Value, typ Type, p *AttributePath, enc *msgpack.Encoder) error {
+func marshalMsgPackObject(val Value, typ Object, p *AttributePath, enc *msgpack.Encoder) error {
 	o, ok := val.value.(map[string]Value)
 	if !ok {
 		return unexpectedValueTypeError(p, o, val.value, typ)
 	}
-	types := typ.(Object).AttributeTypes
+	types := typ.AttributeTypes
 	keys := make([]string, 0, len(types))
 	for k := range types {
 		keys = append(keys, k)


### PR DESCRIPTION
contributes to: https://github.com/hashicorp/terraform-providers-devex-internal/issues/102 + https://github.com/hashicorp/terraform-providers-devex-internal/issues/83

### Notes
- Tried to keep lint ignores consistent for the "type" [switches](https://github.com/hashicorp/terraform-plugin-go/pull/248/files#diff-4d63e5350ff3f5aacb2c53e6d245335b45e121735932a0b5025e14f8587886b8) by keeping them in the statement and not underlying functions
- `deadcode` and `varcheck` linters are deprecated in **golangci-lint** in favor of `unused`
```bash
 $ golangci-lint run
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
```