### PR TITLE
feat: Add `WithManagedDebugEnvFilePath()` option that allows writing `TF_REATTACH_PROVIDERS` to an environment file

### DIFF
--- a/.changes/unreleased/FEATURES-20250307-153800.yaml
+++ b/.changes/unreleased/FEATURES-20250307-153800.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: Add WithManagedDebugEnvFilePath() option that allows writing TF_REATTACH_PROVIDERS to an environment file
+time: 2025-03-07T15:38:00.962006+01:00
+custom:
+    Issue: "484"

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -104,6 +104,7 @@ type ServeConfig struct {
 	managedDebug                      bool
 	managedDebugReattachConfigTimeout time.Duration
 	managedDebugStopSignals           []os.Signal
+	managedDebugEnvFilePath           string
 
 	disableLogInitStderr bool
 	disableLogLocation   bool
@@ -174,6 +175,15 @@ func WithManagedDebugStopSignals(signals []os.Signal) ServeOpt {
 func WithManagedDebugReattachConfigTimeout(timeout time.Duration) ServeOpt {
 	return serveConfigFunc(func(in *ServeConfig) error {
 		in.managedDebugReattachConfigTimeout = timeout
+		return nil
+	})
+}
+
+// WithManagedDebugEnvFilePath returns a ServeOpt that will set the output path
+// for the managed debug process to write the reattach configuration into.
+func WithManagedDebugEnvFilePath(path string) ServeOpt {
+	return serveConfigFunc(func(in *ServeConfig) error {
+		in.managedDebugEnvFilePath = path
 		return nil
 	})
 }
@@ -379,6 +389,15 @@ func Serve(name string, serverFactory func() tfprotov6.ProviderServer, opts ...S
 	}
 
 	fmt.Println("")
+
+	if conf.managedDebugEnvFilePath != "" {
+		fmt.Printf("Writing reattach configuration to env file at path %s\n", conf.managedDebugEnvFilePath)
+
+		err = os.WriteFile(conf.managedDebugEnvFilePath, []byte(fmt.Sprintf("%s='%s'\n", envTfReattachProviders, strings.ReplaceAll(reattachStr, `'`, `'"'"'`))), 0644)
+		if err != nil {
+			return fmt.Errorf("Error writing to env file at path %s: %w", conf.managedDebugEnvFilePath, err)
+		}
+	}
 
 	// Wait for the server to be done.
 	<-conf.debugCloseCh


### PR DESCRIPTION
This PR introduces the option to write the `TF_REATTACH_PROVIDERS` environment variable (and its value) into a file that can be used by downstream tooling.
For example, it can be used in a VSCode launch configuration for debugging Terraform, which allows to debug both provider and Terraform at the same time without the constant need to change `TF_REATTACH_PROVIDERS` in Terraform's debug configuration:

<img width="671" alt="image" src="https://github.com/user-attachments/assets/6df77637-f931-4ae6-9359-bdaa138d769e" />