### PR TITLE
tftypes: Reduce AttributePath and Value type compute and memory usage

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230630-103655.yaml
+++ b/.changes/unreleased/BUG FIXES-20230630-103655.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'tftypes: Significantly reduced compute and memory usage of `Value` type
+  walking and transformation'
+time: 2023-06-30T10:36:55.119505-04:00
+custom:
+  Issue: "307"

--- a/.changes/unreleased/BUG FIXES-20230630-144701.yaml
+++ b/.changes/unreleased/BUG FIXES-20230630-144701.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'tftypes: Removed unnecessary memory allocations from `AttributePath` type
+  `Equal()`, `LastStep()`, and `WithoutLastStep()` methods'
+time: 2023-06-30T14:47:01.127283-04:00
+custom:
+  Issue: "307"

--- a/.changes/unreleased/BUG FIXES-20230630-144945.yaml
+++ b/.changes/unreleased/BUG FIXES-20230630-144945.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'tftypes: Removed unnecessary memory allocations from `NewValue()` function'
+time: 2023-06-30T14:49:45.828209-04:00
+custom:
+  Issue: "307"

--- a/.changes/unreleased/ENHANCEMENTS-20230630-143817.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230630-143817.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'tftypes: Added `AttributePath` type `NextStep()` method, which returns the
+  next step in the path without first copying via `Steps()`'
+time: 2023-06-30T14:38:17.600608-04:00
+custom:
+  Issue: "307"

--- a/tftypes/attribute_path.go
+++ b/tftypes/attribute_path.go
@@ -80,14 +80,20 @@ func (a *AttributePath) String() string {
 // AttributePaths are considered equal if they have the same number of steps,
 // the steps are all the same types, and the steps have all the same values.
 func (a *AttributePath) Equal(o *AttributePath) bool {
-	if len(a.Steps()) == 0 && len(o.Steps()) == 0 {
-		return true
+	if a == nil {
+		return o == nil || len(o.steps) == 0
 	}
-	if len(a.Steps()) != len(o.Steps()) {
+
+	if o == nil {
+		return len(a.steps) == 0
+	}
+
+	if len(a.steps) != len(o.steps) {
 		return false
 	}
-	for pos, aStep := range a.Steps() {
-		oStep := o.Steps()[pos]
+
+	for pos, aStep := range a.steps {
+		oStep := o.steps[pos]
 
 		if !aStep.Equal(oStep) {
 			return false
@@ -120,63 +126,112 @@ func (a *AttributePath) NewError(err error) error {
 	}
 }
 
-// LastStep returns the last step in the path. If the path was
-// empty, nil is returned.
+// LastStep returns the last step in the path. If the path is nil or empty, nil
+// is returned.
 func (a *AttributePath) LastStep() AttributePathStep {
-	steps := a.Steps()
-
-	if len(steps) == 0 {
+	if a == nil || len(a.steps) == 0 {
 		return nil
 	}
 
-	return steps[len(steps)-1]
+	return a.steps[len(a.steps)-1]
+}
+
+// NextStep returns the next step in the path. If the path is nil or empty, nil
+// is returned.
+func (a *AttributePath) NextStep() AttributePathStep {
+	if a == nil || len(a.steps) == 0 {
+		return nil
+	}
+
+	return a.steps[0]
 }
 
 // WithAttributeName adds an AttributeName step to `a`, using `name` as the
 // attribute's name. `a` is copied, not modified.
 func (a *AttributePath) WithAttributeName(name string) *AttributePath {
-	steps := a.Steps()
+	if a == nil {
+		return &AttributePath{
+			steps: []AttributePathStep{AttributeName(name)},
+		}
+	}
+
+	// Avoid re-allocating larger slice
+	steps := make([]AttributePathStep, len(a.steps)+1)
+	copy(steps, a.steps)
+	steps[len(steps)-1] = AttributeName(name)
+
 	return &AttributePath{
-		steps: append(steps, AttributeName(name)),
+		steps: steps,
 	}
 }
 
 // WithElementKeyString adds an ElementKeyString step to `a`, using `key` as
 // the element's key. `a` is copied, not modified.
 func (a *AttributePath) WithElementKeyString(key string) *AttributePath {
-	steps := a.Steps()
+	if a == nil {
+		return &AttributePath{
+			steps: []AttributePathStep{ElementKeyString(key)},
+		}
+	}
+
+	// Avoid re-allocating larger slice
+	steps := make([]AttributePathStep, len(a.steps)+1)
+	copy(steps, a.steps)
+	steps[len(steps)-1] = ElementKeyString(key)
+
 	return &AttributePath{
-		steps: append(steps, ElementKeyString(key)),
+		steps: steps,
 	}
 }
 
 // WithElementKeyInt adds an ElementKeyInt step to `a`, using `key` as the
 // element's key. `a` is copied, not modified.
 func (a *AttributePath) WithElementKeyInt(key int) *AttributePath {
-	steps := a.Steps()
+	if a == nil {
+		return &AttributePath{
+			steps: []AttributePathStep{ElementKeyInt(key)},
+		}
+	}
+
+	// Avoid re-allocating larger slice
+	steps := make([]AttributePathStep, len(a.steps)+1)
+	copy(steps, a.steps)
+	steps[len(steps)-1] = ElementKeyInt(key)
+
 	return &AttributePath{
-		steps: append(steps, ElementKeyInt(key)),
+		steps: steps,
 	}
 }
 
 // WithElementKeyValue adds an ElementKeyValue to `a`, using `key` as the
 // element's key. `a` is copied, not modified.
 func (a *AttributePath) WithElementKeyValue(key Value) *AttributePath {
-	steps := a.Steps()
+	if a == nil {
+		return &AttributePath{
+			steps: []AttributePathStep{ElementKeyValue(key)},
+		}
+	}
+
+	// Avoid re-allocating larger slice
+	steps := make([]AttributePathStep, len(a.steps)+1)
+	copy(steps, a.steps)
+	steps[len(steps)-1] = ElementKeyValue(key)
+
 	return &AttributePath{
-		steps: append(steps, ElementKeyValue(key.Copy())),
+		steps: steps,
 	}
 }
 
 // WithoutLastStep removes the last step, whatever kind of step it was, from
 // `a`. `a` is copied, not modified.
 func (a *AttributePath) WithoutLastStep() *AttributePath {
-	steps := a.Steps()
-	if len(steps) == 0 {
+	if a == nil || len(a.steps) == 0 {
 		return nil
 	}
+
 	return &AttributePath{
-		steps: steps[:len(steps)-1],
+		// Paths are immutable, so this should be safe without copying.
+		steps: a.steps[:len(a.steps)-1],
 	}
 }
 
@@ -296,7 +351,7 @@ type AttributePathStepper interface {
 // types need to use the AttributePathStepper interface to tell
 // WalkAttributePath how to traverse themselves.
 func WalkAttributePath(in interface{}, path *AttributePath) (interface{}, *AttributePath, error) {
-	if len(path.Steps()) < 1 {
+	if path == nil || len(path.steps) == 0 {
 		return in, path, nil
 	}
 	stepper, ok := in.(AttributePathStepper)
@@ -306,11 +361,11 @@ func WalkAttributePath(in interface{}, path *AttributePath) (interface{}, *Attri
 			return in, path, ErrNotAttributePathStepper
 		}
 	}
-	next, err := stepper.ApplyTerraform5AttributePathStep(path.Steps()[0])
+	next, err := stepper.ApplyTerraform5AttributePathStep(path.NextStep())
 	if err != nil {
 		return in, path, err
 	}
-	return WalkAttributePath(next, &AttributePath{steps: path.Steps()[1:]})
+	return WalkAttributePath(next, NewAttributePathWithSteps(path.steps[1:]))
 }
 
 func builtinAttributePathStepper(in interface{}) (AttributePathStepper, bool) {

--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -134,15 +134,17 @@ func (val Value) ApplyTerraform5AttributePathStep(step AttributePathStep) (inter
 	if !val.IsKnown() || val.IsNull() {
 		return nil, ErrInvalidStep
 	}
+
+	// Since this logic is very hot path, it is optimized to use Value
+	// implementation details rather than As() to avoid memory allocations.
 	switch s := step.(type) {
 	case AttributeName:
-		if !val.Type().Is(Object{}) {
+		if _, ok := val.Type().(Object); !ok {
 			return nil, ErrInvalidStep
 		}
-		o := map[string]Value{}
-		err := val.As(&o)
-		if err != nil {
-			return nil, err
+		o, ok := val.value.(map[string]Value)
+		if !ok {
+			return nil, fmt.Errorf("cannot convert %T into map[string]tftypes.Value", val.value)
 		}
 		res, ok := o[string(s)]
 		if !ok {
@@ -150,13 +152,12 @@ func (val Value) ApplyTerraform5AttributePathStep(step AttributePathStep) (inter
 		}
 		return res, nil
 	case ElementKeyString:
-		if !val.Type().Is(Map{}) {
+		if _, ok := val.Type().(Map); !ok {
 			return nil, ErrInvalidStep
 		}
-		m := map[string]Value{}
-		err := val.As(&m)
-		if err != nil {
-			return nil, err
+		m, ok := val.value.(map[string]Value)
+		if !ok {
+			return nil, fmt.Errorf("cannot convert %T into map[string]tftypes.Value", val.value)
 		}
 		res, ok := m[string(s)]
 		if !ok {
@@ -164,36 +165,37 @@ func (val Value) ApplyTerraform5AttributePathStep(step AttributePathStep) (inter
 		}
 		return res, nil
 	case ElementKeyInt:
-		if !val.Type().Is(List{}) && !val.Type().Is(Tuple{}) {
+		_, listOk := val.Type().(List)
+		_, tupleOk := val.Type().(Tuple)
+		if !listOk && !tupleOk {
 			return nil, ErrInvalidStep
 		}
 		if int64(s) < 0 {
 			return nil, ErrInvalidStep
 		}
-		sl := []Value{}
-		err := val.As(&sl)
-		if err != nil {
-			return nil, err
+		sl, ok := val.value.([]Value)
+		if !ok {
+			return nil, fmt.Errorf("cannot convert %T into []tftypes.Value", val.value)
 		}
 		if int64(len(sl)) <= int64(s) {
 			return nil, ErrInvalidStep
 		}
 		return sl[int64(s)], nil
 	case ElementKeyValue:
-		if !val.Type().Is(Set{}) {
+		if _, ok := val.Type().(Set); !ok {
 			return nil, ErrInvalidStep
 		}
-		sl := []Value{}
-		err := val.As(&sl)
-		if err != nil {
-			return nil, err
+		sl, ok := val.value.([]Value)
+		if !ok {
+			return nil, fmt.Errorf("cannot convert %T into []tftypes.Value", val.value)
 		}
+		stepValue := Value(s)
 		for _, el := range sl {
-			diffs, err := el.Diff(Value(s))
+			deepEqual, err := stepValue.deepEqual(el)
 			if err != nil {
 				return nil, err
 			}
-			if len(diffs) == 0 {
+			if deepEqual {
 				return el, nil
 			}
 		}
@@ -219,11 +221,11 @@ func (val Value) Equal(o Value) bool {
 	if !val.Type().Equal(o.Type()) {
 		return false
 	}
-	diff, err := val.Diff(o)
+	deepEqual, err := val.deepEqual(o)
 	if err != nil {
 		panic(err)
 	}
-	return len(diff) < 1
+	return deepEqual
 }
 
 // Copy returns a defensively-copied clone of Value that shares no underlying
@@ -302,57 +304,62 @@ func newValue(t Type, val interface{}) (Value, error) {
 		}
 	}
 
-	switch {
-	case t.Is(String):
-		v, err := valueFromString(val)
+	switch typ := t.(type) {
+	case primitive:
+		switch typ.name {
+		case String.name:
+			v, err := valueFromString(val)
+			if err != nil {
+				return Value{}, err
+			}
+			return v, nil
+		case Number.name:
+			v, err := valueFromNumber(val)
+			if err != nil {
+				return Value{}, err
+			}
+			return v, nil
+		case Bool.name:
+			v, err := valueFromBool(val)
+			if err != nil {
+				return Value{}, err
+			}
+			return v, nil
+		case DynamicPseudoType.name:
+			v, err := valueFromDynamicPseudoType(val)
+			if err != nil {
+				return Value{}, err
+			}
+			return v, nil
+		default:
+			return Value{}, fmt.Errorf("unknown primitive type %v passed to tftypes.NewValue", typ)
+		}
+	case Map:
+		v, err := valueFromMap(typ.ElementType, val)
 		if err != nil {
 			return Value{}, err
 		}
 		return v, nil
-	case t.Is(Number):
-		v, err := valueFromNumber(val)
+	case Object:
+		v, err := valueFromObject(typ.AttributeTypes, typ.OptionalAttributes, val)
 		if err != nil {
 			return Value{}, err
 		}
 		return v, nil
-	case t.Is(Bool):
-		v, err := valueFromBool(val)
+	case List:
+		v, err := valueFromList(typ.ElementType, val)
 		if err != nil {
 			return Value{}, err
 		}
 		return v, nil
-	case t.Is(Map{}):
-		v, err := valueFromMap(t.(Map).ElementType, val)
+	case Set:
+		v, err := valueFromSet(typ.ElementType, val)
 		if err != nil {
 			return Value{}, err
 		}
 		return v, nil
-	case t.Is(Object{}):
-		v, err := valueFromObject(t.(Object).AttributeTypes, t.(Object).OptionalAttributes, val)
-		if err != nil {
-			return Value{}, err
-		}
-		return v, nil
-	case t.Is(List{}):
-		v, err := valueFromList(t.(List).ElementType, val)
-		if err != nil {
-			return Value{}, err
-		}
-		return v, nil
-	case t.Is(Set{}):
-		v, err := valueFromSet(t.(Set).ElementType, val)
-		if err != nil {
-			return Value{}, err
-		}
-		return v, nil
-	case t.Is(Tuple{}):
-		v, err := valueFromTuple(t.(Tuple).ElementTypes, val)
-		if err != nil {
-			return Value{}, err
-		}
-		return v, nil
-	case t.Is(DynamicPseudoType):
-		v, err := valueFromDynamicPseudoType(val)
+	case Tuple:
+		v, err := valueFromTuple(typ.ElementTypes, val)
 		if err != nil {
 			return Value{}, err
 		}

--- a/tftypes/value_benchmark_test.go
+++ b/tftypes/value_benchmark_test.go
@@ -1,0 +1,50 @@
+package tftypes
+
+import "testing"
+
+func BenchmarkValueApplyTerraform5AttributePathStep1000(b *testing.B) {
+	benchmarkValueApplyTerraform5AttributePathStep(b, 1000)
+}
+
+// This benchmark iterates through an entire set of objects, which is one of the
+// most expensive, but common, use cases.
+func benchmarkValueApplyTerraform5AttributePathStep(b *testing.B, elements int) {
+	// Set of objects is one of the most expensive operations
+	objectType := Object{
+		AttributeTypes: map[string]Type{
+			"element_index": Number, // guaranteed to be different each element
+			"test_string":   String,
+		},
+	}
+	setType := Set{
+		ElementType: objectType,
+	}
+
+	setElements := make([]Value, elements)
+
+	for index := range setElements {
+		setElements[index] = NewValue(
+			objectType,
+			map[string]Value{
+				"element_index": NewValue(Number, index),
+				"test_string":   NewValue(String, "test value"),
+			},
+		)
+	}
+
+	value := NewValue(
+		setType,
+		setElements,
+	)
+
+	// ensure iteration occurs through whole set
+	step := ElementKeyValue(setElements[elements-1].Copy())
+
+	for n := 0; n < b.N; n++ {
+		_, err := value.ApplyTerraform5AttributePathStep(step)
+
+		if err != nil {
+			b.Fatalf("unexpected ApplyTerraform5AttributePathStep error: %s", err)
+		}
+	}
+}

--- a/tftypes/value_benchmark_test.go
+++ b/tftypes/value_benchmark_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tftypes
 
 import "testing"

--- a/tftypes/value_equal.go
+++ b/tftypes/value_equal.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tftypes
 
 import (

--- a/tftypes/value_equal.go
+++ b/tftypes/value_equal.go
@@ -1,0 +1,210 @@
+package tftypes
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+// deepEqual walks both Value to ensure any underlying Value are equal. This
+// logic is essentially a duplicate of Diff, however it is intended to return
+// early on any inequality and avoids memory allocations where possible.
+//
+// There might be ways to better share the internal logic of this method with
+// Diff, however that effort is reserved for a time when the effort is justified
+// over resolving the inherent compute and memory performance issues with Diff
+// when only checking for inequality.
+func (val1 Value) deepEqual(val2 Value) (bool, error) {
+	if val1.Type() == nil && val2.Type() == nil && val1.value == nil && val2.value == nil {
+		return false, nil
+	}
+
+	if (val1.Type() == nil && val2.Type() != nil) || (val1.Type() != nil && val2.Type() == nil) {
+		return false, errors.New("cannot diff value missing type")
+	}
+
+	if !val1.Type().Is(val2.Type()) {
+		return false, errors.New("Can't diff values of different types")
+	}
+
+	// Capture walk differences for returning early
+	var hasDiff bool
+
+	// make sure everything in val2 is also in val1
+	err := Walk(val2, func(path *AttributePath, _ Value) (bool, error) {
+		_, _, err := val1.walkAttributePath(path)
+
+		if err != nil && err != ErrInvalidStep {
+			return false, fmt.Errorf("Error walking %q: %w", path, err)
+		} else if err == ErrInvalidStep {
+			hasDiff = true
+
+			return false, stopWalkError
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	if hasDiff {
+		return false, nil
+	}
+
+	// make sure everything in val1 is also in val2 and also that it all matches
+	err = Walk(val1, func(path *AttributePath, value1 Value) (bool, error) {
+		// pull out the Value at the same path in val2
+		value2, _, err := val2.walkAttributePath(path)
+
+		if err != nil && err != ErrInvalidStep {
+			return false, fmt.Errorf("Error walking %q: %w", path, err)
+		} else if err == ErrInvalidStep {
+			hasDiff = true
+
+			return false, stopWalkError
+		}
+
+		// if they're both unknown, no need to continue
+		if !value1.IsKnown() && !value2.IsKnown() {
+			return false, nil
+		}
+
+		if value1.IsKnown() != value2.IsKnown() {
+			hasDiff = true
+
+			return false, stopWalkError
+		}
+
+		// if they're both null, no need to continue
+		if value1.IsNull() && value2.IsNull() {
+			return false, nil
+		}
+
+		if value1.IsNull() != value2.IsNull() {
+			hasDiff = true
+
+			return false, stopWalkError
+		}
+
+		// We know there are known, non-null values, time to compare them.
+		// Since this logic is very hot path, it is optimized to use type and
+		// value implementation details rather than Equal() and As()
+		// respectively, since both result in memory allocations.
+		switch typ := value1.Type().(type) {
+		case primitive:
+			switch typ.name {
+			case String.name:
+				s1, ok := value1.value.(string)
+
+				if !ok {
+					return false, fmt.Errorf("cannot convert %T into string", value1.value)
+				}
+
+				s2, ok := value2.value.(string)
+
+				if !ok {
+					return false, fmt.Errorf("cannot convert %T into string", value2.value)
+				}
+
+				if s1 != s2 {
+					hasDiff = true
+
+					return false, stopWalkError
+				}
+			case Number.name:
+				n1, ok := value1.value.(*big.Float)
+
+				if !ok {
+					return false, fmt.Errorf("cannot convert %T into *big.Float", value1.value)
+				}
+
+				n2, ok := value2.value.(*big.Float)
+
+				if !ok {
+					return false, fmt.Errorf("cannot convert %T into *big.Float", value2.value)
+				}
+
+				if n1.Cmp(n2) != 0 {
+					hasDiff = true
+
+					return false, stopWalkError
+				}
+			case Bool.name:
+				b1, ok := value1.value.(bool)
+
+				if !ok {
+					return false, fmt.Errorf("cannot convert %T into bool", value1.value)
+				}
+
+				b2, ok := value2.value.(bool)
+
+				if !ok {
+					return false, fmt.Errorf("cannot convert %T into bool", value2.value)
+				}
+
+				if b1 != b2 {
+					hasDiff = true
+
+					return false, stopWalkError
+				}
+			case DynamicPseudoType.name:
+				// Let recursion from the walk check the sub-values match
+				return true, nil
+			}
+
+			return false, nil
+		case List, Set, Tuple:
+			s1, ok := value1.value.([]Value)
+
+			if !ok {
+				return false, fmt.Errorf("cannot convert %T into []tftypes.Value", value1.value)
+			}
+
+			s2, ok := value2.value.([]Value)
+
+			if !ok {
+				return false, fmt.Errorf("cannot convert %T into []tftypes.Value", value2.value)
+			}
+
+			// we only care about if the lengths match for lists,
+			// sets, and tuples. If any of the elements differ,
+			// the recursion of the walk will find them for us.
+			if len(s1) != len(s2) {
+				hasDiff = true
+
+				return false, stopWalkError
+			}
+
+			return true, nil
+		case Map, Object:
+			m1, ok := value1.value.(map[string]Value)
+
+			if !ok {
+				return false, fmt.Errorf("cannot convert %T into map[string]tftypes.Value", value1.value)
+			}
+
+			m2, ok := value2.value.(map[string]Value)
+
+			if !ok {
+				return false, fmt.Errorf("cannot convert %T into map[string]tftypes.Value", value2.value)
+			}
+
+			// we only care about if the number of keys match for maps and
+			// objects. If any of the elements differ, the recursion of the walk
+			// will find them for us.
+			if len(m1) != len(m2) {
+				hasDiff = true
+
+				return false, stopWalkError
+			}
+
+			return true, nil
+		}
+
+		return false, fmt.Errorf("unexpected type %v in Diff at %s", value1.Type(), path)
+	})
+
+	return !hasDiff, err
+}

--- a/tftypes/value_walk.go
+++ b/tftypes/value_walk.go
@@ -1,0 +1,30 @@
+package tftypes
+
+import "fmt"
+
+// walkAttributePath will return the Value that `path` is pointing to within the
+// Value. If an error is returned, the AttributePath returned will indicate
+// will indicate the steps that remained to be applied when the error was
+// encountered.
+//
+// This implementation, along with one for Type, could be exported to deprecate
+// the overly generic WalkAttributePath function.
+func (v Value) walkAttributePath(path *AttributePath) (Value, *AttributePath, error) {
+	if path == nil || len(path.steps) == 0 {
+		return v, path, nil
+	}
+
+	nextValueI, err := v.ApplyTerraform5AttributePathStep(path.NextStep())
+
+	if err != nil {
+		return Value{}, path, err
+	}
+
+	nextValue, ok := nextValueI.(Value)
+
+	if !ok {
+		return Value{}, path, fmt.Errorf("unknown type %T returned from tftypes.ApplyTerraform5AttributePathStep", nextValueI)
+	}
+
+	return nextValue.walkAttributePath(NewAttributePathWithSteps(path.steps[1:]))
+}

--- a/tftypes/value_walk.go
+++ b/tftypes/value_walk.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tftypes
 
 import "fmt"

--- a/tftypes/walk_benchmark_test.go
+++ b/tftypes/walk_benchmark_test.go
@@ -1,0 +1,52 @@
+package tftypes
+
+import "testing"
+
+func BenchmarkTransform1000(b *testing.B) {
+	benchmarkTransform(b, 1000)
+}
+
+// This benchmark iterates through an entire set of objects, which is one of the
+// most expensive, but common, use cases.
+func benchmarkTransform(b *testing.B, elements int) {
+	// Set of objects is one of the most expensive operations
+	objectType := Object{
+		AttributeTypes: map[string]Type{
+			"element_index": Number, // guaranteed to be different each element
+			"test_string":   String,
+		},
+	}
+	setType := Set{
+		ElementType: objectType,
+	}
+
+	setElements := make([]Value, elements)
+
+	for index := range setElements {
+		setElements[index] = NewValue(
+			objectType,
+			map[string]Value{
+				"element_index": NewValue(Number, index),
+				"test_string":   NewValue(String, "test value"),
+			},
+		)
+	}
+
+	value := NewValue(
+		setType,
+		setElements,
+	)
+
+	for n := 0; n < b.N; n++ {
+		_, err := Transform(
+			value,
+			func(_ *AttributePath, value Value) (Value, error) {
+				return value, nil
+			},
+		)
+
+		if err != nil {
+			b.Fatalf("unexpected Transform error: %s", err)
+		}
+	}
+}

--- a/tftypes/walk_benchmark_test.go
+++ b/tftypes/walk_benchmark_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tftypes
 
 import "testing"


### PR DESCRIPTION
Closes #307

These optimizations were performed by adding benchmark tests against a set of 1000 "simple" objects and viewing the cpu/memory profiles. The original implementations were spending an immense amount of time dealing with memory allocations and garbage collection, so reducing memory allocations was the main target of these optimizations, which in turn, also reduced compute time.

The largest changes were accomplished by removing `(Value).Diff()` from the logic paths which were only testing equality. The new `(Value).deepEqual()` implementation started as a duplicate of that logic, removing all `ValueDiff` allocations. Then, the walking of `Value` needed a methodology to stop the walk immediately to prevent further allocations. The two changes in that regard were introducing a `stopWalkError` sentinel error type for which callback functions can signal that no remaining `Value` are necessary to traverse and updating the internal `walk()` implementation to include a new bool return to fully accomplish the intended behavior.

The other changes were smaller optimizations noticed from the profiling, such as avoiding the Go runtime immediately reallocating a larger slice with the `AttributePath` methods, avoiding memory allocations caused by `(Type).Is()` usage instead of using type switches, and directly referencing `List`, `Map`, `Object`, `Set`, and `Tuple` value storage instead of allocating an unneeded variable. This logic is heavily used both by this Go module and others, so even these minor optimizations have impact at scale.

`benchstat` differences between prior implementation and proposed changes:

```
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/terraform-plugin-go/tftypes
                                             │   original   │              proposed               │
                                             │    sec/op    │   sec/op     vs base                │
Transform1000-10                               2886.1µ ± 0%   924.6µ ± 0%  -67.96% (p=0.000 n=10)
ValueApplyTerraform5AttributePathStep1000-10   3863.4µ ± 1%   628.9µ ± 0%  -83.72% (p=0.000 n=10)
geomean                                         3.339m        762.5µ       -77.16%

                                             │   original    │               proposed               │
                                             │     B/op      │     B/op      vs base                │
Transform1000-10                               3137.3Ki ± 0%   837.6Ki ± 0%  -73.30% (p=0.000 n=10)
ValueApplyTerraform5AttributePathStep1000-10   3887.1Ki ± 0%   389.3Ki ± 0%  -89.98% (p=0.000 n=10)
geomean                                         3.410Mi        571.0Ki       -83.65%

                                             │   original   │              proposed               │
                                             │  allocs/op   │  allocs/op   vs base                │
Transform1000-10                                61.07k ± 0%   14.02k ± 0%  -77.05% (p=0.000 n=10)
ValueApplyTerraform5AttributePathStep1000-10   123.07k ± 0%   17.64k ± 0%  -85.67% (p=0.000 n=10)
geomean                                         86.69k        15.72k       -81.86%
```