### PR TITLE
tfprotov5+tfprotov6: Remove temporary ResourceServerWithMoveResourceState interface

### DIFF
--- a/.changes/unreleased/BREAKING CHANGES-20240510-105824.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-20240510-105824.yaml
@@ -1,0 +1,6 @@
+kind: BREAKING CHANGES
+body: 'tfprotov5+tfprotov6: Removed temporary `ResourceServerWithMoveResourceState`
+  interface type. Use `ResourceServer` instead.'
+time: 2024-05-10T10:58:24.383876-04:00
+custom:
+  Issue: "408"

--- a/.changes/unreleased/NOTES-20240510-105942.yaml
+++ b/.changes/unreleased/NOTES-20240510-105942.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'all: If using terraform-plugin-mux, it must be upgraded to v0.16.0 or later
+  to prevent compilation errors'
+time: 2024-05-10T10:59:42.325131-04:00
+custom:
+  Issue: "408"

--- a/tfprotov5/resource.go
+++ b/tfprotov5/resource.go
@@ -65,26 +65,6 @@ type ResourceServer interface {
 	MoveResourceState(context.Context, *MoveResourceStateRequest) (*MoveResourceStateResponse, error)
 }
 
-// ResourceServerWithMoveResourceState is a temporary interface for servers
-// to implement MoveResourceState RPC handling.
-//
-// Deprecated: This interface will be removed in a future version. Use
-// ResourceServer instead.
-type ResourceServerWithMoveResourceState interface {
-	ResourceServer
-
-	// MoveResourceState is called when Terraform is asked to change a resource
-	// type for an existing resource. The provider must accept the change as
-	// valid by ensuring the source resource type, schema version, and provider
-	// address are compatible to convert the source state into the target
-	// resource type and latest state version.
-	//
-	// This functionality is only supported in Terraform 1.8 and later. The
-	// provider must have enabled the MoveResourceState server capability to
-	// enable these requests.
-	MoveResourceState(context.Context, *MoveResourceStateRequest) (*MoveResourceStateResponse, error)
-}
-
 // ValidateResourceTypeConfigRequest is the request Terraform sends when it
 // wants to validate a resource's configuration.
 type ValidateResourceTypeConfigRequest struct {

--- a/tfprotov6/resource.go
+++ b/tfprotov6/resource.go
@@ -65,26 +65,6 @@ type ResourceServer interface {
 	MoveResourceState(context.Context, *MoveResourceStateRequest) (*MoveResourceStateResponse, error)
 }
 
-// ResourceServerWithMoveResourceState is a temporary interface for servers
-// to implement MoveResourceState RPC handling.
-//
-// Deprecated: This interface will be removed in a future version. Use
-// ResourceServer instead.
-type ResourceServerWithMoveResourceState interface {
-	ResourceServer
-
-	// MoveResourceState is called when Terraform is asked to change a resource
-	// type for an existing resource. The provider must accept the change as
-	// valid by ensuring the source resource type, schema version, and provider
-	// address are compatible to convert the source state into the target
-	// resource type and latest state version.
-	//
-	// This functionality is only supported in Terraform 1.8 and later. The
-	// provider must have enabled the MoveResourceState server capability to
-	// enable these requests.
-	MoveResourceState(context.Context, *MoveResourceStateRequest) (*MoveResourceStateResponse, error)
-}
-
 // ValidateResourceConfigRequest is the request Terraform sends when it
 // wants to validate a resource's configuration.
 type ValidateResourceConfigRequest struct {


### PR DESCRIPTION
Closes #389

The `ResourceServerWithMoveResourceState` temporary interface was introduced as a way to onboard downstream SDKs onto the new `MoveResourceState` RPC before it was required. This enabled a period where terraform-plugin-go could support new functionality while not causing compilation errors if downstream Go modules happened to be referencing differing SDK versions that may or may not all support the new functionality immediately. Now that those downstream Go modules are referencing `ResourceServer` directly again, the temporary interface can be removed to prevent bloating this Go module.