### PR TITLE
all: Bump minimum Go version to 1.19

### DIFF
--- a/.changes/unreleased/NOTES-20230228-130401.yaml
+++ b/.changes/unreleased/NOTES-20230228-130401.yaml
@@ -1,0 +1,7 @@
+kind: NOTES
+body: 'all: This Go module has been updated to Go 1.19 per the [Go support policy](https://go.dev/doc/devel/release#policy).
+  It is recommended to review the [Go 1.19 release notes](https://go.dev/doc/go1.19)
+  before upgrading. Any consumers building on earlier Go versions may experience errors.'
+time: 2023-02-28T13:04:01.29554-05:00
+custom:
+  Issue: "266"

--- a/.github/workflows/ci-protobuf.yml
+++ b/.github/workflows/ci-protobuf.yml
@@ -37,4 +37,4 @@ jobs:
       - name: git diff
         run: |
           git diff --compact-summary --exit-code || \
-            (echo; echo "Unexpected difference in directories after code generation. Run 'protoc' command and commit."; exit 1)
+            (echo; git diff; echo; echo "Unexpected difference in directories after code generation. Run 'protoc' command and commit."; exit 1)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ is unsupported by the Terraform Plugin SDK team.
 
 This project follows the [support policy](https://golang.org/doc/devel/release.html#policy) of Go as its support policy. The two latest major releases of Go are supported by the project.
 
-Currently, that means Go **1.18** or later must be used when including this project as a dependency.
+Currently, that means Go **1.19** or later must be used when including this project as a dependency.
 
 ## Getting Started
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-plugin-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/tfprotov5/internal/tfplugin5/tfplugin5.pb.go
+++ b/tfprotov5/internal/tfplugin5/tfplugin5.pb.go
@@ -1061,6 +1061,7 @@ type AttributePath_Step struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Selector:
+	//
 	//	*AttributePath_Step_AttributeName
 	//	*AttributePath_Step_ElementKeyString
 	//	*AttributePath_Step_ElementKeyInt
@@ -2486,9 +2487,9 @@ type PlanResourceChange_Response struct {
 	// specific details of the legacy SDK type system, and are not a general
 	// mechanism to avoid proper type handling in providers.
 	//
-	//     ====              DO NOT USE THIS              ====
-	//     ==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
-	//     ====              DO NOT USE THIS              ====
+	//	====              DO NOT USE THIS              ====
+	//	==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
+	//	====              DO NOT USE THIS              ====
 	LegacyTypeSystem bool `protobuf:"varint,5,opt,name=legacy_type_system,json=legacyTypeSystem,proto3" json:"legacy_type_system,omitempty"`
 }
 
@@ -2662,9 +2663,9 @@ type ApplyResourceChange_Response struct {
 	// specific details of the legacy SDK type system, and are not a general
 	// mechanism to avoid proper type handling in providers.
 	//
-	//     ====              DO NOT USE THIS              ====
-	//     ==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
-	//     ====              DO NOT USE THIS              ====
+	//	====              DO NOT USE THIS              ====
+	//	==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
+	//	====              DO NOT USE THIS              ====
 	LegacyTypeSystem bool `protobuf:"varint,4,opt,name=legacy_type_system,json=legacyTypeSystem,proto3" json:"legacy_type_system,omitempty"`
 }
 

--- a/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go
+++ b/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go
@@ -22,21 +22,21 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ProviderClient interface {
-	//////// Information about what a provider supports/expects
+	// ////// Information about what a provider supports/expects
 	GetSchema(ctx context.Context, in *GetProviderSchema_Request, opts ...grpc.CallOption) (*GetProviderSchema_Response, error)
 	PrepareProviderConfig(ctx context.Context, in *PrepareProviderConfig_Request, opts ...grpc.CallOption) (*PrepareProviderConfig_Response, error)
 	ValidateResourceTypeConfig(ctx context.Context, in *ValidateResourceTypeConfig_Request, opts ...grpc.CallOption) (*ValidateResourceTypeConfig_Response, error)
 	ValidateDataSourceConfig(ctx context.Context, in *ValidateDataSourceConfig_Request, opts ...grpc.CallOption) (*ValidateDataSourceConfig_Response, error)
 	UpgradeResourceState(ctx context.Context, in *UpgradeResourceState_Request, opts ...grpc.CallOption) (*UpgradeResourceState_Response, error)
-	//////// One-time initialization, called before other functions below
+	// ////// One-time initialization, called before other functions below
 	Configure(ctx context.Context, in *Configure_Request, opts ...grpc.CallOption) (*Configure_Response, error)
-	//////// Managed Resource Lifecycle
+	// ////// Managed Resource Lifecycle
 	ReadResource(ctx context.Context, in *ReadResource_Request, opts ...grpc.CallOption) (*ReadResource_Response, error)
 	PlanResourceChange(ctx context.Context, in *PlanResourceChange_Request, opts ...grpc.CallOption) (*PlanResourceChange_Response, error)
 	ApplyResourceChange(ctx context.Context, in *ApplyResourceChange_Request, opts ...grpc.CallOption) (*ApplyResourceChange_Response, error)
 	ImportResourceState(ctx context.Context, in *ImportResourceState_Request, opts ...grpc.CallOption) (*ImportResourceState_Response, error)
 	ReadDataSource(ctx context.Context, in *ReadDataSource_Request, opts ...grpc.CallOption) (*ReadDataSource_Response, error)
-	//////// Graceful Shutdown
+	// ////// Graceful Shutdown
 	Stop(ctx context.Context, in *Stop_Request, opts ...grpc.CallOption) (*Stop_Response, error)
 }
 
@@ -160,21 +160,21 @@ func (c *providerClient) Stop(ctx context.Context, in *Stop_Request, opts ...grp
 // All implementations must embed UnimplementedProviderServer
 // for forward compatibility
 type ProviderServer interface {
-	//////// Information about what a provider supports/expects
+	// ////// Information about what a provider supports/expects
 	GetSchema(context.Context, *GetProviderSchema_Request) (*GetProviderSchema_Response, error)
 	PrepareProviderConfig(context.Context, *PrepareProviderConfig_Request) (*PrepareProviderConfig_Response, error)
 	ValidateResourceTypeConfig(context.Context, *ValidateResourceTypeConfig_Request) (*ValidateResourceTypeConfig_Response, error)
 	ValidateDataSourceConfig(context.Context, *ValidateDataSourceConfig_Request) (*ValidateDataSourceConfig_Response, error)
 	UpgradeResourceState(context.Context, *UpgradeResourceState_Request) (*UpgradeResourceState_Response, error)
-	//////// One-time initialization, called before other functions below
+	// ////// One-time initialization, called before other functions below
 	Configure(context.Context, *Configure_Request) (*Configure_Response, error)
-	//////// Managed Resource Lifecycle
+	// ////// Managed Resource Lifecycle
 	ReadResource(context.Context, *ReadResource_Request) (*ReadResource_Response, error)
 	PlanResourceChange(context.Context, *PlanResourceChange_Request) (*PlanResourceChange_Response, error)
 	ApplyResourceChange(context.Context, *ApplyResourceChange_Request) (*ApplyResourceChange_Response, error)
 	ImportResourceState(context.Context, *ImportResourceState_Request) (*ImportResourceState_Response, error)
 	ReadDataSource(context.Context, *ReadDataSource_Request) (*ReadDataSource_Response, error)
-	//////// Graceful Shutdown
+	// ////// Graceful Shutdown
 	Stop(context.Context, *Stop_Request) (*Stop_Response, error)
 	mustEmbedUnimplementedProviderServer()
 }

--- a/tfprotov6/internal/tfplugin6/tfplugin6.pb.go
+++ b/tfprotov6/internal/tfplugin6/tfplugin6.pb.go
@@ -1002,6 +1002,7 @@ type AttributePath_Step struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Selector:
+	//
 	//	*AttributePath_Step_AttributeName
 	//	*AttributePath_Step_ElementKeyString
 	//	*AttributePath_Step_ElementKeyInt
@@ -2505,9 +2506,9 @@ type PlanResourceChange_Response struct {
 	// specific details of the legacy SDK type system, and are not a general
 	// mechanism to avoid proper type handling in providers.
 	//
-	//     ====              DO NOT USE THIS              ====
-	//     ==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
-	//     ====              DO NOT USE THIS              ====
+	//	====              DO NOT USE THIS              ====
+	//	==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
+	//	====              DO NOT USE THIS              ====
 	LegacyTypeSystem bool `protobuf:"varint,5,opt,name=legacy_type_system,json=legacyTypeSystem,proto3" json:"legacy_type_system,omitempty"`
 }
 
@@ -2681,9 +2682,9 @@ type ApplyResourceChange_Response struct {
 	// specific details of the legacy SDK type system, and are not a general
 	// mechanism to avoid proper type handling in providers.
 	//
-	//     ====              DO NOT USE THIS              ====
-	//     ==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
-	//     ====              DO NOT USE THIS              ====
+	//	====              DO NOT USE THIS              ====
+	//	==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
+	//	====              DO NOT USE THIS              ====
 	LegacyTypeSystem bool `protobuf:"varint,4,opt,name=legacy_type_system,json=legacyTypeSystem,proto3" json:"legacy_type_system,omitempty"`
 }
 

--- a/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go
+++ b/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go
@@ -22,21 +22,21 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ProviderClient interface {
-	//////// Information about what a provider supports/expects
+	// ////// Information about what a provider supports/expects
 	GetProviderSchema(ctx context.Context, in *GetProviderSchema_Request, opts ...grpc.CallOption) (*GetProviderSchema_Response, error)
 	ValidateProviderConfig(ctx context.Context, in *ValidateProviderConfig_Request, opts ...grpc.CallOption) (*ValidateProviderConfig_Response, error)
 	ValidateResourceConfig(ctx context.Context, in *ValidateResourceConfig_Request, opts ...grpc.CallOption) (*ValidateResourceConfig_Response, error)
 	ValidateDataResourceConfig(ctx context.Context, in *ValidateDataResourceConfig_Request, opts ...grpc.CallOption) (*ValidateDataResourceConfig_Response, error)
 	UpgradeResourceState(ctx context.Context, in *UpgradeResourceState_Request, opts ...grpc.CallOption) (*UpgradeResourceState_Response, error)
-	//////// One-time initialization, called before other functions below
+	// ////// One-time initialization, called before other functions below
 	ConfigureProvider(ctx context.Context, in *ConfigureProvider_Request, opts ...grpc.CallOption) (*ConfigureProvider_Response, error)
-	//////// Managed Resource Lifecycle
+	// ////// Managed Resource Lifecycle
 	ReadResource(ctx context.Context, in *ReadResource_Request, opts ...grpc.CallOption) (*ReadResource_Response, error)
 	PlanResourceChange(ctx context.Context, in *PlanResourceChange_Request, opts ...grpc.CallOption) (*PlanResourceChange_Response, error)
 	ApplyResourceChange(ctx context.Context, in *ApplyResourceChange_Request, opts ...grpc.CallOption) (*ApplyResourceChange_Response, error)
 	ImportResourceState(ctx context.Context, in *ImportResourceState_Request, opts ...grpc.CallOption) (*ImportResourceState_Response, error)
 	ReadDataSource(ctx context.Context, in *ReadDataSource_Request, opts ...grpc.CallOption) (*ReadDataSource_Response, error)
-	//////// Graceful Shutdown
+	// ////// Graceful Shutdown
 	StopProvider(ctx context.Context, in *StopProvider_Request, opts ...grpc.CallOption) (*StopProvider_Response, error)
 }
 
@@ -160,21 +160,21 @@ func (c *providerClient) StopProvider(ctx context.Context, in *StopProvider_Requ
 // All implementations must embed UnimplementedProviderServer
 // for forward compatibility
 type ProviderServer interface {
-	//////// Information about what a provider supports/expects
+	// ////// Information about what a provider supports/expects
 	GetProviderSchema(context.Context, *GetProviderSchema_Request) (*GetProviderSchema_Response, error)
 	ValidateProviderConfig(context.Context, *ValidateProviderConfig_Request) (*ValidateProviderConfig_Response, error)
 	ValidateResourceConfig(context.Context, *ValidateResourceConfig_Request) (*ValidateResourceConfig_Response, error)
 	ValidateDataResourceConfig(context.Context, *ValidateDataResourceConfig_Request) (*ValidateDataResourceConfig_Response, error)
 	UpgradeResourceState(context.Context, *UpgradeResourceState_Request) (*UpgradeResourceState_Response, error)
-	//////// One-time initialization, called before other functions below
+	// ////// One-time initialization, called before other functions below
 	ConfigureProvider(context.Context, *ConfigureProvider_Request) (*ConfigureProvider_Response, error)
-	//////// Managed Resource Lifecycle
+	// ////// Managed Resource Lifecycle
 	ReadResource(context.Context, *ReadResource_Request) (*ReadResource_Response, error)
 	PlanResourceChange(context.Context, *PlanResourceChange_Request) (*PlanResourceChange_Response, error)
 	ApplyResourceChange(context.Context, *ApplyResourceChange_Request) (*ApplyResourceChange_Response, error)
 	ImportResourceState(context.Context, *ImportResourceState_Request) (*ImportResourceState_Response, error)
 	ReadDataSource(context.Context, *ReadDataSource_Request) (*ReadDataSource_Response, error)
-	//////// Graceful Shutdown
+	// ////// Graceful Shutdown
 	StopProvider(context.Context, *StopProvider_Request) (*StopProvider_Response, error)
 	mustEmbedUnimplementedProviderServer()
 }


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-go/issues/265

Bumped via:

```shell
go mod edit -go=1.19
go mod tidy
go fix ./...
```
