### PR TITLE
don't marshal integer values as msgpack floats

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240418-121811.yaml
+++ b/.changes/unreleased/BUG FIXES-20240418-121811.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'tftypes: Large integers are always encoded as msgpack integers rather than
+  float values to ensure the decoded value will not be rounded to 52-bit precision'
+time: 2024-04-18T12:18:11.880247-04:00
+custom:
+  Issue: "396"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.22.2 (Unreleased)
+
+BUG FIXES:
+
+* tftypes: Large integers are always encoded as msgpack integers rather than float values to ensure the decoded value will not be rounded to 52-bit precision ([#396](https://github.com/hashicorp/terraform-plugin-go/pull/396))
+
+
 ## 0.22.1 (March 11, 2024)
 
 NOTES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## 0.22.2 (Unreleased)
-
-BUG FIXES:
-
-* tftypes: Large integers are always encoded as msgpack integers rather than float values to ensure the decoded value will not be rounded to 52-bit precision ([#396](https://github.com/hashicorp/terraform-plugin-go/pull/396))
-
-
 ## 0.22.1 (March 11, 2024)
 
 NOTES:

--- a/tftypes/value_msgpack.go
+++ b/tftypes/value_msgpack.go
@@ -446,7 +446,7 @@ func marshalMsgPackNumber(val Value, typ Type, p *AttributePath, enc *msgpack.En
 		if err != nil {
 			return p.NewErrorf("error encoding int value: %w", err)
 		}
-	} else if fv, acc := n.Float64(); acc == big.Exact {
+	} else if fv, acc := n.Float64(); acc == big.Exact && !n.IsInt() {
 		err := enc.EncodeFloat64(fv)
 		if err != nil {
 			return p.NewErrorf("error encoding float value: %w", err)


### PR DESCRIPTION
Round-tripping a large integer through a float64, even if the binary representation is exact, causes us to end up with a rounded string representation after decoding, because the decoded number has 52-bit precision instead of the 512 we use when dealing with string representations of large integers.

The test fixture was changed slightly to compare only the final value string representations, which more closely corresponds to the configuration and state values. The comparison of the `Value` directly will contain differences in the underlying `math/big` value.

This mirrors the upstream change in go-cty [here](https://github.com/zclconf/go-cty/commit/f41ae52fdfa8a9590aa00c3ab3ff13cef4dd872f), which will be incorporated into the next version of Terraform, ensuring that the round-trip encoding of values is the same in both directions.

Fixes #391