### PR TITLE
tfprotov5+tfprotov6: Require FunctionServer in ProviderServer

### DIFF
--- a/.changes/unreleased/BREAKING CHANGES-20231214-105454.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-20231214-105454.yaml
@@ -1,0 +1,8 @@
+kind: BREAKING CHANGES
+body: 'tfprotov5+tfprotov6: The `ProviderServer` interface now requires the `FunctionServer`
+  interface. Before upgrading this Go module, ensure you are depending on at least
+  terraform-plugin-framework v1.5.0, terraform-plugin-mux v0.13.0, and
+  terraform-plugin-sdk/v2 v2.31.0.'
+time: 2023-12-14T10:54:54.463017-05:00
+custom:
+  Issue: "353"

--- a/tfprotov5/provider.go
+++ b/tfprotov5/provider.go
@@ -53,10 +53,7 @@ type ProviderServer interface {
 	// are a handy interface for defining what a function is to
 	// terraform-plugin-go, so they are their own interface that is composed
 	// into ProviderServer.
-	//
-	// This will be required in an upcoming release.
-	// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/353
-	// FunctionServer
+	FunctionServer
 }
 
 // GetMetadataRequest represents a GetMetadata RPC request.

--- a/tfprotov6/provider.go
+++ b/tfprotov6/provider.go
@@ -53,10 +53,7 @@ type ProviderServer interface {
 	// are a handy interface for defining what a function is to
 	// terraform-plugin-go, so they are their own interface that is composed
 	// into ProviderServer.
-	//
-	// This will be required in an upcoming release.
-	// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/353
-	// FunctionServer
+	FunctionServer
 }
 
 // GetMetadataRequest represents a GetMetadata RPC request.

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -910,28 +910,6 @@ func (s *server) CallFunction(ctx context.Context, protoReq *tfplugin6.CallFunct
 	logging.ProtocolTrace(ctx, "Received request")
 	defer logging.ProtocolTrace(ctx, "Served request")
 
-	// Remove this check and error in preference of s.downstream.CallFunction
-	// below once ProviderServer interface requires FunctionServer.
-	// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/353
-	functionServer, ok := s.downstream.(tfprotov6.FunctionServer)
-
-	if !ok {
-		logging.ProtocolError(ctx, "ProviderServer does not implement FunctionServer")
-
-		protoResp := &tfplugin6.CallFunction_Response{
-			Diagnostics: []*tfplugin6.Diagnostic{
-				{
-					Severity: tfplugin6.Diagnostic_ERROR,
-					Summary:  "Provider Functions Not Implemented",
-					Detail: "A provider-defined function call was received by the provider, however the provider does not implement functions. " +
-						"Either upgrade the provider to a version that implements provider-defined functions or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return protoResp, nil
-	}
-
 	req, err := fromproto.CallFunctionRequest(protoReq)
 
 	if err != nil {
@@ -946,9 +924,7 @@ func (s *server) CallFunction(ctx context.Context, protoReq *tfplugin6.CallFunct
 
 	ctx = tf6serverlogging.DownstreamRequest(ctx)
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/353
-	// resp, err := s.downstream.CallFunction(ctx, req)
-	resp, err := functionServer.CallFunction(ctx, req)
+	resp, err := s.downstream.CallFunction(ctx, req)
 
 	if err != nil {
 		logging.ProtocolError(ctx, "Error from downstream", map[string]any{logging.KeyError: err})
@@ -976,21 +952,6 @@ func (s *server) GetFunctions(ctx context.Context, protoReq *tfplugin6.GetFuncti
 	logging.ProtocolTrace(ctx, "Received request")
 	defer logging.ProtocolTrace(ctx, "Served request")
 
-	// Remove this check and response in preference of s.downstream.GetFunctions
-	// below once ProviderServer interface requires FunctionServer.
-	// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/353
-	functionServer, ok := s.downstream.(tfprotov6.FunctionServer)
-
-	if !ok {
-		logging.ProtocolWarn(ctx, "ProviderServer does not implement FunctionServer")
-
-		protoResp := &tfplugin6.GetFunctions_Response{
-			Functions: map[string]*tfplugin6.Function{},
-		}
-
-		return protoResp, nil
-	}
-
 	req, err := fromproto.GetFunctionsRequest(protoReq)
 
 	if err != nil {
@@ -1001,9 +962,7 @@ func (s *server) GetFunctions(ctx context.Context, protoReq *tfplugin6.GetFuncti
 
 	ctx = tf6serverlogging.DownstreamRequest(ctx)
 
-	// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/353
-	// resp, err := s.downstream.GetFunctions(ctx, req)
-	resp, err := functionServer.GetFunctions(ctx, req)
+	resp, err := s.downstream.GetFunctions(ctx, req)
 
 	if err != nil {
 		logging.ProtocolError(ctx, "Error from downstream", map[string]any{logging.KeyError: err})


### PR DESCRIPTION
Closes #353

This breaking change aligns the `tfprotov5` and `tfprotov6` packages with the intended design of this Go module, which is to fully implement the Terraform Plugin Protocol. The `FunctionServer` interface was temporarily optional in v0.20.0 so downstream SDKs could implement and release support first with a lesser likelihood that developers would run into compilation errors when only upgrading a single downstream Go module.

Provider developers should upgrade this Go module only after ensuring their provider Go module is using at least:

- github.com/hashicorp/terraform-plugin-framework@v1.5.0
- github.com/hashicorp/terraform-plugin-mux@v0.13.0
- github.com/hashicorp/terraform-plugin-sdk/v2@v2.31.0