### PR TITLE
chore: Update golangci-lint linters and apply fixes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -305,8 +305,6 @@ func TestExample(t *testing.T) {
         },
     }
     for name, testCase := range testCases {
-        // Do not omit this next line
-        name, testCase := name, testCase
         t.Run(name, func(t *testing.T) {
             t.Parallel()
             // Implement test referencing testCase fields

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,9 @@ issues:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - gofmt
     - gosimple
@@ -19,7 +19,7 @@ linters:
     - paralleltest
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
+    - usetesting

--- a/internal/logging/provider_test.go
+++ b/internal/logging/provider_test.go
@@ -27,8 +27,6 @@ func TestProviderLoggerName(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/dynamic_value_test.go
+++ b/tfprotov5/dynamic_value_test.go
@@ -66,8 +66,6 @@ func TestDynamicValueIsNull(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/diag/diagnostics_test.go
+++ b/tfprotov5/internal/diag/diagnostics_test.go
@@ -145,8 +145,6 @@ func TestDiagnosticsErrorCount(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -435,8 +433,6 @@ func TestDiagnosticsLog(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -588,8 +584,6 @@ func TestDiagnosticsWarningCount(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/fromproto/client_capabilities_test.go
+++ b/tfprotov5/internal/fromproto/client_capabilities_test.go
@@ -39,8 +39,6 @@ func TestValidateResourceTypeConfigClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -79,8 +77,6 @@ func TestConfigureProviderClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -119,8 +115,6 @@ func TestReadDataSourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -159,8 +153,6 @@ func TestReadResourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -199,8 +191,6 @@ func TestPlanResourceChangeClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -239,8 +229,6 @@ func TestImportResourceStateClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -279,8 +267,6 @@ func TestOpenEphemeralResourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/fromproto/data_source_test.go
+++ b/tfprotov5/internal/fromproto/data_source_test.go
@@ -66,8 +66,6 @@ func TestReadDataSourceRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -114,8 +112,6 @@ func TestValidateDataSourceConfigRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/fromproto/ephemeral_resource_test.go
+++ b/tfprotov5/internal/fromproto/ephemeral_resource_test.go
@@ -47,8 +47,6 @@ func TestValidateEphemeralResourceConfigRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -107,8 +105,6 @@ func TestOpenEphemeralResourceRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -155,8 +151,6 @@ func TestRenewEphemeralResourceRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -203,8 +197,6 @@ func TestCloseEphemeralResourceRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/fromproto/function_test.go
+++ b/tfprotov5/internal/fromproto/function_test.go
@@ -53,8 +53,6 @@ func TestCallFunctionRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -85,8 +83,6 @@ func TestGetFunctionsRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/fromproto/provider_test.go
+++ b/tfprotov5/internal/fromproto/provider_test.go
@@ -30,8 +30,6 @@ func TestGetMetadataRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -62,8 +60,6 @@ func TestGetProviderSchemaRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -94,8 +90,6 @@ func TestGetResourceIdentitySchemasRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -154,8 +148,6 @@ func TestConfigureProviderRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -194,8 +186,6 @@ func TestPrepareProviderConfigRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -226,8 +216,6 @@ func TestStopProviderRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/fromproto/resource_test.go
+++ b/tfprotov5/internal/fromproto/resource_test.go
@@ -87,8 +87,6 @@ func TestApplyResourceChangeRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -155,8 +153,6 @@ func TestImportResourceStateRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -243,8 +239,6 @@ func TestMoveResourceStateRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -343,8 +337,6 @@ func TestPlanResourceChangeRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -427,8 +419,6 @@ func TestReadResourceRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -483,8 +473,6 @@ func TestUpgradeResourceStateRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -539,8 +527,6 @@ func TestUpgradeResourceIdentityRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -599,8 +585,6 @@ func TestValidateResourceTypeConfigRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/funcerr/function_error_test.go
+++ b/tfprotov5/internal/funcerr/function_error_test.go
@@ -53,8 +53,6 @@ func TestFunctionErrorHasError(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -126,8 +124,6 @@ func TestFunctionErrorLog(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/tf5serverlogging/client_capabilities_test.go
+++ b/tfprotov5/internal/tf5serverlogging/client_capabilities_test.go
@@ -61,8 +61,6 @@ func TestValidateResourceTypeConfigClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -130,8 +128,6 @@ func TestConfigureProviderClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -199,8 +195,6 @@ func TestReadDataSourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -268,8 +262,6 @@ func TestReadResourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -337,8 +329,6 @@ func TestPlanResourceChangeClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -406,8 +396,6 @@ func TestImportResourceStateClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -475,8 +463,6 @@ func TestOpenEphemeralResourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/tf5serverlogging/deferred_test.go
+++ b/tfprotov5/internal/tf5serverlogging/deferred_test.go
@@ -54,8 +54,6 @@ func TestDeferred(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/tf5serverlogging/downstream_request_test.go
+++ b/tfprotov5/internal/tf5serverlogging/downstream_request_test.go
@@ -180,8 +180,6 @@ func TestDownstreamResponse(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -296,8 +294,6 @@ func TestDownstreamResponseWithError(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/tf5serverlogging/server_capabilities_test.go
+++ b/tfprotov5/internal/tf5serverlogging/server_capabilities_test.go
@@ -97,8 +97,6 @@ func TestServerCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/attribute_path_test.go
+++ b/tfprotov5/internal/toproto/attribute_path_test.go
@@ -45,8 +45,6 @@ func TestAttributePath(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -128,8 +126,6 @@ func TestAttributePaths(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -193,8 +189,6 @@ func TestAttributePath_Step(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -263,8 +257,6 @@ func TestAttributePath_Steps(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/data_source_test.go
+++ b/tfprotov5/internal/toproto/data_source_test.go
@@ -39,8 +39,6 @@ func TestGetMetadata_DataSourceMetadata(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -115,8 +113,6 @@ func TestReadDataSource_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -172,8 +168,6 @@ func TestValidateDataSourceConfig_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/deferred_test.go
+++ b/tfprotov5/internal/toproto/deferred_test.go
@@ -61,8 +61,6 @@ func TestDeferred(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/diagnostic_test.go
+++ b/tfprotov5/internal/toproto/diagnostic_test.go
@@ -92,8 +92,6 @@ func TestDiagnostic(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -170,8 +168,6 @@ func TestDiagnostics(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -240,7 +236,6 @@ func TestForceValidUTF8(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.Input, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/ephemeral_resource_test.go
+++ b/tfprotov5/internal/toproto/ephemeral_resource_test.go
@@ -41,8 +41,6 @@ func TestGetMetadata_EphemeralResourceMetadata(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -95,8 +93,6 @@ func TestValidateEphemeralResourceConfig_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -190,8 +186,6 @@ func TestOpenEphemeralResource_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -266,8 +260,6 @@ func TestRenewEphemeralResource_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -323,8 +315,6 @@ func TestCloseEphemeralResource_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/function_test.go
+++ b/tfprotov5/internal/toproto/function_test.go
@@ -58,8 +58,6 @@ func TestCallFunction_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -181,8 +179,6 @@ func TestFunction(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -271,8 +267,6 @@ func TestFunction_Parameter(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -319,8 +313,6 @@ func TestFunction_Return(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -397,8 +389,6 @@ func TestGetFunctions_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -449,8 +439,6 @@ func TestGetMetadata_FunctionMetadata(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/provider_test.go
+++ b/tfprotov5/internal/toproto/provider_test.go
@@ -47,8 +47,6 @@ func TestConfigureProvider_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -207,8 +205,6 @@ func TestGetMetadata_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -476,8 +472,6 @@ func TestGetProviderSchema_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -580,8 +574,6 @@ func TestGetResourceIdentitySchemas_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -646,8 +638,6 @@ func TestPrepareProviderConfig_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -696,8 +686,6 @@ func TestStopProvider_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/resource_identity_schema_test.go
+++ b/tfprotov5/internal/toproto/resource_identity_schema_test.go
@@ -57,8 +57,6 @@ func TestResourceIdentitySchema(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -138,8 +136,6 @@ func TestResourceIdentitySchema_IdentityAttribute(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -208,8 +204,6 @@ func TestResourceIdentitySchema_IdentityAttributes(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/resource_test.go
+++ b/tfprotov5/internal/toproto/resource_test.go
@@ -82,8 +82,6 @@ func TestApplyResourceChange_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -135,8 +133,6 @@ func TestGetMetadata_ResourceMetadata(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -222,8 +218,6 @@ func TestImportResourceState_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -297,8 +291,6 @@ func TestImportResourceState_ImportedResource(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -369,8 +361,6 @@ func TestImportResourceState_ImportedResources(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -441,8 +431,6 @@ func TestMoveResourceState_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -574,8 +562,6 @@ func TestPlanResourceChange_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -674,8 +660,6 @@ func TestReadResource_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -741,8 +725,6 @@ func TestUpgradeResourceState_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -806,8 +788,6 @@ func TestUpgradeResourceIdentity_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -863,8 +843,6 @@ func TestValidateResourceTypeConfig_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/schema_test.go
+++ b/tfprotov5/internal/toproto/schema_test.go
@@ -62,8 +62,6 @@ func TestSchema(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -185,8 +183,6 @@ func TestSchema_Attribute(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -255,8 +251,6 @@ func TestSchema_Attributes(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -372,8 +366,6 @@ func TestSchema_Block(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -467,8 +459,6 @@ func TestSchema_NestedBlock(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -539,8 +529,6 @@ func TestSchema_NestedBlocks(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/internal/toproto/server_capabilities_test.go
+++ b/tfprotov5/internal/toproto/server_capabilities_test.go
@@ -55,8 +55,6 @@ func TestServerCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/raw_identity_test.go
+++ b/tfprotov5/raw_identity_test.go
@@ -69,7 +69,6 @@ func TestRawIdentityUnmarshalWithOpts(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/schema_test.go
+++ b/tfprotov5/schema_test.go
@@ -102,8 +102,6 @@ func TestSchemaAttributeValueType(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -184,8 +182,6 @@ func TestSchemaBlockValueType(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -498,8 +494,6 @@ func TestSchemaNestedBlockValueType(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -590,8 +584,6 @@ func TestSchemaValueType(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov5/state_test.go
+++ b/tfprotov5/state_test.go
@@ -69,7 +69,6 @@ func TestRawStateUnmarshalWithOpts(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/dynamic_value_test.go
+++ b/tfprotov6/dynamic_value_test.go
@@ -66,8 +66,6 @@ func TestDynamicValueIsNull(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/diag/diagnostics_test.go
+++ b/tfprotov6/internal/diag/diagnostics_test.go
@@ -145,8 +145,6 @@ func TestDiagnosticsErrorCount(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -435,8 +433,6 @@ func TestDiagnosticsLog(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -588,8 +584,6 @@ func TestDiagnosticsWarningCount(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/fromproto/client_capabilities_test.go
+++ b/tfprotov6/internal/fromproto/client_capabilities_test.go
@@ -39,8 +39,6 @@ func TestValidateResourceConfigClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -79,8 +77,6 @@ func TestConfigureProviderClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -119,8 +115,6 @@ func TestReadDataSourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -159,8 +153,6 @@ func TestReadResourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -199,8 +191,6 @@ func TestPlanResourceChangeClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -239,8 +229,6 @@ func TestImportResourceStateClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -279,8 +267,6 @@ func TestOpenEphemeralResourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/fromproto/data_source_test.go
+++ b/tfprotov6/internal/fromproto/data_source_test.go
@@ -66,8 +66,6 @@ func TestReadDataSourceRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -114,8 +112,6 @@ func TestValidateDataResourceConfigRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/fromproto/ephemeral_resource_test.go
+++ b/tfprotov6/internal/fromproto/ephemeral_resource_test.go
@@ -47,8 +47,6 @@ func TestValidateEphemeralResourceConfigRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -107,8 +105,6 @@ func TestOpenEphemeralResourceRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -155,8 +151,6 @@ func TestRenewEphemeralResourceRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -203,8 +197,6 @@ func TestCloseEphemeralResourceRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/fromproto/function_test.go
+++ b/tfprotov6/internal/fromproto/function_test.go
@@ -53,8 +53,6 @@ func TestCallFunctionRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -85,8 +83,6 @@ func TestGetFunctionsRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/fromproto/provider_test.go
+++ b/tfprotov6/internal/fromproto/provider_test.go
@@ -30,8 +30,6 @@ func TestGetMetadataRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -62,8 +60,6 @@ func TestGetProviderSchemaRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -122,8 +118,6 @@ func TestConfigureProviderRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -154,8 +148,6 @@ func TestStopProviderRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -194,8 +186,6 @@ func TestValidateProviderConfigRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/fromproto/resource_test.go
+++ b/tfprotov6/internal/fromproto/resource_test.go
@@ -79,8 +79,6 @@ func TestApplyResourceChangeRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -139,8 +137,6 @@ func TestImportResourceStateRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -219,8 +215,6 @@ func TestMoveResourceStateRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -311,8 +305,6 @@ func TestPlanResourceChangeRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -387,8 +379,6 @@ func TestReadResourceRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -443,8 +433,6 @@ func TestUpgradeResourceStateRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -503,8 +491,6 @@ func TestValidateResourceConfigRequest(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/funcerr/function_error_test.go
+++ b/tfprotov6/internal/funcerr/function_error_test.go
@@ -53,8 +53,6 @@ func TestFunctionErrorHasError(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -126,8 +124,6 @@ func TestFunctionErrorLog(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/tf6serverlogging/client_capabilities_test.go
+++ b/tfprotov6/internal/tf6serverlogging/client_capabilities_test.go
@@ -61,8 +61,6 @@ func TestValidateResourceConfigClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -130,8 +128,6 @@ func TestConfigureProviderClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -199,8 +195,6 @@ func TestReadDataSourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -268,8 +262,6 @@ func TestReadResourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -337,8 +329,6 @@ func TestPlanResourceChangeClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -406,8 +396,6 @@ func TestImportResourceStateClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -475,8 +463,6 @@ func TestOpenEphemeralResourceClientCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/tf6serverlogging/deferred_test.go
+++ b/tfprotov6/internal/tf6serverlogging/deferred_test.go
@@ -54,8 +54,6 @@ func TestDeferred(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/tf6serverlogging/downstream_request_test.go
+++ b/tfprotov6/internal/tf6serverlogging/downstream_request_test.go
@@ -180,8 +180,6 @@ func TestDownstreamResponse(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -296,8 +294,6 @@ func TestDownstreamResponseWithError(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/tf6serverlogging/server_capabilities_test.go
+++ b/tfprotov6/internal/tf6serverlogging/server_capabilities_test.go
@@ -97,8 +97,6 @@ func TestServerCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/toproto/attribute_path_test.go
+++ b/tfprotov6/internal/toproto/attribute_path_test.go
@@ -45,8 +45,6 @@ func TestAttributePath(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -128,8 +126,6 @@ func TestAttributePaths(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -193,8 +189,6 @@ func TestAttributePath_Step(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -263,8 +257,6 @@ func TestAttributePath_Steps(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/toproto/data_source_test.go
+++ b/tfprotov6/internal/toproto/data_source_test.go
@@ -39,8 +39,6 @@ func TestGetMetadata_DataSourceMetadata(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -115,8 +113,6 @@ func TestReadDataSource_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -172,8 +168,6 @@ func TestValidateDataResourceConfig_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/toproto/deferred_test.go
+++ b/tfprotov6/internal/toproto/deferred_test.go
@@ -61,8 +61,6 @@ func TestDeferred(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/toproto/diagnostic_test.go
+++ b/tfprotov6/internal/toproto/diagnostic_test.go
@@ -92,8 +92,6 @@ func TestDiagnostic(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -170,8 +168,6 @@ func TestDiagnostics(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -240,7 +236,6 @@ func TestForceValidUTF8(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.Input, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/toproto/ephemeral_resource_test.go
+++ b/tfprotov6/internal/toproto/ephemeral_resource_test.go
@@ -41,8 +41,6 @@ func TestGetMetadata_EphemeralResourceMetadata(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -95,8 +93,6 @@ func TestValidateEphemeralResourceConfig_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -190,8 +186,6 @@ func TestOpenEphemeralResource_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -266,8 +260,6 @@ func TestRenewEphemeralResource_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -323,8 +315,6 @@ func TestCloseEphemeralResource_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/toproto/function_test.go
+++ b/tfprotov6/internal/toproto/function_test.go
@@ -58,8 +58,6 @@ func TestCallFunction_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -181,8 +179,6 @@ func TestFunction(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -271,8 +267,6 @@ func TestFunction_Parameter(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -319,8 +313,6 @@ func TestFunction_Return(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -397,8 +389,6 @@ func TestGetFunctions_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -449,8 +439,6 @@ func TestGetMetadata_FunctionMetadata(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/toproto/provider_test.go
+++ b/tfprotov6/internal/toproto/provider_test.go
@@ -47,8 +47,6 @@ func TestConfigureProvider_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -207,8 +205,6 @@ func TestGetMetadata_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -476,8 +472,6 @@ func TestGetProviderSchema_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -537,8 +531,6 @@ func TestValidateProviderConfig_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -586,8 +578,6 @@ func TestStopProvider_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/toproto/resource_test.go
+++ b/tfprotov6/internal/toproto/resource_test.go
@@ -73,8 +73,6 @@ func TestApplyResourceChange_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -125,8 +123,6 @@ func TestGetMetadata_ResourceMetadata(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -212,8 +208,6 @@ func TestImportResourceState_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -279,8 +273,6 @@ func TestImportResourceState_ImportedResource(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -350,8 +342,6 @@ func TestImportResourceState_ImportedResources(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -422,8 +412,6 @@ func TestMoveResourceState_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -545,8 +533,6 @@ func TestPlanResourceChange_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -635,8 +621,6 @@ func TestReadResource_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -701,8 +685,6 @@ func TestUpgradeResourceState_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -757,8 +739,6 @@ func TestValidateResourceConfig_Response(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/toproto/schema_test.go
+++ b/tfprotov6/internal/toproto/schema_test.go
@@ -62,8 +62,6 @@ func TestSchema(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -207,8 +205,6 @@ func TestSchema_Attribute(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -278,8 +274,6 @@ func TestSchema_Attributes(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -395,8 +389,6 @@ func TestSchema_Block(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -490,8 +482,6 @@ func TestSchema_NestedBlock(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -562,8 +552,6 @@ func TestSchema_NestedBlocks(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -629,8 +617,6 @@ func TestSchema_Object(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/internal/toproto/server_capabilities_test.go
+++ b/tfprotov6/internal/toproto/server_capabilities_test.go
@@ -55,8 +55,6 @@ func TestServerCapabilities(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/schema_test.go
+++ b/tfprotov6/schema_test.go
@@ -364,8 +364,6 @@ func TestSchemaAttributeValueType(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -446,8 +444,6 @@ func TestSchemaBlockValueType(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -760,8 +756,6 @@ func TestSchemaNestedBlockValueType(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1034,8 +1028,6 @@ func TestSchemaObjectValueType(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1126,8 +1118,6 @@ func TestSchemaValueType(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfprotov6/state_test.go
+++ b/tfprotov6/state_test.go
@@ -69,7 +69,6 @@ func TestRawStateUnmarshalWithOpts(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/attribute_path_error_test.go
+++ b/tftypes/attribute_path_error_test.go
@@ -87,7 +87,6 @@ func TestAttributePathErrorEqual(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/attribute_path_test.go
+++ b/tftypes/attribute_path_test.go
@@ -345,7 +345,6 @@ func TestWalkAttributePath(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			result, remaining, err := WalkAttributePath(test.in, test.path)
@@ -683,7 +682,6 @@ func TestAttributePathEqual(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			isEqual := test.path1.Equal(test.path2)
@@ -740,7 +738,6 @@ func TestAttributePathLastStep(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -806,7 +803,6 @@ func TestAttributePathString(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			str := test.path.String()
@@ -853,7 +849,6 @@ func TestAttributeNameEqual(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -903,7 +898,6 @@ func TestElementKeyIntEqual(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -953,7 +947,6 @@ func TestElementKeyStringEqual(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -1003,8 +996,6 @@ func TestElementKeyValueEqual(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/diff_test.go
+++ b/tftypes/diff_test.go
@@ -415,7 +415,6 @@ func TestValueDiffEqual(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			isEqual := test.diff1.Equal(test.diff2)
@@ -559,7 +558,6 @@ func TestValueDiffDiff(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/list_test.go
+++ b/tftypes/list_test.go
@@ -58,8 +58,6 @@ func TestListApplyTerraform5AttributePathStep(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -138,7 +136,6 @@ func TestListEqual(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -230,7 +227,6 @@ func TestListIs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -323,7 +319,6 @@ func TestListUsableAs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/map_test.go
+++ b/tftypes/map_test.go
@@ -52,8 +52,6 @@ func TestMapApplyTerraform5AttributePathStep(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -132,7 +130,6 @@ func TestMapEqual(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -219,7 +216,6 @@ func TestMapIs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -312,7 +308,6 @@ func TestMapUsableAs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/object_test.go
+++ b/tftypes/object_test.go
@@ -60,8 +60,6 @@ func TestObjectApplyTerraform5AttributePathStep(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -240,7 +238,6 @@ func TestObjectEqual(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -436,7 +433,6 @@ func TestObjectIs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -624,7 +620,6 @@ func TestObjectUsableAs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/primitive_test.go
+++ b/tftypes/primitive_test.go
@@ -118,8 +118,6 @@ func TestPrimitiveApplyTerraform5AttributePathStep(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -157,7 +155,6 @@ func TestPrimitiveEqual(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -194,7 +191,6 @@ func TestPrimitiveIs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -267,7 +263,6 @@ func TestPrimitiveUsableAs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/set_test.go
+++ b/tftypes/set_test.go
@@ -52,8 +52,6 @@ func TestSetApplyTerraform5AttributePathStep(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -132,7 +130,6 @@ func TestSetEqual(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -219,7 +216,6 @@ func TestSetIs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -312,7 +308,6 @@ func TestSetUsableAs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/tuple_test.go
+++ b/tftypes/tuple_test.go
@@ -64,8 +64,6 @@ func TestTupleApplyTerraform5AttributePathStep(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -149,7 +147,6 @@ func TestTupleEqual(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -241,7 +238,6 @@ func TestTupleIs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -339,7 +335,6 @@ func TestTupleUsableAs(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/type_json_test.go
+++ b/tftypes/type_json_test.go
@@ -188,7 +188,6 @@ func TestTypeJSON(t *testing.T) {
 	}
 
 	for name, test := range testCases {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/value_dpt_test.go
+++ b/tftypes/value_dpt_test.go
@@ -125,7 +125,6 @@ func Test_newValue_dpt(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/value_json_test.go
+++ b/tftypes/value_json_test.go
@@ -396,7 +396,6 @@ func TestValueFromJSON(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			val, err := ValueFromJSON([]byte(test.json), test.typ)
@@ -456,7 +455,6 @@ func TestValueFromJSONWithOpts(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			val, err := ValueFromJSONWithOpts([]byte(test.json), test.typ, ValueFromJSONOpts{

--- a/tftypes/value_list_test.go
+++ b/tftypes/value_list_test.go
@@ -77,7 +77,6 @@ func Test_newValue_list(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/value_map_test.go
+++ b/tftypes/value_map_test.go
@@ -77,7 +77,6 @@ func Test_newValue_map(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/value_msgpack_test.go
+++ b/tftypes/value_msgpack_test.go
@@ -534,7 +534,6 @@ func TestValueFromMsgPack(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got, err := test.value.MarshalMsgPack(test.typ) //nolint:staticcheck

--- a/tftypes/value_number_test.go
+++ b/tftypes/value_number_test.go
@@ -234,7 +234,6 @@ func TestNewValue_number(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if !test.expected.Equal(test.result) {

--- a/tftypes/value_object_test.go
+++ b/tftypes/value_object_test.go
@@ -218,7 +218,6 @@ func Test_newValue_object(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/value_set_test.go
+++ b/tftypes/value_set_test.go
@@ -77,7 +77,6 @@ func Test_newValue_set(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/value_test.go
+++ b/tftypes/value_test.go
@@ -431,7 +431,6 @@ func TestValueAs(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -709,7 +708,6 @@ func TestValueIsKnown(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			known := test.value.IsKnown()
@@ -1203,7 +1201,6 @@ func TestValueEqual(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if result := test.val1.Equal(test.val2); result != test.equal {
@@ -1585,7 +1582,6 @@ func TestValueApplyTerraform5AttributePathStep(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1693,7 +1689,6 @@ func TestValueWalkAttributePath(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			result, remaining, err := WalkAttributePath(test.val, test.path)
@@ -1864,7 +1859,6 @@ func TestValueString(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/value_tuple_test.go
+++ b/tftypes/value_tuple_test.go
@@ -135,7 +135,6 @@ func Test_newValue_tuple(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tftypes/walk_test.go
+++ b/tftypes/walk_test.go
@@ -1707,7 +1707,6 @@ func TestTransform(t *testing.T) {
 	}
 
 	for name, testCase := range tests {
-		name, testCase := name, testCase
 		t.Run(fmt.Sprintf("testCase=%s", name), func(t *testing.T) {
 			t.Parallel()
 
@@ -1958,8 +1957,6 @@ func TestTransform_OriginalValueUnmodified(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
> Follow-up to #476 where we found the linter deprecations

If you're not familiar what the fix/original behavior was (or are like me and completely forgot since we're always 1 go version behind 😆): [Fixing For Loops in Go 1.22](https://go.dev/blog/loopvar-preview)