### PR TITLE
tfprotov5+6: Add `ValueType` implementation to identity schemas

### DIFF
--- a/tfprotov5/resource_identity_schema.go
+++ b/tfprotov5/resource_identity_schema.go
@@ -21,6 +21,37 @@ type ResourceIdentitySchema struct {
 	IdentityAttributes []*ResourceIdentitySchemaAttribute
 }
 
+// ValueType returns the tftypes.Type for a ResourceIdentitySchema.
+//
+// If ResourceIdentitySchema is missing, an empty Object is returned.
+func (s *ResourceIdentitySchema) ValueType() tftypes.Type {
+	if s == nil {
+		return tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{},
+		}
+	}
+
+	attributeTypes := map[string]tftypes.Type{}
+
+	for _, attribute := range s.IdentityAttributes {
+		if attribute == nil {
+			continue
+		}
+
+		attributeType := attribute.ValueType()
+
+		if attributeType == nil {
+			continue
+		}
+
+		attributeTypes[attribute.Name] = attributeType
+	}
+
+	return tftypes.Object{
+		AttributeTypes: attributeTypes,
+	}
+}
+
 // ResourceIdentitySchemaAttribute represents one value of data within
 // resource identity.
 // These are always used in resource identity comparisons.
@@ -55,4 +86,15 @@ type ResourceIdentitySchemaAttribute struct {
 
 	// Description is a human-readable description of the attribute.
 	Description string
+}
+
+// ValueType returns the tftypes.Type for a ResourceIdentitySchemaAttribute.
+//
+// If ResourceIdentitySchemaAttribute is missing, nil is returned.
+func (s *ResourceIdentitySchemaAttribute) ValueType() tftypes.Type {
+	if s == nil {
+		return nil
+	}
+
+	return s.Type
 }

--- a/tfprotov5/resource_identity_schema_test.go
+++ b/tfprotov5/resource_identity_schema_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfprotov5_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestResourceIdentitySchemaValueType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		identitySchema *tfprotov5.ResourceIdentitySchema
+		expected       tftypes.Type
+	}{
+		"nil": {
+			identitySchema: nil,
+			expected: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{},
+			},
+		},
+		"Attribute-String": {
+			identitySchema: &tfprotov5.ResourceIdentitySchema{
+				IdentityAttributes: []*tfprotov5.ResourceIdentitySchemaAttribute{
+					{
+						Name: "test_string_attribute",
+						Type: tftypes.String,
+					},
+				},
+			},
+			expected: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"test_string_attribute": tftypes.String,
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.identitySchema.ValueType()
+
+			if testCase.expected == nil {
+				if got == nil {
+					return
+				}
+
+				t.Fatalf("expected nil, got: %s", got)
+			}
+
+			if !testCase.expected.Equal(got) {
+				t.Errorf("expected %s, got: %s", testCase.expected, got)
+			}
+		})
+	}
+}
+
+func TestResourceIdentitySchemaAttributeValueType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		identitySchemaAttribute *tfprotov5.ResourceIdentitySchemaAttribute
+		expected                tftypes.Type
+	}{
+		"nil": {
+			identitySchemaAttribute: nil,
+			expected:                nil,
+		},
+		"Bool": {
+			identitySchemaAttribute: &tfprotov5.ResourceIdentitySchemaAttribute{
+				Type: tftypes.Bool,
+			},
+			expected: tftypes.Bool,
+		},
+		"List-String": {
+			identitySchemaAttribute: &tfprotov5.ResourceIdentitySchemaAttribute{
+				Type: tftypes.List{
+					ElementType: tftypes.String,
+				},
+			},
+			expected: tftypes.List{
+				ElementType: tftypes.String,
+			},
+		},
+		"Number": {
+			identitySchemaAttribute: &tfprotov5.ResourceIdentitySchemaAttribute{
+				Type: tftypes.Number,
+			},
+			expected: tftypes.Number,
+		},
+		"String": {
+			identitySchemaAttribute: &tfprotov5.ResourceIdentitySchemaAttribute{
+				Type: tftypes.String,
+			},
+			expected: tftypes.String,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.identitySchemaAttribute.ValueType()
+
+			if testCase.expected == nil {
+				if got == nil {
+					return
+				}
+
+				t.Fatalf("expected nil, got: %s", got)
+			}
+
+			if !testCase.expected.Equal(got) {
+				t.Errorf("expected %s, got: %s", testCase.expected, got)
+			}
+		})
+	}
+}

--- a/tfprotov6/resource_identity_schema.go
+++ b/tfprotov6/resource_identity_schema.go
@@ -21,6 +21,37 @@ type ResourceIdentitySchema struct {
 	IdentityAttributes []*ResourceIdentitySchemaAttribute
 }
 
+// ValueType returns the tftypes.Type for a ResourceIdentitySchema.
+//
+// If ResourceIdentitySchema is missing, an empty Object is returned.
+func (s *ResourceIdentitySchema) ValueType() tftypes.Type {
+	if s == nil {
+		return tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{},
+		}
+	}
+
+	attributeTypes := map[string]tftypes.Type{}
+
+	for _, attribute := range s.IdentityAttributes {
+		if attribute == nil {
+			continue
+		}
+
+		attributeType := attribute.ValueType()
+
+		if attributeType == nil {
+			continue
+		}
+
+		attributeTypes[attribute.Name] = attributeType
+	}
+
+	return tftypes.Object{
+		AttributeTypes: attributeTypes,
+	}
+}
+
 // ResourceIdentitySchemaAttribute represents one value of data within
 // resource identity.
 // These are always used in resource identity comparisons.
@@ -55,4 +86,15 @@ type ResourceIdentitySchemaAttribute struct {
 
 	// Description is a human-readable description of the attribute.
 	Description string
+}
+
+// ValueType returns the tftypes.Type for a ResourceIdentitySchemaAttribute.
+//
+// If ResourceIdentitySchemaAttribute is missing, nil is returned.
+func (s *ResourceIdentitySchemaAttribute) ValueType() tftypes.Type {
+	if s == nil {
+		return nil
+	}
+
+	return s.Type
 }

--- a/tfprotov6/resource_identity_schema_test.go
+++ b/tfprotov6/resource_identity_schema_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfprotov6_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestResourceIdentitySchemaValueType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		identitySchema *tfprotov6.ResourceIdentitySchema
+		expected       tftypes.Type
+	}{
+		"nil": {
+			identitySchema: nil,
+			expected: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{},
+			},
+		},
+		"Attribute-String": {
+			identitySchema: &tfprotov6.ResourceIdentitySchema{
+				IdentityAttributes: []*tfprotov6.ResourceIdentitySchemaAttribute{
+					{
+						Name: "test_string_attribute",
+						Type: tftypes.String,
+					},
+				},
+			},
+			expected: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"test_string_attribute": tftypes.String,
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.identitySchema.ValueType()
+
+			if testCase.expected == nil {
+				if got == nil {
+					return
+				}
+
+				t.Fatalf("expected nil, got: %s", got)
+			}
+
+			if !testCase.expected.Equal(got) {
+				t.Errorf("expected %s, got: %s", testCase.expected, got)
+			}
+		})
+	}
+}
+
+func TestResourceIdentitySchemaAttributeValueType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		identitySchemaAttribute *tfprotov6.ResourceIdentitySchemaAttribute
+		expected                tftypes.Type
+	}{
+		"nil": {
+			identitySchemaAttribute: nil,
+			expected:                nil,
+		},
+		"Bool": {
+			identitySchemaAttribute: &tfprotov6.ResourceIdentitySchemaAttribute{
+				Type: tftypes.Bool,
+			},
+			expected: tftypes.Bool,
+		},
+		"List-String": {
+			identitySchemaAttribute: &tfprotov6.ResourceIdentitySchemaAttribute{
+				Type: tftypes.List{
+					ElementType: tftypes.String,
+				},
+			},
+			expected: tftypes.List{
+				ElementType: tftypes.String,
+			},
+		},
+		"Number": {
+			identitySchemaAttribute: &tfprotov6.ResourceIdentitySchemaAttribute{
+				Type: tftypes.Number,
+			},
+			expected: tftypes.Number,
+		},
+		"String": {
+			identitySchemaAttribute: &tfprotov6.ResourceIdentitySchemaAttribute{
+				Type: tftypes.String,
+			},
+			expected: tftypes.String,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.identitySchemaAttribute.ValueType()
+
+			if testCase.expected == nil {
+				if got == nil {
+					return
+				}
+
+				t.Fatalf("expected nil, got: %s", got)
+			}
+
+			if !testCase.expected.Equal(got) {
+				t.Errorf("expected %s, got: %s", testCase.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the `(*ResourceIdentitySchema).ValueType()` and `(*ResourceIdentitySchemaAttribute).ValueType()` implementations to retrieve the relevant `tftypes.Type`.

This can be useful for decoding dynamic values like we do in the `testprovider`  implementation in `terraform-plugin-testing`: https://github.com/hashicorp/terraform-plugin-testing/pull/468/files#diff-4a86857e52f10a46f3a385f0dc7eed824866ff9d6edbe23c0fb4aa09b1156394