### PR TITLE
tftypes: Introduce unknown value refinement support for `Value`

### DIFF
--- a/tftypes/refinement/collection_length_lower_bound.go
+++ b/tftypes/refinement/collection_length_lower_bound.go
@@ -5,7 +5,8 @@ package refinement
 
 import "fmt"
 
-// TODO: doc
+// CollectionLengthLowerBound represents an unknown value refinement which indicates the length of the final collection value will be
+// at least the specified int64 value. This refinement can only be applied to List, Map, and Set types.
 type CollectionLengthLowerBound struct {
 	value int64
 }
@@ -23,14 +24,15 @@ func (n CollectionLengthLowerBound) String() string {
 	return fmt.Sprintf("length lower bound = %d", n.LowerBound())
 }
 
-// TODO: doc
+// LowerBound returns the int64 value that the final value's collection length will be at least.
 func (n CollectionLengthLowerBound) LowerBound() int64 {
 	return n.value
 }
 
 func (n CollectionLengthLowerBound) unimplementable() {}
 
-// TODO: doc
+// NewCollectionLengthLowerBound returns the CollectionLengthLowerBound unknown value refinement which indicates the length of the final
+// collection value will be at least the specified int64 value. This refinement can only be applied to List, Map, and Set types.
 func NewCollectionLengthLowerBound(value int64) Refinement {
 	return CollectionLengthLowerBound{
 		value: value,

--- a/tftypes/refinement/collection_length_lower_bound.go
+++ b/tftypes/refinement/collection_length_lower_bound.go
@@ -1,0 +1,33 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package refinement
+
+// TODO: doc
+type CollectionLengthLowerBound struct {
+	value int64
+}
+
+func (n CollectionLengthLowerBound) Equal(Refinement) bool {
+	// TODO: implement
+	return false
+}
+
+func (n CollectionLengthLowerBound) String() string {
+	// TODO: implement
+	return "todo - CollectionLengthLowerBound"
+}
+
+// TODO: doc
+func (n CollectionLengthLowerBound) LowerBound() int64 {
+	return n.value
+}
+
+func (n CollectionLengthLowerBound) unimplementable() {}
+
+// TODO: doc
+func NewCollectionLengthLowerBound(value int64) Refinement {
+	return CollectionLengthLowerBound{
+		value: value,
+	}
+}

--- a/tftypes/refinement/collection_length_lower_bound.go
+++ b/tftypes/refinement/collection_length_lower_bound.go
@@ -3,19 +3,24 @@
 
 package refinement
 
+import "fmt"
+
 // TODO: doc
 type CollectionLengthLowerBound struct {
 	value int64
 }
 
-func (n CollectionLengthLowerBound) Equal(Refinement) bool {
-	// TODO: implement
-	return false
+func (n CollectionLengthLowerBound) Equal(other Refinement) bool {
+	otherVal, ok := other.(CollectionLengthLowerBound)
+	if !ok {
+		return false
+	}
+
+	return n.LowerBound() == otherVal.LowerBound()
 }
 
 func (n CollectionLengthLowerBound) String() string {
-	// TODO: implement
-	return "todo - CollectionLengthLowerBound"
+	return fmt.Sprintf("length lower bound = %d", n.LowerBound())
 }
 
 // TODO: doc

--- a/tftypes/refinement/collection_length_upper_bound.go
+++ b/tftypes/refinement/collection_length_upper_bound.go
@@ -1,0 +1,33 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package refinement
+
+// TODO: doc
+type CollectionLengthUpperBound struct {
+	value int64
+}
+
+func (n CollectionLengthUpperBound) Equal(Refinement) bool {
+	// TODO: implement
+	return false
+}
+
+func (n CollectionLengthUpperBound) String() string {
+	// TODO: implement
+	return "todo - CollectionLengthUpperBound"
+}
+
+// TODO: doc
+func (n CollectionLengthUpperBound) UpperBound() int64 {
+	return n.value
+}
+
+func (n CollectionLengthUpperBound) unimplementable() {}
+
+// TODO: doc
+func NewCollectionLengthUpperBound(value int64) Refinement {
+	return CollectionLengthUpperBound{
+		value: value,
+	}
+}

--- a/tftypes/refinement/collection_length_upper_bound.go
+++ b/tftypes/refinement/collection_length_upper_bound.go
@@ -5,7 +5,8 @@ package refinement
 
 import "fmt"
 
-// TODO: doc
+// CollectionLengthUpperBound represents an unknown value refinement which indicates the length of the final collection value will be
+// at most the specified int64 value. This refinement can only be applied to List, Map, and Set types.
 type CollectionLengthUpperBound struct {
 	value int64
 }
@@ -23,14 +24,15 @@ func (n CollectionLengthUpperBound) String() string {
 	return fmt.Sprintf("length upper bound = %d", n.UpperBound())
 }
 
-// TODO: doc
+// UpperBound returns the int64 value that the final value's collection length will be at most.
 func (n CollectionLengthUpperBound) UpperBound() int64 {
 	return n.value
 }
 
 func (n CollectionLengthUpperBound) unimplementable() {}
 
-// TODO: doc
+// NewCollectionLengthUpperBound returns the CollectionLengthUpperBound unknown value refinement which indicates the length of the final
+// collection value will be at most the specified int64 value. This refinement can only be applied to List, Map, and Set types.
 func NewCollectionLengthUpperBound(value int64) Refinement {
 	return CollectionLengthUpperBound{
 		value: value,

--- a/tftypes/refinement/collection_length_upper_bound.go
+++ b/tftypes/refinement/collection_length_upper_bound.go
@@ -3,19 +3,24 @@
 
 package refinement
 
+import "fmt"
+
 // TODO: doc
 type CollectionLengthUpperBound struct {
 	value int64
 }
 
-func (n CollectionLengthUpperBound) Equal(Refinement) bool {
-	// TODO: implement
-	return false
+func (n CollectionLengthUpperBound) Equal(other Refinement) bool {
+	otherVal, ok := other.(CollectionLengthUpperBound)
+	if !ok {
+		return false
+	}
+
+	return n.UpperBound() == otherVal.UpperBound()
 }
 
 func (n CollectionLengthUpperBound) String() string {
-	// TODO: implement
-	return "todo - CollectionLengthUpperBound"
+	return fmt.Sprintf("length upper bound = %d", n.UpperBound())
 }
 
 // TODO: doc

--- a/tftypes/refinement/doc.go
+++ b/tftypes/refinement/doc.go
@@ -1,5 +1,11 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// TODO: docs
+// The refinement package contains the interfaces and structs that represent unknown value refinement data. Refinements contain
+// additional constraints about unknown values and what their eventual known values can be. In certain scenarios, Terraform can
+// use these constraints to produce known results from unknown values. (like evaluating a count expression comparing an unknown
+// value to "null")
+//
+// Unknown value refinements can be added to a `tftypes.Value` via the `(tftypes.Value).Refine` method. Refinements on an unknown
+// `tftypes.Value` can be retrieved via the `(tftypes.Value).Refinements()` method.
 package refinement

--- a/tftypes/refinement/doc.go
+++ b/tftypes/refinement/doc.go
@@ -1,0 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// TODO: docs
+package refinement

--- a/tftypes/refinement/nullness.go
+++ b/tftypes/refinement/nullness.go
@@ -8,14 +8,23 @@ type Nullness struct {
 	value bool
 }
 
-func (n Nullness) Equal(Refinement) bool {
-	// TODO: implement
-	return false
+func (n Nullness) Equal(other Refinement) bool {
+	otherVal, ok := other.(Nullness)
+	if !ok {
+		return false
+	}
+
+	return n.Nullness() == otherVal.Nullness()
 }
 
 func (n Nullness) String() string {
-	// TODO: implement
-	return "todo - Nullness"
+	if n.value {
+		// This case should never happen, as an unknown value that is definitely null should be
+		// represented as a known null value.
+		return "null"
+	}
+
+	return "not null"
 }
 
 // TODO: doc

--- a/tftypes/refinement/nullness.go
+++ b/tftypes/refinement/nullness.go
@@ -1,7 +1,19 @@
 package refinement
 
+import "github.com/vmihailenco/msgpack/v5"
+
 type nullness struct {
 	Value bool
+}
+
+func (n nullness) Encode(enc *msgpack.Encoder) error {
+	err := enc.EncodeInt(int64(KeyNullness))
+	if err != nil {
+		return err
+	}
+
+	// A value that is definitely null cannot be unknown
+	return enc.EncodeBool(false)
 }
 
 func (n nullness) Equal(Refinement) bool {
@@ -14,6 +26,8 @@ func (n nullness) String() string {
 
 func (n nullness) unimplementable() {}
 
+// TODO: Should this accept a value? If a value is unknown and the it's refined to be null
+// then the value should be a known value of null instead.
 func Nullness(value bool) Refinement {
 	return nullness{
 		Value: value,

--- a/tftypes/refinement/nullness.go
+++ b/tftypes/refinement/nullness.go
@@ -1,21 +1,7 @@
 package refinement
 
-import "github.com/vmihailenco/msgpack/v5"
-
 type Nullness struct {
 	value bool
-}
-
-func (n Nullness) Encode(enc *msgpack.Encoder) error {
-	err := enc.EncodeInt(int64(KeyNullness))
-	if err != nil {
-		return err
-	}
-
-	// It shouldn't be possible for an unknown value to be definitely null (i.e. nullness.value = true),
-	// as that should be represented by a known null value instead. This encoding is in place to be compliant
-	// with Terraform's encoding which uses a definitely null refinement to collapse into a known null value.
-	return enc.EncodeBool(n.value)
 }
 
 func (n Nullness) Equal(Refinement) bool {
@@ -26,8 +12,8 @@ func (n Nullness) String() string {
 	return "todo - Nullness"
 }
 
-func (n Nullness) NotNull() bool {
-	return !n.value
+func (n Nullness) Nullness() bool {
+	return n.value
 }
 
 func (n Nullness) unimplementable() {}

--- a/tftypes/refinement/nullness.go
+++ b/tftypes/refinement/nullness.go
@@ -2,34 +2,38 @@ package refinement
 
 import "github.com/vmihailenco/msgpack/v5"
 
-type nullness struct {
-	Value bool
+type Nullness struct {
+	value bool
 }
 
-func (n nullness) Encode(enc *msgpack.Encoder) error {
+func (n Nullness) Encode(enc *msgpack.Encoder) error {
 	err := enc.EncodeInt(int64(KeyNullness))
 	if err != nil {
 		return err
 	}
 
-	// A value that is definitely null cannot be unknown
-	return enc.EncodeBool(false)
+	// It shouldn't be possible for an unknown value to be definitely null (i.e. nullness.value = true),
+	// as that should be represented by a known null value instead. This encoding is in place to be compliant
+	// with Terraform's encoding which uses a definitely null refinement to collapse into a known null value.
+	return enc.EncodeBool(n.value)
 }
 
-func (n nullness) Equal(Refinement) bool {
+func (n Nullness) Equal(Refinement) bool {
 	return false
 }
 
-func (n nullness) String() string {
-	return "todo - nullness"
+func (n Nullness) String() string {
+	return "todo - Nullness"
 }
 
-func (n nullness) unimplementable() {}
+func (n Nullness) NotNull() bool {
+	return !n.value
+}
 
-// TODO: Should this accept a value? If a value is unknown and the it's refined to be null
-// then the value should be a known value of null instead.
-func Nullness(value bool) Refinement {
-	return nullness{
-		Value: value,
+func (n Nullness) unimplementable() {}
+
+func NewNullness(value bool) Refinement {
+	return Nullness{
+		value: value,
 	}
 }

--- a/tftypes/refinement/nullness.go
+++ b/tftypes/refinement/nullness.go
@@ -1,0 +1,21 @@
+package refinement
+
+type nullness struct {
+	Value bool
+}
+
+func (n nullness) Equal(Refinement) bool {
+	return false
+}
+
+func (n nullness) String() string {
+	return "todo - nullness"
+}
+
+func (n nullness) unimplementable() {}
+
+func Nullness(value bool) Refinement {
+	return nullness{
+		Value: value,
+	}
+}

--- a/tftypes/refinement/nullness.go
+++ b/tftypes/refinement/nullness.go
@@ -1,23 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package refinement
 
+// TODO: doc
 type Nullness struct {
 	value bool
 }
 
 func (n Nullness) Equal(Refinement) bool {
+	// TODO: implement
 	return false
 }
 
 func (n Nullness) String() string {
+	// TODO: implement
 	return "todo - Nullness"
 }
 
+// TODO: doc
 func (n Nullness) Nullness() bool {
 	return n.value
 }
 
 func (n Nullness) unimplementable() {}
 
+// TODO: doc
 func NewNullness(value bool) Refinement {
 	return Nullness{
 		value: value,

--- a/tftypes/refinement/nullness.go
+++ b/tftypes/refinement/nullness.go
@@ -3,7 +3,12 @@
 
 package refinement
 
-// TODO: doc
+// Nullness represents an unknown value refinement that indicates the final value will definitely not be null (Nullness = false). This refinement
+// can be applied to a value of any type (excluding DynamicPseudoType).
+//
+// While an unknown value can be refined to indicate that the final value will definitely be null (Nullness = true), there is no practical reason
+// to do this. This option is exposed to maintain parity with Terraform's type system, while all practical usages of this refinement should collapse
+// to known null values instead.
 type Nullness struct {
 	value bool
 }
@@ -27,14 +32,25 @@ func (n Nullness) String() string {
 	return "not null"
 }
 
-// TODO: doc
+// Nullness returns the underlying refinement data indicating:
+//   - When "false", the final value will definitely not be null.
+//   - When "true", the final value will definitely be null.
+//
+// While an unknown value can be refined to indicate that the final value will definitely be null (Nullness = true), there is no practical reason
+// to do this. This option is exposed to maintain parity with Terraform's type system, while all practical usages of this refinement should collapse
+// to known null values instead.
 func (n Nullness) Nullness() bool {
 	return n.value
 }
 
 func (n Nullness) unimplementable() {}
 
-// TODO: doc
+// NewNullness returns the Nullness unknown value refinement that indicates the final value will definitely not be null (Nullness = false). This refinement
+// can be applied to a value of any type (excluding DynamicPseudoType).
+//
+// While an unknown value can be refined to indicate that the final value will definitely be null (Nullness = true), there is no practical reason
+// to do this. This option is exposed to maintain parity with Terraform's type system, while all practical usages of this refinement should collapse
+// to known null values instead.
 func NewNullness(value bool) Refinement {
 	return Nullness{
 		value: value,

--- a/tftypes/refinement/number_lower_bound.go
+++ b/tftypes/refinement/number_lower_bound.go
@@ -1,0 +1,35 @@
+package refinement
+
+import (
+	"math/big"
+)
+
+type NumberLowerBound struct {
+	inclusive bool
+	value     *big.Float
+}
+
+func (n NumberLowerBound) Equal(Refinement) bool {
+	return false
+}
+
+func (n NumberLowerBound) String() string {
+	return "todo - NumberLowerBound"
+}
+
+func (n NumberLowerBound) IsInclusive() bool {
+	return n.inclusive
+}
+
+func (n NumberLowerBound) LowerBound() *big.Float {
+	return n.value
+}
+
+func (n NumberLowerBound) unimplementable() {}
+
+func NewNumberLowerBound(value *big.Float, inclusive bool) Refinement {
+	return NumberLowerBound{
+		value:     value,
+		inclusive: inclusive,
+	}
+}

--- a/tftypes/refinement/number_lower_bound.go
+++ b/tftypes/refinement/number_lower_bound.go
@@ -8,7 +8,8 @@ import (
 	"math/big"
 )
 
-// TODO: doc
+// NumberLowerBound represents an unknown value refinement that indicates the final value will not be less than the specified
+// *big.Float value, as well as whether that bound is inclusive or exclusive. This refinement can only be applied to the Number type.
 type NumberLowerBound struct {
 	inclusive bool
 	value     *big.Float
@@ -32,19 +33,21 @@ func (n NumberLowerBound) String() string {
 	return fmt.Sprintf("lower bound = %s (%s)", n.LowerBound().String(), rangeDescription)
 }
 
-// TODO: doc
+// IsInclusive returns whether the bound returned by the `LowerBound` method is inclusive or exclusive.
 func (n NumberLowerBound) IsInclusive() bool {
 	return n.inclusive
 }
 
-// TODO: doc
+// LowerBound returns the *big.Float value that the final value will not be less than. The `IsInclusive` method must also be used during
+// comparison to determine whether the bound is inclusive or exclusive.
 func (n NumberLowerBound) LowerBound() *big.Float {
 	return n.value
 }
 
 func (n NumberLowerBound) unimplementable() {}
 
-// TODO: doc
+// NewNumberLowerBound returns the NumberLowerBound unknown value refinement that indicates the final value will not be less than the specified
+// *big.Float value, as well as whether that bound is inclusive or exclusive. This refinement can only be applied to the Number type.
 func NewNumberLowerBound(value *big.Float, inclusive bool) Refinement {
 	return NumberLowerBound{
 		value:     value,

--- a/tftypes/refinement/number_lower_bound.go
+++ b/tftypes/refinement/number_lower_bound.go
@@ -1,32 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package refinement
 
 import (
 	"math/big"
 )
 
+// TODO: doc
 type NumberLowerBound struct {
 	inclusive bool
 	value     *big.Float
 }
 
 func (n NumberLowerBound) Equal(Refinement) bool {
+	// TODO: implement
 	return false
 }
 
 func (n NumberLowerBound) String() string {
+	// TODO: implement
 	return "todo - NumberLowerBound"
 }
 
+// TODO: doc
 func (n NumberLowerBound) IsInclusive() bool {
 	return n.inclusive
 }
 
+// TODO: doc
 func (n NumberLowerBound) LowerBound() *big.Float {
 	return n.value
 }
 
 func (n NumberLowerBound) unimplementable() {}
 
+// TODO: doc
 func NewNumberLowerBound(value *big.Float, inclusive bool) Refinement {
 	return NumberLowerBound{
 		value:     value,

--- a/tftypes/refinement/number_lower_bound.go
+++ b/tftypes/refinement/number_lower_bound.go
@@ -4,6 +4,7 @@
 package refinement
 
 import (
+	"fmt"
 	"math/big"
 )
 
@@ -13,14 +14,22 @@ type NumberLowerBound struct {
 	value     *big.Float
 }
 
-func (n NumberLowerBound) Equal(Refinement) bool {
-	// TODO: implement
-	return false
+func (n NumberLowerBound) Equal(other Refinement) bool {
+	otherVal, ok := other.(NumberLowerBound)
+	if !ok {
+		return false
+	}
+
+	return n.IsInclusive() == otherVal.IsInclusive() && n.LowerBound().Cmp(otherVal.LowerBound()) == 0
 }
 
 func (n NumberLowerBound) String() string {
-	// TODO: implement
-	return "todo - NumberLowerBound"
+	rangeDescription := "inclusive"
+	if !n.IsInclusive() {
+		rangeDescription = "exclusive"
+	}
+
+	return fmt.Sprintf("lower bound = %s (%s)", n.LowerBound().String(), rangeDescription)
 }
 
 // TODO: doc

--- a/tftypes/refinement/number_upper_bound.go
+++ b/tftypes/refinement/number_upper_bound.go
@@ -8,7 +8,8 @@ import (
 	"math/big"
 )
 
-// TODO: doc
+// NumberUpperBound represents an unknown value refinement that indicates the final value will not be greater than the specified
+// *big.Float value, as well as whether that bound is inclusive or exclusive. This refinement can only be applied to the Number type.
 type NumberUpperBound struct {
 	inclusive bool
 	value     *big.Float
@@ -32,19 +33,21 @@ func (n NumberUpperBound) String() string {
 	return fmt.Sprintf("upper bound = %s (%s)", n.UpperBound().String(), rangeDescription)
 }
 
-// TODO: doc
+// IsInclusive returns whether the bound returned by the `UpperBound` method is inclusive or exclusive.
 func (n NumberUpperBound) IsInclusive() bool {
 	return n.inclusive
 }
 
-// TODO: doc
+// UpperBound returns the *big.Float value that the final value will not be greater than. The `IsInclusive` method must also be used during
+// comparison to determine whether the bound is inclusive or exclusive.
 func (n NumberUpperBound) UpperBound() *big.Float {
 	return n.value
 }
 
 func (n NumberUpperBound) unimplementable() {}
 
-// TODO: doc
+// NewNumberUpperBound returns the NumberUpperBound unknown value refinement that indicates the final value will not be greater than the specified
+// *big.Float value, as well as whether that bound is inclusive or exclusive. This refinement can only be applied to the Number type.
 func NewNumberUpperBound(value *big.Float, inclusive bool) Refinement {
 	return NumberUpperBound{
 		value:     value,

--- a/tftypes/refinement/number_upper_bound.go
+++ b/tftypes/refinement/number_upper_bound.go
@@ -1,32 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package refinement
 
 import (
 	"math/big"
 )
 
+// TODO: doc
 type NumberUpperBound struct {
 	inclusive bool
 	value     *big.Float
 }
 
 func (n NumberUpperBound) Equal(Refinement) bool {
+	// TODO: implement
 	return false
 }
 
 func (n NumberUpperBound) String() string {
+	// TODO: implement
 	return "todo - NumberUpperBound"
 }
 
+// TODO: doc
 func (n NumberUpperBound) IsInclusive() bool {
 	return n.inclusive
 }
 
+// TODO: doc
 func (n NumberUpperBound) UpperBound() *big.Float {
 	return n.value
 }
 
 func (n NumberUpperBound) unimplementable() {}
 
+// TODO: doc
 func NewNumberUpperBound(value *big.Float, inclusive bool) Refinement {
 	return NumberUpperBound{
 		value:     value,

--- a/tftypes/refinement/number_upper_bound.go
+++ b/tftypes/refinement/number_upper_bound.go
@@ -1,0 +1,35 @@
+package refinement
+
+import (
+	"math/big"
+)
+
+type NumberUpperBound struct {
+	inclusive bool
+	value     *big.Float
+}
+
+func (n NumberUpperBound) Equal(Refinement) bool {
+	return false
+}
+
+func (n NumberUpperBound) String() string {
+	return "todo - NumberUpperBound"
+}
+
+func (n NumberUpperBound) IsInclusive() bool {
+	return n.inclusive
+}
+
+func (n NumberUpperBound) UpperBound() *big.Float {
+	return n.value
+}
+
+func (n NumberUpperBound) unimplementable() {}
+
+func NewNumberUpperBound(value *big.Float, inclusive bool) Refinement {
+	return NumberUpperBound{
+		value:     value,
+		inclusive: inclusive,
+	}
+}

--- a/tftypes/refinement/number_upper_bound.go
+++ b/tftypes/refinement/number_upper_bound.go
@@ -4,6 +4,7 @@
 package refinement
 
 import (
+	"fmt"
 	"math/big"
 )
 
@@ -13,14 +14,22 @@ type NumberUpperBound struct {
 	value     *big.Float
 }
 
-func (n NumberUpperBound) Equal(Refinement) bool {
-	// TODO: implement
-	return false
+func (n NumberUpperBound) Equal(other Refinement) bool {
+	otherVal, ok := other.(NumberUpperBound)
+	if !ok {
+		return false
+	}
+
+	return n.IsInclusive() == otherVal.IsInclusive() && n.UpperBound().Cmp(otherVal.UpperBound()) == 0
 }
 
 func (n NumberUpperBound) String() string {
-	// TODO: implement
-	return "todo - NumberUpperBound"
+	rangeDescription := "inclusive"
+	if !n.IsInclusive() {
+		rangeDescription = "exclusive"
+	}
+
+	return fmt.Sprintf("upper bound = %s (%s)", n.UpperBound().String(), rangeDescription)
 }
 
 // TODO: doc

--- a/tftypes/refinement/refinement.go
+++ b/tftypes/refinement/refinement.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package refinement
 
 import (
@@ -23,20 +26,56 @@ func (k Key) String() string {
 }
 
 const (
-	KeyNullness         = Key(1)
-	KeyStringPrefix     = Key(2)
+	// KeyNullness represents a refinement that specifies whether the final value will not be null.
+	//
+	// MAINTINAER NOTE: In practice, this refinement data will only contain "false", indicating the final value
+	// cannot be null. If the refinement data was ever set to "true", that would indicate the final value will be null, in which
+	// case the value is not unknown, it is known and should not have any refinement data.
+	//
+	// This refinement is relevant for all types except tftypes.DynamicPseudoType.
+	KeyNullness = Key(1)
+
+	// KeyStringPrefix represents a refinement that specifies a known prefix of a final string value.
+	//
+	// This refinement is only relevant for tftypes.String.
+	KeyStringPrefix = Key(2)
+
+	// KeyNumberLowerBound represents a refinement that specifies the lower bound of possible values for a final number value.
+	// The refinement data contains a boolean which indicates whether the bound is inclusive.
+	//
+	// This refinement is only relevant for tftypes.Number.
 	KeyNumberLowerBound = Key(3)
+
+	// KeyNumberUpperBound represents a refinement that specifies the upper bound of possible values for a final number value.
+	// The refinement data contains a boolean which indicates whether the bound is inclusive.
+	//
+	// This refinement is only relevant for tftypes.Number.
 	KeyNumberUpperBound = Key(4)
-	// KeyCollectionLengthLowerBound = Key(5)
-	// KeyCollectionLengthUpperBound = Key(6)
+
+	// KeyCollectionLengthLowerBound represents a refinement that specifies the lower bound of possible length for a final collection value.
+	//
+	// This refinement is only relevant for tftypes.List, tftypes.Set, and tftypes.Map.
+	KeyCollectionLengthLowerBound = Key(5)
+
+	// KeyCollectionLengthUpperBound represents a refinement that specifies the upper bound of possible length for a final collection value.
+	//
+	// This refinement is only relevant for tftypes.List, tftypes.Set, and tftypes.Map.
+	KeyCollectionLengthUpperBound = Key(6)
 )
 
+// TODO: docs
 type Refinement interface {
+	// Equal should return true if the Refinement is considered equivalent to the
+	// Refinement passed as an argument.
 	Equal(Refinement) bool
+
+	// String should return a human-friendly version of the Refinement.
 	String() string
+
 	unimplementable() // prevents external implementations, all refinements are defined in the Terraform/HCL type system go-cty.
 }
 
+// TODO: docs
 type Refinements map[Key]Refinement
 
 func (r Refinements) Equal(o Refinements) bool {

--- a/tftypes/refinement/refinement.go
+++ b/tftypes/refinement/refinement.go
@@ -12,7 +12,6 @@ import (
 type Key int64
 
 func (k Key) String() string {
-	// TODO: Not sure when this is used, double check the names
 	switch k {
 	case KeyNullness:
 		return "nullness"
@@ -22,6 +21,10 @@ func (k Key) String() string {
 		return "number_lower_bound"
 	case KeyNumberUpperBound:
 		return "number_upper_bound"
+	case KeyCollectionLengthLowerBound:
+		return "collection_length_lower_bound"
+	case KeyCollectionLengthUpperBound:
+		return "collection_length_upper_bound"
 	default:
 		return fmt.Sprintf("unsupported refinement: %d", k)
 	}
@@ -65,7 +68,8 @@ const (
 	KeyCollectionLengthUpperBound = Key(6)
 )
 
-// TODO: docs
+// Refinement represents an unknown value refinement with data constraints relevant to the final value. This interface can be asserted further
+// with the associated structs in the `refinement` package to extract underlying refinement data.
 type Refinement interface {
 	// Equal should return true if the Refinement is considered equivalent to the
 	// Refinement passed as an argument.
@@ -77,7 +81,7 @@ type Refinement interface {
 	unimplementable() // prevents external implementations, all refinements are defined in the Terraform/HCL type system go-cty.
 }
 
-// TODO: docs
+// Refinements represents a map of unknown value refinement data.
 type Refinements map[Key]Refinement
 
 func (r Refinements) Equal(other Refinements) bool {

--- a/tftypes/refinement/refinement.go
+++ b/tftypes/refinement/refinement.go
@@ -1,0 +1,31 @@
+package refinement
+
+type Key int64
+
+func (k Key) String() string {
+	return "todo"
+}
+
+const (
+	KeyNullness = Key(1)
+	// KeyStringPrefix               = Key(2)
+	// KeyNumberLowerBound           = Key(3)
+	// KeyNumberUpperBound           = Key(4)
+	// KeyCollectionLengthLowerBound = Key(5)
+	// KeyCollectionLengthUpperBound = Key(6)
+)
+
+type Refinement interface {
+	Equal(Refinement) bool
+	String() string
+	unimplementable() // prevent external implementations
+}
+
+type Refinements map[Key]Refinement
+
+func (r Refinements) Equal(o Refinements) bool {
+	return false
+}
+func (r Refinements) String() string {
+	return "todo"
+}

--- a/tftypes/refinement/refinement.go
+++ b/tftypes/refinement/refinement.go
@@ -2,8 +2,6 @@ package refinement
 
 import (
 	"fmt"
-
-	"github.com/vmihailenco/msgpack/v5"
 )
 
 type Key int64
@@ -15,23 +13,26 @@ func (k Key) String() string {
 		return "nullness"
 	case KeyStringPrefix:
 		return "string_prefix"
+	case KeyNumberLowerBound:
+		return "number_lower_bound"
+	case KeyNumberUpperBound:
+		return "number_upper_bound"
 	default:
 		return fmt.Sprintf("unsupported refinement: %d", k)
 	}
 }
 
 const (
-	KeyNullness     = Key(1)
-	KeyStringPrefix = Key(2)
-	// KeyNumberLowerBound           = Key(3)
-	// KeyNumberUpperBound           = Key(4)
+	KeyNullness         = Key(1)
+	KeyStringPrefix     = Key(2)
+	KeyNumberLowerBound = Key(3)
+	KeyNumberUpperBound = Key(4)
 	// KeyCollectionLengthLowerBound = Key(5)
 	// KeyCollectionLengthUpperBound = Key(6)
 )
 
 type Refinement interface {
 	Equal(Refinement) bool
-	Encode(*msgpack.Encoder) error
 	String() string
 	unimplementable() // prevents external implementations, all refinements are defined in the Terraform/HCL type system go-cty.
 }

--- a/tftypes/refinement/refinement.go
+++ b/tftypes/refinement/refinement.go
@@ -5,6 +5,8 @@ package refinement
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 )
 
 type Key int64
@@ -78,10 +80,41 @@ type Refinement interface {
 // TODO: docs
 type Refinements map[Key]Refinement
 
-func (r Refinements) Equal(o Refinements) bool {
-	return false
+func (r Refinements) Equal(other Refinements) bool {
+	if len(r) != len(other) {
+		return false
+	}
+
+	for key, refnVal := range r {
+		otherRefnVal, ok := other[key]
+		if !ok {
+			// Didn't find a refinement at the same key
+			return false
+		}
+
+		if !refnVal.Equal(otherRefnVal) {
+			// Refinement data is not equal
+			return false
+		}
+	}
+
+	return true
 }
 func (r Refinements) String() string {
-	// TODO: Not sure when this is used, should just aggregate and call all underlying refinements.String() method
-	return "todo"
+	var res strings.Builder
+
+	keys := make([]Key, 0, len(r))
+	for k := range r {
+		keys = append(keys, k)
+	}
+
+	sort.Slice(keys, func(a, b int) bool { return keys[a] < keys[b] })
+	for pos, key := range keys {
+		if pos != 0 {
+			res.WriteString(", ")
+		}
+		res.WriteString(r[key].String())
+	}
+
+	return res.String()
 }

--- a/tftypes/refinement/refinement.go
+++ b/tftypes/refinement/refinement.go
@@ -1,11 +1,23 @@
 package refinement
 
-import "github.com/vmihailenco/msgpack/v5"
+import (
+	"fmt"
+
+	"github.com/vmihailenco/msgpack/v5"
+)
 
 type Key int64
 
 func (k Key) String() string {
-	return "todo"
+	// TODO: Not sure when this is used, double check the names
+	switch k {
+	case KeyNullness:
+		return "nullness"
+	case KeyStringPrefix:
+		return "string_prefix"
+	default:
+		return fmt.Sprintf("unsupported refinement: %d", k)
+	}
 }
 
 const (
@@ -21,7 +33,7 @@ type Refinement interface {
 	Equal(Refinement) bool
 	Encode(*msgpack.Encoder) error
 	String() string
-	unimplementable() // prevent external implementations
+	unimplementable() // prevents external implementations, all refinements are defined in the Terraform/HCL type system go-cty.
 }
 
 type Refinements map[Key]Refinement
@@ -30,5 +42,6 @@ func (r Refinements) Equal(o Refinements) bool {
 	return false
 }
 func (r Refinements) String() string {
+	// TODO: Not sure when this is used, should just aggregate and call all underlying refinements.String() method
 	return "todo"
 }

--- a/tftypes/refinement/refinement.go
+++ b/tftypes/refinement/refinement.go
@@ -1,5 +1,7 @@
 package refinement
 
+import "github.com/vmihailenco/msgpack/v5"
+
 type Key int64
 
 func (k Key) String() string {
@@ -7,8 +9,8 @@ func (k Key) String() string {
 }
 
 const (
-	KeyNullness = Key(1)
-	// KeyStringPrefix               = Key(2)
+	KeyNullness     = Key(1)
+	KeyStringPrefix = Key(2)
 	// KeyNumberLowerBound           = Key(3)
 	// KeyNumberUpperBound           = Key(4)
 	// KeyCollectionLengthLowerBound = Key(5)
@@ -17,6 +19,7 @@ const (
 
 type Refinement interface {
 	Equal(Refinement) bool
+	Encode(*msgpack.Encoder) error
 	String() string
 	unimplementable() // prevent external implementations
 }

--- a/tftypes/refinement/string_prefix.go
+++ b/tftypes/refinement/string_prefix.go
@@ -3,19 +3,24 @@
 
 package refinement
 
+import "fmt"
+
 // TODO: doc
 type StringPrefix struct {
 	value string
 }
 
-func (s StringPrefix) Equal(Refinement) bool {
-	// TODO: implement
-	return false
+func (s StringPrefix) Equal(other Refinement) bool {
+	otherVal, ok := other.(StringPrefix)
+	if !ok {
+		return false
+	}
+
+	return s.PrefixValue() == otherVal.PrefixValue()
 }
 
 func (s StringPrefix) String() string {
-	// TODO: implement
-	return "todo - stringPrefix"
+	return fmt.Sprintf("prefix = %q", s.PrefixValue())
 }
 
 // TODO: doc

--- a/tftypes/refinement/string_prefix.go
+++ b/tftypes/refinement/string_prefix.go
@@ -5,7 +5,9 @@ package refinement
 
 import "fmt"
 
-// TODO: doc
+// StringPrefix represents an unknown value refinement that indicates the final value will be prefixed with the specified string value.
+// String prefixes that exceed 256 characters in length will be truncated and empty string prefixes will not be encoded. This refinement can
+// only be applied to the String type.
 type StringPrefix struct {
 	value string
 }
@@ -23,14 +25,16 @@ func (s StringPrefix) String() string {
 	return fmt.Sprintf("prefix = %q", s.PrefixValue())
 }
 
-// TODO: doc
+// PrefixValue returns the string value that the final value will be prefixed with.
 func (s StringPrefix) PrefixValue() string {
 	return s.value
 }
 
 func (s StringPrefix) unimplementable() {}
 
-// TODO: doc
+// NewStringPrefix returns the StringPrefix unknown value refinement that indicates the final value will be prefixed with the specified
+// string value. String prefixes that exceed 256 characters in length will be truncated and empty string prefixes will not be encoded. This
+// refinement can only be applied to the String type.
 func NewStringPrefix(value string) Refinement {
 	return StringPrefix{
 		value: value,

--- a/tftypes/refinement/string_prefix.go
+++ b/tftypes/refinement/string_prefix.go
@@ -1,23 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package refinement
 
+// TODO: doc
 type StringPrefix struct {
 	value string
 }
 
 func (s StringPrefix) Equal(Refinement) bool {
+	// TODO: implement
 	return false
 }
 
 func (s StringPrefix) String() string {
+	// TODO: implement
 	return "todo - stringPrefix"
 }
 
+// TODO: doc
 func (s StringPrefix) PrefixValue() string {
 	return s.value
 }
 
 func (s StringPrefix) unimplementable() {}
 
+// TODO: doc
 func NewStringPrefix(value string) Refinement {
 	return StringPrefix{
 		value: value,

--- a/tftypes/refinement/string_prefix.go
+++ b/tftypes/refinement/string_prefix.go
@@ -1,31 +1,7 @@
 package refinement
 
-import "github.com/vmihailenco/msgpack/v5"
-
 type StringPrefix struct {
 	value string
-}
-
-// TODO: What if the prefix is empty? Should we skip encoding? Throw an error earlier? Throw an error here?
-// - I think an empty prefix string is valid, empty string is still more information then wholly unknown?
-// - I wonder what Terraform does in this situation today
-func (s StringPrefix) Encode(enc *msgpack.Encoder) error {
-	// Matching go-cty for the max prefix length allowed here
-	//
-	// This ensures the total size of the refinements blob does not exceed the limit
-	// set by the decoder (1024).
-	maxPrefixLength := 256
-	prefix := s.value
-	if len(s.value) > maxPrefixLength {
-		prefix = prefix[:maxPrefixLength-1]
-	}
-
-	err := enc.EncodeInt(int64(KeyStringPrefix))
-	if err != nil {
-		return err
-	}
-
-	return enc.EncodeString(prefix)
 }
 
 func (s StringPrefix) Equal(Refinement) bool {

--- a/tftypes/refinement/string_prefix.go
+++ b/tftypes/refinement/string_prefix.go
@@ -7,6 +7,8 @@ type stringPrefix struct {
 }
 
 // TODO: What if the prefix is empty? Should we skip encoding? Throw an error earlier? Throw an error here?
+// - I think an empty prefix string is valid, empty string is still more information then wholly unknown?
+// - I wonder what Terraform does in this situation today
 func (s stringPrefix) Encode(enc *msgpack.Encoder) error {
 	// Matching go-cty for the max prefix length allowed here
 	//

--- a/tftypes/refinement/string_prefix.go
+++ b/tftypes/refinement/string_prefix.go
@@ -2,21 +2,21 @@ package refinement
 
 import "github.com/vmihailenco/msgpack/v5"
 
-type stringPrefix struct {
-	Value string
+type StringPrefix struct {
+	value string
 }
 
 // TODO: What if the prefix is empty? Should we skip encoding? Throw an error earlier? Throw an error here?
 // - I think an empty prefix string is valid, empty string is still more information then wholly unknown?
 // - I wonder what Terraform does in this situation today
-func (s stringPrefix) Encode(enc *msgpack.Encoder) error {
+func (s StringPrefix) Encode(enc *msgpack.Encoder) error {
 	// Matching go-cty for the max prefix length allowed here
 	//
 	// This ensures the total size of the refinements blob does not exceed the limit
 	// set by the decoder (1024).
 	maxPrefixLength := 256
-	prefix := s.Value
-	if len(s.Value) > maxPrefixLength {
+	prefix := s.value
+	if len(s.value) > maxPrefixLength {
 		prefix = prefix[:maxPrefixLength-1]
 	}
 
@@ -28,18 +28,22 @@ func (s stringPrefix) Encode(enc *msgpack.Encoder) error {
 	return enc.EncodeString(prefix)
 }
 
-func (s stringPrefix) Equal(Refinement) bool {
+func (s StringPrefix) Equal(Refinement) bool {
 	return false
 }
 
-func (s stringPrefix) String() string {
+func (s StringPrefix) String() string {
 	return "todo - stringPrefix"
 }
 
-func (s stringPrefix) unimplementable() {}
+func (s StringPrefix) PrefixValue() string {
+	return s.value
+}
 
-func StringPrefix(value string) Refinement {
-	return stringPrefix{
-		Value: value,
+func (s StringPrefix) unimplementable() {}
+
+func NewStringPrefix(value string) Refinement {
+	return StringPrefix{
+		value: value,
 	}
 }

--- a/tftypes/refinement/string_prefix.go
+++ b/tftypes/refinement/string_prefix.go
@@ -1,0 +1,43 @@
+package refinement
+
+import "github.com/vmihailenco/msgpack/v5"
+
+type stringPrefix struct {
+	Value string
+}
+
+// TODO: What if the prefix is empty? Should we skip encoding? Throw an error earlier? Throw an error here?
+func (s stringPrefix) Encode(enc *msgpack.Encoder) error {
+	// Matching go-cty for the max prefix length allowed here
+	//
+	// This ensures the total size of the refinements blob does not exceed the limit
+	// set by the decoder (1024).
+	maxPrefixLength := 256
+	prefix := s.Value
+	if len(s.Value) > maxPrefixLength {
+		prefix = prefix[:maxPrefixLength-1]
+	}
+
+	err := enc.EncodeInt(int64(KeyStringPrefix))
+	if err != nil {
+		return err
+	}
+
+	return enc.EncodeString(prefix)
+}
+
+func (s stringPrefix) Equal(Refinement) bool {
+	return false
+}
+
+func (s stringPrefix) String() string {
+	return "todo - stringPrefix"
+}
+
+func (s stringPrefix) unimplementable() {}
+
+func StringPrefix(value string) Refinement {
+	return stringPrefix{
+		Value: value,
+	}
+}

--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -42,8 +42,6 @@ type ValueCreator interface {
 // The recommended usage of a Value is to check that it is known, using
 // Value.IsKnown, then to convert it to a Go type, using Value.As. The Go type
 // can then be manipulated.
-//
-// TODO: add docs for new refinement data
 type Value struct {
 	typ   Type
 	value interface{}
@@ -628,7 +626,10 @@ func unexpectedValueTypeError(p *AttributePath, expected, got interface{}, typ T
 	return p.NewErrorf("unexpected value type %T, %s values must be of type %T", got, typ, expected)
 }
 
-// TODO: doc, mention returning value if not unknown
+// Refine is used to apply unknown refinement data to a Value. This method will return a copy of the Value, fully
+// replacing all the existing refinement data with the provided refinements.
+//
+// If the Value is not unknown, then a copy of the Value will be returned with no refinements.
 func (val Value) Refine(refinements refinement.Refinements) Value {
 	newVal := val.Copy()
 
@@ -648,8 +649,9 @@ func (val Value) Refine(refinements refinement.Refinements) Value {
 	return newVal
 }
 
-// TODO: doc, mention copy
+// Refinements returns the unknown refinement data for the Value.
 func (val Value) Refinements() refinement.Refinements {
+	// Copy the data first to prevent any mutation of the refinement map data.
 	valCopy := val.Copy()
 
 	return valCopy.refinements

--- a/tftypes/value.go
+++ b/tftypes/value.go
@@ -46,6 +46,8 @@ type Value struct {
 	typ   Type
 	value interface{}
 
+	// refinements represents the unknown value refinement data associated with this Value.
+	// This field is only populated for unknown values.
 	refinements refinement.Refinements
 }
 

--- a/tftypes/value_msgpack.go
+++ b/tftypes/value_msgpack.go
@@ -434,6 +434,8 @@ func msgpackUnmarshalUnknown(dec *msgpack.Decoder, typ Type, path *AttributePath
 				return Value{}, path.NewErrorf("failed to decode msgpack extension body: string prefix refinement is not valid UTF-8")
 			}
 
+			// TODO: If terraform doesn't support an empty string prefix, then neither should we, potentially return an error here.
+
 			newRefinements[keyCode] = refinement.StringPrefix(prefix)
 		default:
 			// We don't want to error here, as go-cty could introduce new refinements that we'd
@@ -501,7 +503,8 @@ func marshalUnknownValue(val Value, typ Type, p *AttributePath, enc *msgpack.Enc
 	refnEnc := msgpack.NewEncoder(&refnBuf)
 	mapLen := 0
 
-	// TODO: Should the refinement interface be defining the encoding? Should we export the refinement implementations?
+	// TODO: Should the refinement interface be defining the encoding? Should we export the refinement implementation details?
+	// - If we keep it in the interface, then we can simplify this logic
 	for kind, refn := range val.refinements {
 		switch kind {
 		case refinement.KeyNullness:

--- a/tftypes/value_msgpack.go
+++ b/tftypes/value_msgpack.go
@@ -421,7 +421,11 @@ func msgpackUnmarshalUnknown(dec *msgpack.Decoder, typ Type, path *AttributePath
 			// The presence of this key means we're refining the null-ness one
 			// way or another. If nullness is unknown then this key should not
 			// be present at all.
-			newRefinements[keyCode] = refinement.Nullness(isNull)
+			//
+			// isNull should always be false if this refinement is present, but to match Terraform's support
+			// of this encoding, we will pass along the value. If isNull is true, then the value should not be
+			// unknown with refinements, it should be a known null value.
+			newRefinements[keyCode] = refinement.NewNullness(isNull)
 		case refinement.KeyStringPrefix:
 			if !typ.Is(String) {
 				return Value{}, path.NewErrorf("failed to decode msgpack extension body: string prefix refinement for non-string type")
@@ -436,7 +440,7 @@ func msgpackUnmarshalUnknown(dec *msgpack.Decoder, typ Type, path *AttributePath
 
 			// TODO: If terraform doesn't support an empty string prefix, then neither should we, potentially return an error here.
 
-			newRefinements[keyCode] = refinement.StringPrefix(prefix)
+			newRefinements[keyCode] = refinement.NewStringPrefix(prefix)
 		default:
 			// We don't want to error here, as go-cty could introduce new refinements that we'd
 			// want to just ignore until this logic is updated

--- a/tftypes/value_msgpack.go
+++ b/tftypes/value_msgpack.go
@@ -442,6 +442,10 @@ func msgpackUnmarshalUnknown(dec *msgpack.Decoder, typ Type, path *AttributePath
 
 			newRefinements[keyCode] = refinement.NewStringPrefix(prefix)
 		default:
+			err := rfnDec.Skip()
+			if err != nil {
+				return Value{}, path.NewErrorf("error skipping unknown extension body, keycode = %d: %w", keyCode, err)
+			}
 			// We don't want to error here, as go-cty could introduce new refinements that we'd
 			// want to just ignore until this logic is updated
 			continue

--- a/tftypes/value_msgpack.go
+++ b/tftypes/value_msgpack.go
@@ -17,7 +17,6 @@ import (
 	msgpackCodes "github.com/vmihailenco/msgpack/v5/msgpcode"
 )
 
-// https://github.com/zclconf/go-cty/blob/main/cty/msgpack/unknown.go#L32
 const unknownWithRefinementsExt = 0x0c
 
 type msgPackUnknownType struct{}

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tftypes/refinement"
 )
 
 func numberComparer(i, j *big.Float) bool {
@@ -783,9 +784,166 @@ func TestValueEqual(t *testing.T) {
 			val2:  NewValue(String, UnknownValue),
 			equal: true,
 		},
+		"unknownEqual-bool-refinements": {
+			val1: NewValue(Bool, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness: refinement.NewNullness(false),
+			}),
+			val2: NewValue(Bool, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness: refinement.NewNullness(false),
+			}),
+			equal: true,
+		},
+		"unknownEqual-string-refinements": {
+			val1: NewValue(String, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:     refinement.NewNullness(false),
+				refinement.KeyStringPrefix: refinement.NewStringPrefix("hello"),
+			}),
+			val2: NewValue(String, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:     refinement.NewNullness(false),
+				refinement.KeyStringPrefix: refinement.NewStringPrefix("hello"),
+			}),
+			equal: true,
+		},
+		"unknownEqual-number-refinements": {
+			val1: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5), false),
+			}),
+			val2: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5), false),
+			}),
+			equal: true,
+		},
+		"unknownEqual-number-refinements-float": {
+			val1: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1.23), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5.67), false),
+			}),
+			val2: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1.23), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5.67), false),
+			}),
+			equal: true,
+		},
+		"unknownEqual-list-refinements": {
+			val1: NewValue(List{ElementType: String}, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:                   refinement.NewNullness(false),
+				refinement.KeyCollectionLengthLowerBound: refinement.NewCollectionLengthLowerBound(1),
+				refinement.KeyCollectionLengthUpperBound: refinement.NewCollectionLengthUpperBound(5),
+			}),
+			val2: NewValue(List{ElementType: String}, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:                   refinement.NewNullness(false),
+				refinement.KeyCollectionLengthLowerBound: refinement.NewCollectionLengthLowerBound(1),
+				refinement.KeyCollectionLengthUpperBound: refinement.NewCollectionLengthUpperBound(5),
+			}),
+			equal: true,
+		},
 		"unknownDiff": {
 			val1:  NewValue(String, UnknownValue),
 			val2:  NewValue(String, "world"),
+			equal: false,
+		},
+		"unknownDiff-bool-refinements": {
+			val1: NewValue(Bool, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness: refinement.NewNullness(false),
+			}),
+			val2: NewValue(Bool, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness: refinement.NewNullness(true),
+			}),
+			equal: false,
+		},
+		"unknownDiff-string-refinements": {
+			val1: NewValue(String, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:     refinement.NewNullness(false),
+				refinement.KeyStringPrefix: refinement.NewStringPrefix("hello"),
+			}),
+			val2: NewValue(String, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:     refinement.NewNullness(false),
+				refinement.KeyStringPrefix: refinement.NewStringPrefix("world"),
+			}),
+			equal: false,
+		},
+		"unknownDiff-number-refinements-lowerInclusiveDiff": {
+			val1: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5), true),
+			}),
+			val2: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1), false),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5), true),
+			}),
+			equal: false,
+		},
+		"unknownDiff-number-refinements-upperInclusiveDiff": {
+			val1: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5), true),
+			}),
+			val2: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5), false),
+			}),
+			equal: false,
+		},
+		"unknownDiff-number-refinements-lowerBoundDiff": {
+			val1: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5), true),
+			}),
+			val2: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(3), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5), true),
+			}),
+			equal: false,
+		},
+		"unknownDiff-number-refinements-upperBoundDiff": {
+			val1: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(5), true),
+			}),
+			val2: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(1), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(3), true),
+			}),
+			equal: false,
+		},
+		"unknownDiff-list-refinements-lowerBoundDiff": {
+			val1: NewValue(List{ElementType: String}, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:                   refinement.NewNullness(false),
+				refinement.KeyCollectionLengthLowerBound: refinement.NewCollectionLengthLowerBound(1),
+				refinement.KeyCollectionLengthUpperBound: refinement.NewCollectionLengthUpperBound(5),
+			}),
+			val2: NewValue(List{ElementType: String}, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:                   refinement.NewNullness(false),
+				refinement.KeyCollectionLengthLowerBound: refinement.NewCollectionLengthLowerBound(3),
+				refinement.KeyCollectionLengthUpperBound: refinement.NewCollectionLengthUpperBound(5),
+			}),
+			equal: false,
+		},
+		"unknownDiff-list-refinements-upperBoundDiff": {
+			val1: NewValue(List{ElementType: String}, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:                   refinement.NewNullness(false),
+				refinement.KeyCollectionLengthLowerBound: refinement.NewCollectionLengthLowerBound(1),
+				refinement.KeyCollectionLengthUpperBound: refinement.NewCollectionLengthUpperBound(5),
+			}),
+			val2: NewValue(List{ElementType: String}, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:                   refinement.NewNullness(false),
+				refinement.KeyCollectionLengthLowerBound: refinement.NewCollectionLengthLowerBound(1),
+				refinement.KeyCollectionLengthUpperBound: refinement.NewCollectionLengthUpperBound(3),
+			}),
 			equal: false,
 		},
 		"listEqual": {
@@ -1721,6 +1879,59 @@ func TestValueString(t *testing.T) {
 			in:       Value{},
 			expected: "invalid typeless tftypes.Value<>",
 		},
+		"unknown-bool": {
+			in:       NewValue(Bool, UnknownValue),
+			expected: "tftypes.Bool<unknown>",
+		},
+		"unknown-bool-with-nullness-refinement": {
+			in: NewValue(Bool, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness: refinement.NewNullness(false),
+			}),
+			expected: `tftypes.Bool<unknown, not null>`,
+		},
+		"unknown-string": {
+			in:       NewValue(String, UnknownValue),
+			expected: "tftypes.String<unknown>",
+		},
+		"unknown-string-with-multiple-refinements": {
+			in: NewValue(String, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:     refinement.NewNullness(false),
+				refinement.KeyStringPrefix: refinement.NewStringPrefix("str://"),
+			}),
+			expected: `tftypes.String<unknown, not null, prefix = "str://">`,
+		},
+		"unknown-number": {
+			in:       NewValue(Number, UnknownValue),
+			expected: "tftypes.Number<unknown>",
+		},
+		"unknown-number-with-multiple-refinements": {
+			in: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(5), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(10), true),
+			}),
+			expected: `tftypes.Number<unknown, not null, lower bound = 5 (inclusive), upper bound = 10 (inclusive)>`,
+		},
+		"unknown-number-float-with-multiple-refinements": {
+			in: NewValue(Number, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:         refinement.NewNullness(false),
+				refinement.KeyNumberLowerBound: refinement.NewNumberLowerBound(big.NewFloat(5.67), true),
+				refinement.KeyNumberUpperBound: refinement.NewNumberUpperBound(big.NewFloat(10.123), true),
+			}),
+			expected: `tftypes.Number<unknown, not null, lower bound = 5.67 (inclusive), upper bound = 10.123 (inclusive)>`,
+		},
+		"unknown-list": {
+			in:       NewValue(List{ElementType: String}, UnknownValue),
+			expected: "tftypes.List[tftypes.String]<unknown>",
+		},
+		"unknown-list-with-multiple-refinements": {
+			in: NewValue(List{ElementType: String}, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness:                   refinement.NewNullness(false),
+				refinement.KeyCollectionLengthLowerBound: refinement.NewCollectionLengthLowerBound(2),
+				refinement.KeyCollectionLengthUpperBound: refinement.NewCollectionLengthUpperBound(7),
+			}),
+			expected: `tftypes.List[tftypes.String]<unknown, not null, length lower bound = 2, length upper bound = 7>`,
+		},
 		"string": {
 			in:       NewValue(String, "hello"),
 			expected: "tftypes.String<\"hello\">",
@@ -1873,5 +2084,33 @@ func TestValueString(t *testing.T) {
 				t.Errorf("Unexpected results (-wanted, +got): %s", diff)
 			}
 		})
+	}
+}
+
+func TestValueRefine_immutable(t *testing.T) {
+	t.Parallel()
+
+	originalRefinements := refinement.Refinements{refinement.KeyStringPrefix: refinement.NewStringPrefix("hello")}
+	originalVal := NewValue(String, UnknownValue).Refine(originalRefinements)
+
+	// Attempt to mutate the original refinements map
+	originalRefinements[refinement.KeyStringPrefix] = refinement.NewStringPrefix("world")
+
+	if !originalVal.Equal(NewValue(String, UnknownValue).Refine(refinement.Refinements{refinement.KeyStringPrefix: refinement.NewStringPrefix("hello")})) {
+		t.Fatal("unexpected Refinements mutation")
+	}
+}
+
+func TestValueRefinements_immutable(t *testing.T) {
+	t.Parallel()
+
+	originalVal := NewValue(String, UnknownValue).Refine(refinement.Refinements{refinement.KeyStringPrefix: refinement.NewStringPrefix("hello")})
+	originalRefinements := originalVal.Refinements()
+
+	// Attempt to mutate the original refinements map
+	originalRefinements[refinement.KeyStringPrefix] = refinement.NewStringPrefix("world")
+
+	if !originalVal.Equal(NewValue(String, UnknownValue).Refine(refinement.Refinements{refinement.KeyStringPrefix: refinement.NewStringPrefix("hello")})) {
+		t.Fatal("unexpected Refinements mutation")
 	}
 }

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -784,6 +784,11 @@ func TestValueEqual(t *testing.T) {
 			val2:  NewValue(String, UnknownValue),
 			equal: true,
 		},
+		"unknownEqual-empty-refinements": {
+			val1:  NewValue(Bool, UnknownValue),
+			val2:  NewValue(Bool, UnknownValue).Refine(refinement.Refinements{}),
+			equal: true,
+		},
 		"unknownEqual-bool-refinements": {
 			val1: NewValue(Bool, UnknownValue).Refine(refinement.Refinements{
 				refinement.KeyNullness: refinement.NewNullness(false),
@@ -846,6 +851,20 @@ func TestValueEqual(t *testing.T) {
 		"unknownDiff": {
 			val1:  NewValue(String, UnknownValue),
 			val2:  NewValue(String, "world"),
+			equal: false,
+		},
+		"unknownDiff-nil-refinements": {
+			val1: NewValue(Bool, UnknownValue),
+			val2: NewValue(Bool, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness: refinement.NewNullness(true),
+			}),
+			equal: false,
+		},
+		"unknownDiff-empty-refinements": {
+			val1: NewValue(Bool, UnknownValue).Refine(refinement.Refinements{
+				refinement.KeyNullness: refinement.NewNullness(true),
+			}),
+			val2:  NewValue(Bool, UnknownValue).Refine(refinement.Refinements{}),
 			equal: false,
 		},
 		"unknownDiff-bool-refinements": {


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform/issues/30937
Ref: https://github.com/hashicorp/terraform-plugin-framework/issues/869

--------------------

This PR introduces [value refinement](https://github.com/zclconf/go-cty/blob/63279be090d7ca5fd01e5ecb7f02ac5f0c273ef2/docs/refinements.md) support to the `tftypes` package. This allows Terraform providers to communicate unknown value refinements to/from Terraform core (Terraform 1.6+).

Value refinements are additional constraints that can be applied to unknown values in Terraform that can be used to produce known results from unknown values. For example, with value refinements, providers can now indicate specific attributes will "definitely not be null" during `PlanResourceChange`, which would allow Terraform core to successfully evaluate expressions like `count` during plan, rather than returning an error like:

```bash
│ Error: Invalid count argument
│
│ ...
│
│ The "count" value depends on resource attributes that cannot be
│ determined until apply, so Terraform cannot predict how many
│ instances will be created. To work around this, use the -target
│ argument to first apply only the resources that the count depends
│ on.
```

------------------------

> No changes to existing provider code will be necessary as partially unknown values will still evaluate the same as a wholly unknown value today.

## TODOs left on this PR
- Design is still under review
- Changelogs