### PR TITLE
tfprotov5+tfprotov6: Remove unnecessary AttributePath_Step error return

### DIFF
--- a/tfprotov5/internal/toproto/attribute_path.go
+++ b/tfprotov5/internal/toproto/attribute_path.go
@@ -4,95 +4,89 @@
 package toproto
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-var ErrUnknownAttributePathStepType = errors.New("unknown type of AttributePath_Step")
-
-func AttributePath(in *tftypes.AttributePath) (*tfplugin5.AttributePath, error) {
+func AttributePath(in *tftypes.AttributePath) *tfplugin5.AttributePath {
 	if in == nil {
-		return nil, nil
-	}
-
-	steps, err := AttributePath_Steps(in.Steps())
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.AttributePath{
-		Steps: steps,
+		Steps: AttributePath_Steps(in.Steps()),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func AttributePaths(in []*tftypes.AttributePath) ([]*tfplugin5.AttributePath, error) {
+func AttributePaths(in []*tftypes.AttributePath) []*tfplugin5.AttributePath {
 	resp := make([]*tfplugin5.AttributePath, 0, len(in))
 
 	for _, a := range in {
-		attr, err := AttributePath(a)
-
-		if err != nil {
-			return resp, err
-		}
-
-		resp = append(resp, attr)
+		resp = append(resp, AttributePath(a))
 	}
 
-	return resp, nil
+	return resp
 }
 
-func AttributePath_Step(step tftypes.AttributePathStep) (*tfplugin5.AttributePath_Step, error) {
-	var resp tfplugin5.AttributePath_Step
-	if name, ok := step.(tftypes.AttributeName); ok {
-		resp.Selector = &tfplugin5.AttributePath_Step_AttributeName{
-			AttributeName: string(name),
+func AttributePath_Step(step tftypes.AttributePathStep) *tfplugin5.AttributePath_Step {
+	if step == nil {
+		return nil
+	}
+
+	switch step := step.(type) {
+	case tftypes.AttributeName:
+		return &tfplugin5.AttributePath_Step{
+			Selector: &tfplugin5.AttributePath_Step_AttributeName{
+				AttributeName: string(step),
+			},
 		}
-		return &resp, nil
-	}
-	if key, ok := step.(tftypes.ElementKeyString); ok {
-		resp.Selector = &tfplugin5.AttributePath_Step_ElementKeyString{
-			ElementKeyString: string(key),
+	case tftypes.ElementKeyInt:
+		return &tfplugin5.AttributePath_Step{
+			Selector: &tfplugin5.AttributePath_Step_ElementKeyInt{
+				ElementKeyInt: int64(step),
+			},
 		}
-		return &resp, nil
-	}
-	if key, ok := step.(tftypes.ElementKeyInt); ok {
-		resp.Selector = &tfplugin5.AttributePath_Step_ElementKeyInt{
-			ElementKeyInt: int64(key),
+	case tftypes.ElementKeyString:
+		return &tfplugin5.AttributePath_Step{
+			Selector: &tfplugin5.AttributePath_Step_ElementKeyString{
+				ElementKeyString: string(step),
+			},
 		}
-		return &resp, nil
+	case tftypes.ElementKeyValue:
+		// The protocol has no equivalent of an ElementKeyValue, so this
+		// returns nil for the step to signal a step we cannot convey back
+		// to Terraform.
+		return nil
 	}
-	if _, ok := step.(tftypes.ElementKeyValue); ok {
-		// the protocol has no equivalent of an ElementKeyValue, so we
-		// return nil for both the step and the error here, to signal
-		// that we've hit a step we can't convey back to Terraform
-		return nil, nil
-	}
-	return nil, ErrUnknownAttributePathStepType
+
+	// It is not currently possible to create tftypes.AttributePathStep
+	// implementations outside the tftypes package and these implementations
+	// should rarely change, if ever, since they are critical to how
+	// Terraform understands attribute paths. If this panic was reached, it
+	// implies that a new step type was introduced and needs to be
+	// implemented as a new case above or that this logic needs to be
+	// otherwise changed to handle some new attribute path system.
+	panic(fmt.Sprintf("unimplemented tftypes.AttributePathStep type: %T", step))
 }
 
-func AttributePath_Steps(in []tftypes.AttributePathStep) ([]*tfplugin5.AttributePath_Step, error) {
+func AttributePath_Steps(in []tftypes.AttributePathStep) []*tfplugin5.AttributePath_Step {
 	resp := make([]*tfplugin5.AttributePath_Step, 0, len(in))
+
 	for _, step := range in {
-		if step == nil {
-			resp = append(resp, nil)
-			continue
-		}
-		s, err := AttributePath_Step(step)
-		if err != nil {
-			return resp, err
-		}
-		// in the face of a set, the protocol has no way to represent
-		// the index, so we just bail and return the prefix we can
-		// return.
+		s := AttributePath_Step(step)
+
+		// In the face of a ElementKeyValue or missing step, Terraform has no
+		// way to represent the attribute path, so only return the prefix.
 		if s == nil {
-			return resp, nil
+			return resp
 		}
+
 		resp = append(resp, s)
 	}
-	return resp, nil
+
+	return resp
 }

--- a/tfprotov5/internal/toproto/attribute_path_test.go
+++ b/tfprotov5/internal/toproto/attribute_path_test.go
@@ -50,11 +50,7 @@ func TestAttributePath(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.AttributePath(testCase.in)
+			got := toproto.AttributePath(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -137,11 +133,7 @@ func TestAttributePaths(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.AttributePaths(testCase.in)
+			got := toproto.AttributePaths(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -206,11 +198,7 @@ func TestAttributePath_Step(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.AttributePath_Step(testCase.in)
+			got := toproto.AttributePath_Step(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -280,11 +268,7 @@ func TestAttributePath_Steps(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.AttributePath_Steps(testCase.in)
+			got := toproto.AttributePath_Steps(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov5/internal/toproto/data_source.go
+++ b/tfprotov5/internal/toproto/data_source.go
@@ -20,39 +20,27 @@ func GetMetadata_DataSourceMetadata(in *tfprotov5.DataSourceMetadata) *tfplugin5
 	return resp
 }
 
-func ValidateDataSourceConfig_Response(in *tfprotov5.ValidateDataSourceConfigResponse) (*tfplugin5.ValidateDataSourceConfig_Response, error) {
+func ValidateDataSourceConfig_Response(in *tfprotov5.ValidateDataSourceConfigResponse) *tfplugin5.ValidateDataSourceConfig_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.ValidateDataSourceConfig_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func ReadDataSource_Response(in *tfprotov5.ReadDataSourceResponse) (*tfplugin5.ReadDataSource_Response, error) {
+func ReadDataSource_Response(in *tfprotov5.ReadDataSourceResponse) *tfplugin5.ReadDataSource_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.ReadDataSource_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 		State:       DynamicValue(in.State),
 	}
 
-	return resp, nil
+	return resp
 }

--- a/tfprotov5/internal/toproto/data_source_test.go
+++ b/tfprotov5/internal/toproto/data_source_test.go
@@ -107,11 +107,7 @@ func TestReadDataSource_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ReadDataSource_Response(testCase.in)
+			got := toproto.ReadDataSource_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -167,11 +163,7 @@ func TestValidateDataSourceConfig_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ValidateDataSourceConfig_Response(testCase.in)
+			got := toproto.ValidateDataSourceConfig_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov5/internal/toproto/diagnostic.go
+++ b/tfprotov5/internal/toproto/diagnostic.go
@@ -10,46 +10,34 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
 )
 
-func Diagnostic(in *tfprotov5.Diagnostic) (*tfplugin5.Diagnostic, error) {
+func Diagnostic(in *tfprotov5.Diagnostic) *tfplugin5.Diagnostic {
 	if in == nil {
-		return nil, nil
-	}
-
-	attribute, err := AttributePath(in.Attribute)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.Diagnostic{
-		Attribute:        attribute,
+		Attribute:        AttributePath(in.Attribute),
 		Detail:           ForceValidUTF8(in.Detail),
 		FunctionArgument: in.FunctionArgument,
 		Severity:         Diagnostic_Severity(in.Severity),
 		Summary:          ForceValidUTF8(in.Summary),
 	}
 
-	return resp, nil
+	return resp
 }
 
 func Diagnostic_Severity(in tfprotov5.DiagnosticSeverity) tfplugin5.Diagnostic_Severity {
 	return tfplugin5.Diagnostic_Severity(in)
 }
 
-func Diagnostics(in []*tfprotov5.Diagnostic) ([]*tfplugin5.Diagnostic, error) {
+func Diagnostics(in []*tfprotov5.Diagnostic) []*tfplugin5.Diagnostic {
 	resp := make([]*tfplugin5.Diagnostic, 0, len(in))
 
 	for _, diag := range in {
-		d, err := Diagnostic(diag)
-
-		if err != nil {
-			return resp, err
-		}
-
-		resp = append(resp, d)
+		resp = append(resp, Diagnostic(diag))
 	}
 
-	return resp, nil
+	return resp
 }
 
 // ForceValidUTF8 returns a string guaranteed to be valid UTF-8 even if the

--- a/tfprotov5/internal/toproto/diagnostic_test.go
+++ b/tfprotov5/internal/toproto/diagnostic_test.go
@@ -105,11 +105,7 @@ func TestDiagnostic(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.Diagnostic(testCase.in)
+			got := toproto.Diagnostic(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -187,11 +183,7 @@ func TestDiagnostics(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.Diagnostics(testCase.in)
+			got := toproto.Diagnostics(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov5/internal/toproto/function.go
+++ b/tfprotov5/internal/toproto/function.go
@@ -10,23 +10,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
 )
 
-func CallFunction_Response(in *tfprotov5.CallFunctionResponse) (*tfplugin5.CallFunction_Response, error) {
+func CallFunction_Response(in *tfprotov5.CallFunctionResponse) *tfplugin5.CallFunction_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.CallFunction_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 		Result:      DynamicValue(in.Result),
 	}
 
-	return resp, nil
+	return resp
 }
 
 func Function(in *tfprotov5.Function) (*tfplugin5.Function, error) {
@@ -136,14 +130,8 @@ func GetFunctions_Response(in *tfprotov5.GetFunctionsResponse) (*tfplugin5.GetFu
 		return nil, nil
 	}
 
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
-	}
-
 	resp := &tfplugin5.GetFunctions_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 		Functions:   make(map[string]*tfplugin5.Function, len(in.Functions)),
 	}
 

--- a/tfprotov5/internal/toproto/function_test.go
+++ b/tfprotov5/internal/toproto/function_test.go
@@ -60,11 +60,7 @@ func TestCallFunction_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.CallFunction_Response(testCase.in)
+			got := toproto.CallFunction_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov5/internal/toproto/provider.go
+++ b/tfprotov5/internal/toproto/provider.go
@@ -10,25 +10,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5"
 )
 
-func GetMetadata_Response(in *tfprotov5.GetMetadataResponse) (*tfplugin5.GetMetadata_Response, error) {
+func GetMetadata_Response(in *tfprotov5.GetMetadataResponse) *tfplugin5.GetMetadata_Response {
 	if in == nil {
-		return nil, nil
+		return nil
 	}
 
 	resp := &tfplugin5.GetMetadata_Response{
 		DataSources:        make([]*tfplugin5.GetMetadata_DataSourceMetadata, 0, len(in.DataSources)),
+		Diagnostics:        Diagnostics(in.Diagnostics),
 		Functions:          make([]*tfplugin5.GetMetadata_FunctionMetadata, 0, len(in.Functions)),
 		Resources:          make([]*tfplugin5.GetMetadata_ResourceMetadata, 0, len(in.Resources)),
 		ServerCapabilities: ServerCapabilities(in.ServerCapabilities),
 	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return resp, err
-	}
-
-	resp.Diagnostics = diags
 
 	for _, datasource := range in.DataSources {
 		resp.DataSources = append(resp.DataSources, GetMetadata_DataSourceMetadata(&datasource))
@@ -42,18 +35,12 @@ func GetMetadata_Response(in *tfprotov5.GetMetadataResponse) (*tfplugin5.GetMeta
 		resp.Resources = append(resp.Resources, GetMetadata_ResourceMetadata(&resource))
 	}
 
-	return resp, nil
+	return resp
 }
 
 func GetProviderSchema_Response(in *tfprotov5.GetProviderSchemaResponse) (*tfplugin5.GetProviderSchema_Response, error) {
 	if in == nil {
 		return nil, nil
-	}
-
-	diagnostics, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
 	}
 
 	provider, err := Schema(in.Provider)
@@ -70,7 +57,7 @@ func GetProviderSchema_Response(in *tfprotov5.GetProviderSchemaResponse) (*tfplu
 
 	resp := &tfplugin5.GetProviderSchema_Response{
 		DataSourceSchemas:  make(map[string]*tfplugin5.Schema, len(in.DataSourceSchemas)),
-		Diagnostics:        diagnostics,
+		Diagnostics:        Diagnostics(in.Diagnostics),
 		Functions:          make(map[string]*tfplugin5.Function, len(in.Functions)),
 		Provider:           provider,
 		ProviderMeta:       providerMeta,
@@ -111,41 +98,29 @@ func GetProviderSchema_Response(in *tfprotov5.GetProviderSchemaResponse) (*tfplu
 	return resp, nil
 }
 
-func PrepareProviderConfig_Response(in *tfprotov5.PrepareProviderConfigResponse) (*tfplugin5.PrepareProviderConfig_Response, error) {
+func PrepareProviderConfig_Response(in *tfprotov5.PrepareProviderConfigResponse) *tfplugin5.PrepareProviderConfig_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.PrepareProviderConfig_Response{
-		Diagnostics:    diags,
+		Diagnostics:    Diagnostics(in.Diagnostics),
 		PreparedConfig: DynamicValue(in.PreparedConfig),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func Configure_Response(in *tfprotov5.ConfigureProviderResponse) (*tfplugin5.Configure_Response, error) {
+func Configure_Response(in *tfprotov5.ConfigureProviderResponse) *tfplugin5.Configure_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.Configure_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 	}
 
-	return resp, nil
+	return resp
 }
 
 func Stop_Response(in *tfprotov5.StopProviderResponse) *tfplugin5.Stop_Response {

--- a/tfprotov5/internal/toproto/provider_test.go
+++ b/tfprotov5/internal/toproto/provider_test.go
@@ -51,11 +51,7 @@ func TestConfigureProvider_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.Configure_Response(testCase.in)
+			got := toproto.Configure_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -189,11 +185,7 @@ func TestGetMetadata_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.GetMetadata_Response(testCase.in)
+			got := toproto.GetMetadata_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -494,11 +486,7 @@ func TestPrepareProviderConfig_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.PrepareProviderConfig_Response(testCase.in)
+			got := toproto.PrepareProviderConfig_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov5/internal/toproto/resource.go
+++ b/tfprotov5/internal/toproto/resource.go
@@ -20,129 +20,87 @@ func GetMetadata_ResourceMetadata(in *tfprotov5.ResourceMetadata) *tfplugin5.Get
 	return resp
 }
 
-func ValidateResourceTypeConfig_Response(in *tfprotov5.ValidateResourceTypeConfigResponse) (*tfplugin5.ValidateResourceTypeConfig_Response, error) {
+func ValidateResourceTypeConfig_Response(in *tfprotov5.ValidateResourceTypeConfigResponse) *tfplugin5.ValidateResourceTypeConfig_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.ValidateResourceTypeConfig_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func UpgradeResourceState_Response(in *tfprotov5.UpgradeResourceStateResponse) (*tfplugin5.UpgradeResourceState_Response, error) {
+func UpgradeResourceState_Response(in *tfprotov5.UpgradeResourceStateResponse) *tfplugin5.UpgradeResourceState_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.UpgradeResourceState_Response{
-		Diagnostics:   diags,
+		Diagnostics:   Diagnostics(in.Diagnostics),
 		UpgradedState: DynamicValue(in.UpgradedState),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func ReadResource_Response(in *tfprotov5.ReadResourceResponse) (*tfplugin5.ReadResource_Response, error) {
+func ReadResource_Response(in *tfprotov5.ReadResourceResponse) *tfplugin5.ReadResource_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.ReadResource_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 		NewState:    DynamicValue(in.NewState),
 		Private:     in.Private,
 	}
 
-	return resp, nil
+	return resp
 }
 
-func PlanResourceChange_Response(in *tfprotov5.PlanResourceChangeResponse) (*tfplugin5.PlanResourceChange_Response, error) {
+func PlanResourceChange_Response(in *tfprotov5.PlanResourceChangeResponse) *tfplugin5.PlanResourceChange_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
-	}
-
-	requiresReplace, err := AttributePaths(in.RequiresReplace)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.PlanResourceChange_Response{
-		Diagnostics:      diags,
+		Diagnostics:      Diagnostics(in.Diagnostics),
 		LegacyTypeSystem: in.UnsafeToUseLegacyTypeSystem, //nolint:staticcheck
 		PlannedPrivate:   in.PlannedPrivate,
 		PlannedState:     DynamicValue(in.PlannedState),
-		RequiresReplace:  requiresReplace,
+		RequiresReplace:  AttributePaths(in.RequiresReplace),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func ApplyResourceChange_Response(in *tfprotov5.ApplyResourceChangeResponse) (*tfplugin5.ApplyResourceChange_Response, error) {
+func ApplyResourceChange_Response(in *tfprotov5.ApplyResourceChangeResponse) *tfplugin5.ApplyResourceChange_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.ApplyResourceChange_Response{
-		Diagnostics:      diags,
+		Diagnostics:      Diagnostics(in.Diagnostics),
 		LegacyTypeSystem: in.UnsafeToUseLegacyTypeSystem, //nolint:staticcheck
 		NewState:         DynamicValue(in.NewState),
 		Private:          in.Private,
 	}
 
-	return resp, nil
+	return resp
 }
 
-func ImportResourceState_Response(in *tfprotov5.ImportResourceStateResponse) (*tfplugin5.ImportResourceState_Response, error) {
+func ImportResourceState_Response(in *tfprotov5.ImportResourceStateResponse) *tfplugin5.ImportResourceState_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.ImportResourceState_Response{
-		Diagnostics:       diags,
+		Diagnostics:       Diagnostics(in.Diagnostics),
 		ImportedResources: ImportResourceState_ImportedResources(in.ImportedResources),
 	}
 
-	return resp, nil
+	return resp
 }
 
 func ImportResourceState_ImportedResource(in *tfprotov5.ImportedResource) *tfplugin5.ImportResourceState_ImportedResource {
@@ -169,21 +127,15 @@ func ImportResourceState_ImportedResources(in []*tfprotov5.ImportedResource) []*
 	return resp
 }
 
-func MoveResourceState_Response(in *tfprotov5.MoveResourceStateResponse) (*tfplugin5.MoveResourceState_Response, error) {
+func MoveResourceState_Response(in *tfprotov5.MoveResourceStateResponse) *tfplugin5.MoveResourceState_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin5.MoveResourceState_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 		TargetState: DynamicValue(in.TargetState),
 	}
 
-	return resp, nil
+	return resp
 }

--- a/tfprotov5/internal/toproto/resource_test.go
+++ b/tfprotov5/internal/toproto/resource_test.go
@@ -78,11 +78,7 @@ func TestApplyResourceChange_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ApplyResourceChange_Response(testCase.in)
+			got := toproto.ApplyResourceChange_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -207,11 +203,7 @@ func TestImportResourceState_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ImportResourceState_Response(testCase.in)
+			got := toproto.ImportResourceState_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -411,11 +403,7 @@ func TestMoveResourceState_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.MoveResourceState_Response(testCase.in)
+			got := toproto.MoveResourceState_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -524,11 +512,7 @@ func TestPlanResourceChange_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.PlanResourceChange_Response(testCase.in)
+			got := toproto.PlanResourceChange_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -604,11 +588,7 @@ func TestReadResource_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ReadResource_Response(testCase.in)
+			got := toproto.ReadResource_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -673,11 +653,7 @@ func TestUpgradeResourceState_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.UpgradeResourceState_Response(testCase.in)
+			got := toproto.UpgradeResourceState_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -733,11 +709,7 @@ func TestValidateResourceTypeConfig_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ValidateResourceTypeConfig_Response(testCase.in)
+			got := toproto.ValidateResourceTypeConfig_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov5/tf5server/server.go
+++ b/tfprotov5/tf5server/server.go
@@ -508,12 +508,7 @@ func (s *server) GetMetadata(ctx context.Context, protoReq *tfplugin5.GetMetadat
 	tf5serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 	tf5serverlogging.ServerCapabilities(ctx, resp.ServerCapabilities)
 
-	protoResp, err := toproto.GetMetadata_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.GetMetadata_Response(resp)
 
 	return protoResp, nil
 }
@@ -574,12 +569,7 @@ func (s *server) PrepareProviderConfig(ctx context.Context, protoReq *tfplugin5.
 	tf5serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "PreparedConfig", resp.PreparedConfig)
 
-	protoResp, err := toproto.PrepareProviderConfig_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.PrepareProviderConfig_Response(resp)
 
 	return protoResp, nil
 }
@@ -606,12 +596,7 @@ func (s *server) Configure(ctx context.Context, protoReq *tfplugin5.Configure_Re
 
 	tf5serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 
-	protoResp, err := toproto.Configure_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.Configure_Response(resp)
 
 	return protoResp, nil
 }
@@ -682,12 +667,7 @@ func (s *server) ValidateDataSourceConfig(ctx context.Context, protoReq *tfplugi
 
 	tf5serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 
-	protoResp, err := toproto.ValidateDataSourceConfig_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ValidateDataSourceConfig_Response(resp)
 
 	return protoResp, nil
 }
@@ -717,12 +697,7 @@ func (s *server) ReadDataSource(ctx context.Context, protoReq *tfplugin5.ReadDat
 	tf5serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "State", resp.State)
 
-	protoResp, err := toproto.ReadDataSource_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ReadDataSource_Response(resp)
 
 	return protoResp, nil
 }
@@ -751,12 +726,7 @@ func (s *server) ValidateResourceTypeConfig(ctx context.Context, protoReq *tfplu
 
 	tf5serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 
-	protoResp, err := toproto.ValidateResourceTypeConfig_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ValidateResourceTypeConfig_Response(resp)
 
 	return protoResp, nil
 }
@@ -784,12 +754,7 @@ func (s *server) UpgradeResourceState(ctx context.Context, protoReq *tfplugin5.U
 	tf5serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "UpgradedState", resp.UpgradedState)
 
-	protoResp, err := toproto.UpgradeResourceState_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.UpgradeResourceState_Response(resp)
 
 	return protoResp, nil
 }
@@ -823,12 +788,7 @@ func (s *server) ReadResource(ctx context.Context, protoReq *tfplugin5.ReadResou
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "NewState", resp.NewState)
 	logging.ProtocolPrivateData(ctx, s.protocolDataDir, rpc, "Response", "Private", resp.Private)
 
-	protoResp, err := toproto.ReadResource_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ReadResource_Response(resp)
 
 	return protoResp, nil
 }
@@ -863,12 +823,7 @@ func (s *server) PlanResourceChange(ctx context.Context, protoReq *tfplugin5.Pla
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "PlannedState", resp.PlannedState)
 	logging.ProtocolPrivateData(ctx, s.protocolDataDir, rpc, "Response", "PlannedPrivate", resp.PlannedPrivate)
 
-	protoResp, err := toproto.PlanResourceChange_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.PlanResourceChange_Response(resp)
 
 	return protoResp, nil
 }
@@ -903,12 +858,7 @@ func (s *server) ApplyResourceChange(ctx context.Context, protoReq *tfplugin5.Ap
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "NewState", resp.NewState)
 	logging.ProtocolPrivateData(ctx, s.protocolDataDir, rpc, "Response", "Private", resp.Private)
 
-	protoResp, err := toproto.ApplyResourceChange_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ApplyResourceChange_Response(resp)
 
 	return protoResp, nil
 }
@@ -940,12 +890,7 @@ func (s *server) ImportResourceState(ctx context.Context, protoReq *tfplugin5.Im
 		logging.ProtocolPrivateData(ctx, s.protocolDataDir, rpc, "Response_ImportedResource", "Private", importedResource.Private)
 	}
 
-	protoResp, err := toproto.ImportResourceState_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ImportResourceState_Response(resp)
 
 	return protoResp, nil
 }
@@ -1000,13 +945,7 @@ func (s *server) MoveResourceState(ctx context.Context, protoReq *tfplugin5.Move
 	tf5serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "TargetState", resp.TargetState)
 
-	protoResp, err := toproto.MoveResourceState_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-
-		return nil, err
-	}
+	protoResp := toproto.MoveResourceState_Response(resp)
 
 	return protoResp, nil
 }
@@ -1061,12 +1000,7 @@ func (s *server) CallFunction(ctx context.Context, protoReq *tfplugin5.CallFunct
 	tf5serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "Result", resp.Result)
 
-	protoResp, err := toproto.CallFunction_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]any{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.CallFunction_Response(resp)
 
 	return protoResp, nil
 }

--- a/tfprotov6/internal/toproto/attribute_path.go
+++ b/tfprotov6/internal/toproto/attribute_path.go
@@ -4,95 +4,89 @@
 package toproto
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-var ErrUnknownAttributePathStepType = errors.New("unknown type of AttributePath_Step")
-
-func AttributePath(in *tftypes.AttributePath) (*tfplugin6.AttributePath, error) {
+func AttributePath(in *tftypes.AttributePath) *tfplugin6.AttributePath {
 	if in == nil {
-		return nil, nil
-	}
-
-	steps, err := AttributePath_Steps(in.Steps())
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.AttributePath{
-		Steps: steps,
+		Steps: AttributePath_Steps(in.Steps()),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func AttributePaths(in []*tftypes.AttributePath) ([]*tfplugin6.AttributePath, error) {
+func AttributePaths(in []*tftypes.AttributePath) []*tfplugin6.AttributePath {
 	resp := make([]*tfplugin6.AttributePath, 0, len(in))
 
 	for _, a := range in {
-		attr, err := AttributePath(a)
-
-		if err != nil {
-			return resp, err
-		}
-
-		resp = append(resp, attr)
+		resp = append(resp, AttributePath(a))
 	}
 
-	return resp, nil
+	return resp
 }
 
-func AttributePath_Step(step tftypes.AttributePathStep) (*tfplugin6.AttributePath_Step, error) {
-	var resp tfplugin6.AttributePath_Step
-	if name, ok := step.(tftypes.AttributeName); ok {
-		resp.Selector = &tfplugin6.AttributePath_Step_AttributeName{
-			AttributeName: string(name),
+func AttributePath_Step(step tftypes.AttributePathStep) *tfplugin6.AttributePath_Step {
+	if step == nil {
+		return nil
+	}
+
+	switch step := step.(type) {
+	case tftypes.AttributeName:
+		return &tfplugin6.AttributePath_Step{
+			Selector: &tfplugin6.AttributePath_Step_AttributeName{
+				AttributeName: string(step),
+			},
 		}
-		return &resp, nil
-	}
-	if key, ok := step.(tftypes.ElementKeyString); ok {
-		resp.Selector = &tfplugin6.AttributePath_Step_ElementKeyString{
-			ElementKeyString: string(key),
+	case tftypes.ElementKeyInt:
+		return &tfplugin6.AttributePath_Step{
+			Selector: &tfplugin6.AttributePath_Step_ElementKeyInt{
+				ElementKeyInt: int64(step),
+			},
 		}
-		return &resp, nil
-	}
-	if key, ok := step.(tftypes.ElementKeyInt); ok {
-		resp.Selector = &tfplugin6.AttributePath_Step_ElementKeyInt{
-			ElementKeyInt: int64(key),
+	case tftypes.ElementKeyString:
+		return &tfplugin6.AttributePath_Step{
+			Selector: &tfplugin6.AttributePath_Step_ElementKeyString{
+				ElementKeyString: string(step),
+			},
 		}
-		return &resp, nil
+	case tftypes.ElementKeyValue:
+		// The protocol has no equivalent of an ElementKeyValue, so this
+		// returns nil for the step to signal a step we cannot convey back
+		// to Terraform.
+		return nil
 	}
-	if _, ok := step.(tftypes.ElementKeyValue); ok {
-		// the protocol has no equivalent of an ElementKeyValue, so we
-		// return nil for both the step and the error here, to signal
-		// that we've hit a step we can't convey back to Terraform
-		return nil, nil
-	}
-	return nil, ErrUnknownAttributePathStepType
+
+	// It is not currently possible to create tftypes.AttributePathStep
+	// implementations outside the tftypes package and these implementations
+	// should rarely change, if ever, since they are critical to how
+	// Terraform understands attribute paths. If this panic was reached, it
+	// implies that a new step type was introduced and needs to be
+	// implemented as a new case above or that this logic needs to be
+	// otherwise changed to handle some new attribute path system.
+	panic(fmt.Sprintf("unimplemented tftypes.AttributePathStep type: %T", step))
 }
 
-func AttributePath_Steps(in []tftypes.AttributePathStep) ([]*tfplugin6.AttributePath_Step, error) {
+func AttributePath_Steps(in []tftypes.AttributePathStep) []*tfplugin6.AttributePath_Step {
 	resp := make([]*tfplugin6.AttributePath_Step, 0, len(in))
+
 	for _, step := range in {
-		if step == nil {
-			resp = append(resp, nil)
-			continue
-		}
-		s, err := AttributePath_Step(step)
-		if err != nil {
-			return resp, err
-		}
-		// in the face of a set, the protocol has no way to represent
-		// the index, so we just bail and return the prefix we can
-		// return.
+		s := AttributePath_Step(step)
+
+		// In the face of a ElementKeyValue or missing step, Terraform has no
+		// way to represent the attribute path, so only return the prefix.
 		if s == nil {
-			return resp, nil
+			return resp
 		}
+
 		resp = append(resp, s)
 	}
-	return resp, nil
+
+	return resp
 }

--- a/tfprotov6/internal/toproto/attribute_path_test.go
+++ b/tfprotov6/internal/toproto/attribute_path_test.go
@@ -50,11 +50,7 @@ func TestAttributePath(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.AttributePath(testCase.in)
+			got := toproto.AttributePath(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -137,11 +133,7 @@ func TestAttributePaths(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.AttributePaths(testCase.in)
+			got := toproto.AttributePaths(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -206,11 +198,7 @@ func TestAttributePath_Step(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.AttributePath_Step(testCase.in)
+			got := toproto.AttributePath_Step(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -280,11 +268,7 @@ func TestAttributePath_Steps(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.AttributePath_Steps(testCase.in)
+			got := toproto.AttributePath_Steps(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov6/internal/toproto/data_source.go
+++ b/tfprotov6/internal/toproto/data_source.go
@@ -18,39 +18,27 @@ func GetMetadata_DataSourceMetadata(in *tfprotov6.DataSourceMetadata) *tfplugin6
 	}
 }
 
-func ValidateDataResourceConfig_Response(in *tfprotov6.ValidateDataResourceConfigResponse) (*tfplugin6.ValidateDataResourceConfig_Response, error) {
+func ValidateDataResourceConfig_Response(in *tfprotov6.ValidateDataResourceConfigResponse) *tfplugin6.ValidateDataResourceConfig_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.ValidateDataResourceConfig_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func ReadDataSource_Response(in *tfprotov6.ReadDataSourceResponse) (*tfplugin6.ReadDataSource_Response, error) {
+func ReadDataSource_Response(in *tfprotov6.ReadDataSourceResponse) *tfplugin6.ReadDataSource_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.ReadDataSource_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 		State:       DynamicValue(in.State),
 	}
 
-	return resp, nil
+	return resp
 }

--- a/tfprotov6/internal/toproto/data_source_test.go
+++ b/tfprotov6/internal/toproto/data_source_test.go
@@ -107,11 +107,7 @@ func TestReadDataSource_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ReadDataSource_Response(testCase.in)
+			got := toproto.ReadDataSource_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -167,11 +163,7 @@ func TestValidateDataResourceConfig_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ValidateDataResourceConfig_Response(testCase.in)
+			got := toproto.ValidateDataResourceConfig_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov6/internal/toproto/diagnostic.go
+++ b/tfprotov6/internal/toproto/diagnostic.go
@@ -10,46 +10,34 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6"
 )
 
-func Diagnostic(in *tfprotov6.Diagnostic) (*tfplugin6.Diagnostic, error) {
+func Diagnostic(in *tfprotov6.Diagnostic) *tfplugin6.Diagnostic {
 	if in == nil {
-		return nil, nil
-	}
-
-	attribute, err := AttributePath(in.Attribute)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.Diagnostic{
-		Attribute:        attribute,
+		Attribute:        AttributePath(in.Attribute),
 		Detail:           ForceValidUTF8(in.Detail),
 		FunctionArgument: in.FunctionArgument,
 		Severity:         Diagnostic_Severity(in.Severity),
 		Summary:          ForceValidUTF8(in.Summary),
 	}
 
-	return resp, nil
+	return resp
 }
 
 func Diagnostic_Severity(in tfprotov6.DiagnosticSeverity) tfplugin6.Diagnostic_Severity {
 	return tfplugin6.Diagnostic_Severity(in)
 }
 
-func Diagnostics(in []*tfprotov6.Diagnostic) ([]*tfplugin6.Diagnostic, error) {
+func Diagnostics(in []*tfprotov6.Diagnostic) []*tfplugin6.Diagnostic {
 	resp := make([]*tfplugin6.Diagnostic, 0, len(in))
 
 	for _, diag := range in {
-		d, err := Diagnostic(diag)
-
-		if err != nil {
-			return resp, err
-		}
-
-		resp = append(resp, d)
+		resp = append(resp, Diagnostic(diag))
 	}
 
-	return resp, nil
+	return resp
 }
 
 // ForceValidUTF8 returns a string guaranteed to be valid UTF-8 even if the

--- a/tfprotov6/internal/toproto/diagnostic_test.go
+++ b/tfprotov6/internal/toproto/diagnostic_test.go
@@ -105,11 +105,7 @@ func TestDiagnostic(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.Diagnostic(testCase.in)
+			got := toproto.Diagnostic(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -187,11 +183,7 @@ func TestDiagnostics(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.Diagnostics(testCase.in)
+			got := toproto.Diagnostics(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov6/internal/toproto/function.go
+++ b/tfprotov6/internal/toproto/function.go
@@ -10,23 +10,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6"
 )
 
-func CallFunction_Response(in *tfprotov6.CallFunctionResponse) (*tfplugin6.CallFunction_Response, error) {
+func CallFunction_Response(in *tfprotov6.CallFunctionResponse) *tfplugin6.CallFunction_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.CallFunction_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 		Result:      DynamicValue(in.Result),
 	}
 
-	return resp, nil
+	return resp
 }
 
 func Function(in *tfprotov6.Function) (*tfplugin6.Function, error) {
@@ -136,14 +130,8 @@ func GetFunctions_Response(in *tfprotov6.GetFunctionsResponse) (*tfplugin6.GetFu
 		return nil, nil
 	}
 
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
-	}
-
 	resp := &tfplugin6.GetFunctions_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 		Functions:   make(map[string]*tfplugin6.Function, len(in.Functions)),
 	}
 

--- a/tfprotov6/internal/toproto/function_test.go
+++ b/tfprotov6/internal/toproto/function_test.go
@@ -60,11 +60,7 @@ func TestCallFunction_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.CallFunction_Response(testCase.in)
+			got := toproto.CallFunction_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov6/internal/toproto/provider.go
+++ b/tfprotov6/internal/toproto/provider.go
@@ -10,20 +10,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6"
 )
 
-func GetMetadata_Response(in *tfprotov6.GetMetadataResponse) (*tfplugin6.GetMetadata_Response, error) {
+func GetMetadata_Response(in *tfprotov6.GetMetadataResponse) *tfplugin6.GetMetadata_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.GetMetadata_Response{
 		DataSources:        make([]*tfplugin6.GetMetadata_DataSourceMetadata, 0, len(in.DataSources)),
-		Diagnostics:        diags,
+		Diagnostics:        Diagnostics(in.Diagnostics),
 		Functions:          make([]*tfplugin6.GetMetadata_FunctionMetadata, 0, len(in.Functions)),
 		Resources:          make([]*tfplugin6.GetMetadata_ResourceMetadata, 0, len(in.Resources)),
 		ServerCapabilities: ServerCapabilities(in.ServerCapabilities),
@@ -41,18 +35,12 @@ func GetMetadata_Response(in *tfprotov6.GetMetadataResponse) (*tfplugin6.GetMeta
 		resp.Resources = append(resp.Resources, GetMetadata_ResourceMetadata(&resource))
 	}
 
-	return resp, nil
+	return resp
 }
 
 func GetProviderSchema_Response(in *tfprotov6.GetProviderSchemaResponse) (*tfplugin6.GetProviderSchema_Response, error) {
 	if in == nil {
 		return nil, nil
-	}
-
-	diagnostics, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
 	}
 
 	provider, err := Schema(in.Provider)
@@ -69,7 +57,7 @@ func GetProviderSchema_Response(in *tfprotov6.GetProviderSchemaResponse) (*tfplu
 
 	resp := &tfplugin6.GetProviderSchema_Response{
 		DataSourceSchemas:  make(map[string]*tfplugin6.Schema, len(in.DataSourceSchemas)),
-		Diagnostics:        diagnostics,
+		Diagnostics:        Diagnostics(in.Diagnostics),
 		Functions:          make(map[string]*tfplugin6.Function, len(in.Functions)),
 		Provider:           provider,
 		ProviderMeta:       providerMeta,
@@ -110,40 +98,28 @@ func GetProviderSchema_Response(in *tfprotov6.GetProviderSchemaResponse) (*tfplu
 	return resp, nil
 }
 
-func ValidateProviderConfig_Response(in *tfprotov6.ValidateProviderConfigResponse) (*tfplugin6.ValidateProviderConfig_Response, error) {
+func ValidateProviderConfig_Response(in *tfprotov6.ValidateProviderConfigResponse) *tfplugin6.ValidateProviderConfig_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.ValidateProviderConfig_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func ConfigureProvider_Response(in *tfprotov6.ConfigureProviderResponse) (*tfplugin6.ConfigureProvider_Response, error) {
+func ConfigureProvider_Response(in *tfprotov6.ConfigureProviderResponse) *tfplugin6.ConfigureProvider_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.ConfigureProvider_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 	}
 
-	return resp, nil
+	return resp
 }
 
 func StopProvider_Response(in *tfprotov6.StopProviderResponse) *tfplugin6.StopProvider_Response {

--- a/tfprotov6/internal/toproto/provider_test.go
+++ b/tfprotov6/internal/toproto/provider_test.go
@@ -51,11 +51,7 @@ func TestConfigureProvider_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ConfigureProvider_Response(testCase.in)
+			got := toproto.ConfigureProvider_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -189,11 +185,7 @@ func TestGetMetadata_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.GetMetadata_Response(testCase.in)
+			got := toproto.GetMetadata_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -485,11 +477,7 @@ func TestValidateProviderConfig_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ValidateProviderConfig_Response(testCase.in)
+			got := toproto.ValidateProviderConfig_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov6/internal/toproto/resource.go
+++ b/tfprotov6/internal/toproto/resource.go
@@ -20,129 +20,87 @@ func GetMetadata_ResourceMetadata(in *tfprotov6.ResourceMetadata) *tfplugin6.Get
 	return resp
 }
 
-func ValidateResourceConfig_Response(in *tfprotov6.ValidateResourceConfigResponse) (*tfplugin6.ValidateResourceConfig_Response, error) {
+func ValidateResourceConfig_Response(in *tfprotov6.ValidateResourceConfigResponse) *tfplugin6.ValidateResourceConfig_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.ValidateResourceConfig_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func UpgradeResourceState_Response(in *tfprotov6.UpgradeResourceStateResponse) (*tfplugin6.UpgradeResourceState_Response, error) {
+func UpgradeResourceState_Response(in *tfprotov6.UpgradeResourceStateResponse) *tfplugin6.UpgradeResourceState_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.UpgradeResourceState_Response{
-		Diagnostics:   diags,
+		Diagnostics:   Diagnostics(in.Diagnostics),
 		UpgradedState: DynamicValue(in.UpgradedState),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func ReadResource_Response(in *tfprotov6.ReadResourceResponse) (*tfplugin6.ReadResource_Response, error) {
+func ReadResource_Response(in *tfprotov6.ReadResourceResponse) *tfplugin6.ReadResource_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.ReadResource_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 		NewState:    DynamicValue(in.NewState),
 		Private:     in.Private,
 	}
 
-	return resp, nil
+	return resp
 }
 
-func PlanResourceChange_Response(in *tfprotov6.PlanResourceChangeResponse) (*tfplugin6.PlanResourceChange_Response, error) {
+func PlanResourceChange_Response(in *tfprotov6.PlanResourceChangeResponse) *tfplugin6.PlanResourceChange_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
-	}
-
-	requiresReplace, err := AttributePaths(in.RequiresReplace)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.PlanResourceChange_Response{
-		Diagnostics:      diags,
+		Diagnostics:      Diagnostics(in.Diagnostics),
 		LegacyTypeSystem: in.UnsafeToUseLegacyTypeSystem, //nolint:staticcheck
 		PlannedPrivate:   in.PlannedPrivate,
 		PlannedState:     DynamicValue(in.PlannedState),
-		RequiresReplace:  requiresReplace,
+		RequiresReplace:  AttributePaths(in.RequiresReplace),
 	}
 
-	return resp, nil
+	return resp
 }
 
-func ApplyResourceChange_Response(in *tfprotov6.ApplyResourceChangeResponse) (*tfplugin6.ApplyResourceChange_Response, error) {
+func ApplyResourceChange_Response(in *tfprotov6.ApplyResourceChangeResponse) *tfplugin6.ApplyResourceChange_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.ApplyResourceChange_Response{
-		Diagnostics:      diags,
+		Diagnostics:      Diagnostics(in.Diagnostics),
 		LegacyTypeSystem: in.UnsafeToUseLegacyTypeSystem, //nolint:staticcheck
 		NewState:         DynamicValue(in.NewState),
 		Private:          in.Private,
 	}
 
-	return resp, nil
+	return resp
 }
 
-func ImportResourceState_Response(in *tfprotov6.ImportResourceStateResponse) (*tfplugin6.ImportResourceState_Response, error) {
+func ImportResourceState_Response(in *tfprotov6.ImportResourceStateResponse) *tfplugin6.ImportResourceState_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.ImportResourceState_Response{
-		Diagnostics:       diags,
+		Diagnostics:       Diagnostics(in.Diagnostics),
 		ImportedResources: ImportResourceState_ImportedResources(in.ImportedResources),
 	}
 
-	return resp, nil
+	return resp
 }
 
 func ImportResourceState_ImportedResource(in *tfprotov6.ImportedResource) *tfplugin6.ImportResourceState_ImportedResource {
@@ -169,21 +127,15 @@ func ImportResourceState_ImportedResources(in []*tfprotov6.ImportedResource) []*
 	return resp
 }
 
-func MoveResourceState_Response(in *tfprotov6.MoveResourceStateResponse) (*tfplugin6.MoveResourceState_Response, error) {
+func MoveResourceState_Response(in *tfprotov6.MoveResourceStateResponse) *tfplugin6.MoveResourceState_Response {
 	if in == nil {
-		return nil, nil
-	}
-
-	diags, err := Diagnostics(in.Diagnostics)
-
-	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	resp := &tfplugin6.MoveResourceState_Response{
-		Diagnostics: diags,
+		Diagnostics: Diagnostics(in.Diagnostics),
 		TargetState: DynamicValue(in.TargetState),
 	}
 
-	return resp, nil
+	return resp
 }

--- a/tfprotov6/internal/toproto/resource_test.go
+++ b/tfprotov6/internal/toproto/resource_test.go
@@ -78,11 +78,7 @@ func TestApplyResourceChange_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ApplyResourceChange_Response(testCase.in)
+			got := toproto.ApplyResourceChange_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -207,11 +203,7 @@ func TestImportResourceState_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ImportResourceState_Response(testCase.in)
+			got := toproto.ImportResourceState_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -411,11 +403,7 @@ func TestMoveResourceState_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.MoveResourceState_Response(testCase.in)
+			got := toproto.MoveResourceState_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -524,11 +512,7 @@ func TestPlanResourceChange_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.PlanResourceChange_Response(testCase.in)
+			got := toproto.PlanResourceChange_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -604,11 +588,7 @@ func TestReadResource_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ReadResource_Response(testCase.in)
+			got := toproto.ReadResource_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -673,11 +653,7 @@ func TestUpgradeResourceState_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.UpgradeResourceState_Response(testCase.in)
+			got := toproto.UpgradeResourceState_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than
@@ -733,11 +709,7 @@ func TestValidateResourceConfig_Response(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Intentionally not checking the error return as it is impossible
-			// to implement a test case which would raise an error. This return
-			// will be removed in preference of a panic a future change.
-			// Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365
-			got, _ := toproto.ValidateResourceConfig_Response(testCase.in)
+			got := toproto.ValidateResourceConfig_Response(testCase.in)
 
 			// Protocol Buffers generated types must have unexported fields
 			// ignored or cmp.Diff() will raise an error. This is easier than

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -508,12 +508,7 @@ func (s *server) GetMetadata(ctx context.Context, protoReq *tfplugin6.GetMetadat
 	tf6serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 	tf6serverlogging.ServerCapabilities(ctx, resp.ServerCapabilities)
 
-	protoResp, err := toproto.GetMetadata_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.GetMetadata_Response(resp)
 
 	return protoResp, nil
 }
@@ -573,12 +568,7 @@ func (s *server) ConfigureProvider(ctx context.Context, protoReq *tfplugin6.Conf
 
 	tf6serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 
-	protoResp, err := toproto.ConfigureProvider_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ConfigureProvider_Response(resp)
 
 	return protoResp, nil
 }
@@ -605,12 +595,7 @@ func (s *server) ValidateProviderConfig(ctx context.Context, protoReq *tfplugin6
 
 	tf6serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 
-	protoResp, err := toproto.ValidateProviderConfig_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ValidateProviderConfig_Response(resp)
 
 	return protoResp, nil
 }
@@ -681,12 +666,7 @@ func (s *server) ValidateDataResourceConfig(ctx context.Context, protoReq *tfplu
 
 	tf6serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 
-	protoResp, err := toproto.ValidateDataResourceConfig_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ValidateDataResourceConfig_Response(resp)
 
 	return protoResp, nil
 }
@@ -718,12 +698,7 @@ func (s *server) ReadDataSource(ctx context.Context, protoReq *tfplugin6.ReadDat
 
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "State", resp.State)
 
-	protoResp, err := toproto.ReadDataSource_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ReadDataSource_Response(resp)
 
 	return protoResp, nil
 }
@@ -752,12 +727,7 @@ func (s *server) ValidateResourceConfig(ctx context.Context, protoReq *tfplugin6
 
 	tf6serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 
-	protoResp, err := toproto.ValidateResourceConfig_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ValidateResourceConfig_Response(resp)
 
 	return protoResp, nil
 }
@@ -785,12 +755,7 @@ func (s *server) UpgradeResourceState(ctx context.Context, protoReq *tfplugin6.U
 	tf6serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "UpgradedState", resp.UpgradedState)
 
-	protoResp, err := toproto.UpgradeResourceState_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.UpgradeResourceState_Response(resp)
 
 	return protoResp, nil
 }
@@ -823,12 +788,7 @@ func (s *server) ReadResource(ctx context.Context, protoReq *tfplugin6.ReadResou
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "NewState", resp.NewState)
 	logging.ProtocolPrivateData(ctx, s.protocolDataDir, rpc, "Response", "Private", resp.Private)
 
-	protoResp, err := toproto.ReadResource_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ReadResource_Response(resp)
 
 	return protoResp, nil
 }
@@ -863,12 +823,7 @@ func (s *server) PlanResourceChange(ctx context.Context, protoReq *tfplugin6.Pla
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "PlannedState", resp.PlannedState)
 	logging.ProtocolPrivateData(ctx, s.protocolDataDir, rpc, "Response", "PlannedPrivate", resp.PlannedPrivate)
 
-	protoResp, err := toproto.PlanResourceChange_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.PlanResourceChange_Response(resp)
 
 	return protoResp, nil
 }
@@ -903,12 +858,7 @@ func (s *server) ApplyResourceChange(ctx context.Context, protoReq *tfplugin6.Ap
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "NewState", resp.NewState)
 	logging.ProtocolPrivateData(ctx, s.protocolDataDir, rpc, "Response", "Private", resp.Private)
 
-	protoResp, err := toproto.ApplyResourceChange_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ApplyResourceChange_Response(resp)
 
 	return protoResp, nil
 }
@@ -940,11 +890,8 @@ func (s *server) ImportResourceState(ctx context.Context, protoReq *tfplugin6.Im
 		logging.ProtocolPrivateData(ctx, s.protocolDataDir, rpc, "Response_ImportedResource", "Private", importedResource.Private)
 	}
 
-	protoResp, err := toproto.ImportResourceState_Response(resp)
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.ImportResourceState_Response(resp)
+
 	return protoResp, nil
 }
 
@@ -998,13 +945,7 @@ func (s *server) MoveResourceState(ctx context.Context, protoReq *tfplugin6.Move
 	tf6serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "TargetState", resp.TargetState)
 
-	protoResp, err := toproto.MoveResourceState_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]interface{}{logging.KeyError: err})
-
-		return nil, err
-	}
+	protoResp := toproto.MoveResourceState_Response(resp)
 
 	return protoResp, nil
 }
@@ -1059,12 +1000,7 @@ func (s *server) CallFunction(ctx context.Context, protoReq *tfplugin6.CallFunct
 	tf6serverlogging.DownstreamResponse(ctx, resp.Diagnostics)
 	logging.ProtocolData(ctx, s.protocolDataDir, rpc, "Response", "Result", resp.Result)
 
-	protoResp, err := toproto.CallFunction_Response(resp)
-
-	if err != nil {
-		logging.ProtocolError(ctx, "Error converting response to protobuf", map[string]any{logging.KeyError: err})
-		return nil, err
-	}
+	protoResp := toproto.CallFunction_Response(resp)
 
 	return protoResp, nil
 }


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-go/issues/365

It is not possible for an unexpected attribute path step implementation to reach the protocol conversion logic unless there is a protocol change, which the logic should be updated anyways at the same time and unit tested. This simplifies many of the gRPC server handling methods to not need to handle the currently impossible-to-have errors.