### PR TITLE
all: Remove temporary `ProviderServerWithResourceIdentity` interface

### DIFF
--- a/.changes/unreleased/BREAKING CHANGES-20250521-145243.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-20250521-145243.yaml
@@ -1,0 +1,5 @@
+kind: BREAKING CHANGES
+body: 'tfprotov5+tfprotov6: Removed temporary `ProviderServerWithResourceIdentity` interface type. Use `ProviderServer` instead.'
+time: 2025-05-21T14:52:43.175919-04:00
+custom:
+    Issue: "516"

--- a/.changes/unreleased/BREAKING CHANGES-20250521-145326.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-20250521-145326.yaml
@@ -1,0 +1,7 @@
+kind: BREAKING CHANGES
+body: 'tfprotov5+tfprotov6: `GetResourceIdentitySchemas` and `UpgradeResourceIdentity` RPC calls are now required in
+  `ProviderServer` and `ResourceServer`. Implementations not needing resource identity support can return empty responses from the `GetResourceIdentitySchemas` method
+  and an error message the `UpgradeResourceIdentity` method.'
+time: 2025-05-21T14:53:26.293403-04:00
+custom:
+    Issue: "516"

--- a/.changes/unreleased/BREAKING CHANGES-20250521-145326.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-20250521-145326.yaml
@@ -1,6 +1,6 @@
 kind: BREAKING CHANGES
 body: 'tfprotov5+tfprotov6: `GetResourceIdentitySchemas` and `UpgradeResourceIdentity` RPC calls are now required in
-  `ProviderServer` and `ResourceServer`. Implementations that don't support resource identity can return empty responses from the `GetResourceIdentitySchemas` method
+  `ProviderServer` and `ResourceServer`. Implementations that don''t support resource identity can return empty responses from the `GetResourceIdentitySchemas` method
   and an error message the `UpgradeResourceIdentity` method.'
 time: 2025-05-21T14:53:26.293403-04:00
 custom:

--- a/.changes/unreleased/BREAKING CHANGES-20250521-145326.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-20250521-145326.yaml
@@ -1,6 +1,6 @@
 kind: BREAKING CHANGES
 body: 'tfprotov5+tfprotov6: `GetResourceIdentitySchemas` and `UpgradeResourceIdentity` RPC calls are now required in
-  `ProviderServer` and `ResourceServer`. Implementations not needing resource identity support can return empty responses from the `GetResourceIdentitySchemas` method
+  `ProviderServer` and `ResourceServer`. Implementations that don't support resource identity can return empty responses from the `GetResourceIdentitySchemas` method
   and an error message the `UpgradeResourceIdentity` method.'
 time: 2025-05-21T14:53:26.293403-04:00
 custom:

--- a/.changes/unreleased/NOTES-20250521-145307.yaml
+++ b/.changes/unreleased/NOTES-20250521-145307.yaml
@@ -1,5 +1,5 @@
 kind: NOTES
-body: 'all: To prevent compilation errors, ensure your Go module is updated to at least terraform-plugin-framework@v1.15.0, terraform-plugin-mux@v0.20.0, terraform
+body: 'all: To prevent compilation errors, ensure your Go module is updated to at least terraform-plugin-framework@v1.15.0, terraform-plugin-mux@v0.20.0,
     terraform-plugin-sdk/v2@v2.37.0, and terraform-plugin-testing@v1.13.0 before upgrading this dependency.'
 time: 2025-05-21T14:53:07.094145-04:00
 custom:

--- a/.changes/unreleased/NOTES-20250521-145307.yaml
+++ b/.changes/unreleased/NOTES-20250521-145307.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'all: To prevent compilation errors, ensure your Go module is updated to at least terraform-plugin-framework@v1.15.0, terraform-plugin-mux@v0.20.0, terraform
+    terraform-plugin-sdk/v2@v2.37.0, and terraform-plugin-testing@v1.13.0 before upgrading this dependency.'
+time: 2025-05-21T14:53:07.094145-04:00
+custom:
+    Issue: "516"

--- a/tfprotov5/provider.go
+++ b/tfprotov5/provider.go
@@ -24,7 +24,7 @@ type ProviderServer interface {
 
 	// GetResourceIdentitySchemas is called when Terraform needs to know
 	// what the provider's resource identity schemas are.
-	GetResourceIdentitySchemas(context.Context, *GetResourceIdentitySchemasRequest) (*GetResourceIdentitySchemasResponse, error) // This will go into the ProviderServer interface
+	GetResourceIdentitySchemas(context.Context, *GetResourceIdentitySchemasRequest) (*GetResourceIdentitySchemasResponse, error)
 
 	// PrepareProviderConfig is called to give a provider a chance to
 	// modify the configuration the user specified before validation.

--- a/tfprotov5/provider.go
+++ b/tfprotov5/provider.go
@@ -22,6 +22,10 @@ type ProviderServer interface {
 	// and data sources.
 	GetProviderSchema(context.Context, *GetProviderSchemaRequest) (*GetProviderSchemaResponse, error)
 
+	// GetResourceIdentitySchemas is called when Terraform needs to know
+	// what the provider's resource identity schemas are.
+	GetResourceIdentitySchemas(context.Context, *GetResourceIdentitySchemasRequest) (*GetResourceIdentitySchemasResponse, error) // This will go into the ProviderServer interface
+
 	// PrepareProviderConfig is called to give a provider a chance to
 	// modify the configuration the user specified before validation.
 	PrepareProviderConfig(context.Context, *PrepareProviderConfigRequest) (*PrepareProviderConfigResponse, error)
@@ -61,29 +65,6 @@ type ProviderServer interface {
 	// ephemeral resource is to terraform-plugin-go, so they're their own
 	// interface that is composed into ProviderServer.
 	EphemeralResourceServer
-}
-
-// ProviderServerWithResourceIdentity is a temporary interface for servers
-// to implement Resource Identity RPC handling with:
-//
-// - GetResourceIdentitySchemas
-// - UpgradeResourceIdentity
-//
-// Deprecated: All methods will be moved into the
-// ProviderServer and ResourceServer interfaces and this interface will be removed in a future
-// version.
-type ProviderServerWithResourceIdentity interface {
-	ProviderServer
-
-	// GetResourceIdentitySchemas is called when Terraform needs to know
-	// what the provider's resource identity schemas are.
-	GetResourceIdentitySchemas(context.Context, *GetResourceIdentitySchemasRequest) (*GetResourceIdentitySchemasResponse, error) // This will go into the ProviderServer interface
-
-	// UpgradeResourceIdentity is called when Terraform has encountered a
-	// resource with an identity state in a schema that doesn't match the schema's
-	// current version. It is the provider's responsibility to modify the
-	// identity state to upgrade it to the latest state schema.
-	UpgradeResourceIdentity(context.Context, *UpgradeResourceIdentityRequest) (*UpgradeResourceIdentityResponse, error) // This will go into the ResourceServer interface
 }
 
 // GetMetadataRequest represents a GetMetadata RPC request.

--- a/tfprotov5/resource.go
+++ b/tfprotov5/resource.go
@@ -63,6 +63,12 @@ type ResourceServer interface {
 	// provider must have enabled the MoveResourceState server capability to
 	// enable these requests.
 	MoveResourceState(context.Context, *MoveResourceStateRequest) (*MoveResourceStateResponse, error)
+
+	// UpgradeResourceIdentity is called when Terraform has encountered a
+	// resource with an identity state in a schema that doesn't match the schema's
+	// current version. It is the provider's responsibility to modify the
+	// identity state to upgrade it to the latest state schema.
+	UpgradeResourceIdentity(context.Context, *UpgradeResourceIdentityRequest) (*UpgradeResourceIdentityResponse, error)
 }
 
 // ValidateResourceTypeConfigRequest is the request Terraform sends when it

--- a/tfprotov5/tf5server/server.go
+++ b/tfprotov5/tf5server/server.go
@@ -572,31 +572,7 @@ func (s *server) GetResourceIdentitySchemas(ctx context.Context, protoReq *tfplu
 
 	ctx = tf5serverlogging.DownstreamRequest(ctx)
 
-	// TODO: Remove this check and error in preference of
-	// s.downstream.GetResourceIdentitySchemas below once ProviderServer interface
-	// implements this RPC method.
-	// nolint:staticcheck
-	resourceIdentityProviderServer, ok := s.downstream.(tfprotov5.ProviderServerWithResourceIdentity)
-	if !ok {
-		logging.ProtocolError(ctx, "ProviderServer does not implement GetResourceIdentitySchemas")
-
-		protoResp := &tfplugin5.GetResourceIdentitySchemas_Response{
-			Diagnostics: []*tfplugin5.Diagnostic{
-				{
-					Severity: tfplugin5.Diagnostic_ERROR,
-					Summary:  "Provider GetResourceIdentitySchemas Not Implemented",
-					Detail: "A GetResourceIdentitySchemas call was received by the provider, however the provider does not implement the call. " +
-						"Either upgrade the provider to a version that implements resource identity support or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return protoResp, nil
-	}
-
-	// TODO: Update this to call downstream once optional interface is removed
-	// resp, err := s.downstream.GetResourceIdentitySchemas(ctx, req)
-	resp, err := resourceIdentityProviderServer.GetResourceIdentitySchemas(ctx, req)
+	resp, err := s.downstream.GetResourceIdentitySchemas(ctx, req)
 
 	if err != nil {
 		logging.ProtocolError(ctx, "Error from downstream", map[string]interface{}{logging.KeyError: err})
@@ -845,31 +821,7 @@ func (s *server) UpgradeResourceIdentity(ctx context.Context, protoReq *tfplugin
 
 	ctx = tf5serverlogging.DownstreamRequest(ctx)
 
-	// TODO: Remove this check and error in preference of
-	// s.downstream.UpgradeResourceIdentity below once ProviderServer interface
-	// implements this RPC method.
-	// nolint:staticcheck
-	resourceIdentityProviderServer, ok := s.downstream.(tfprotov5.ProviderServerWithResourceIdentity)
-	if !ok {
-		logging.ProtocolError(ctx, "ProviderServer does not implement UpgradeResourceIdentity")
-
-		protoResp := &tfplugin5.UpgradeResourceIdentity_Response{
-			Diagnostics: []*tfplugin5.Diagnostic{
-				{
-					Severity: tfplugin5.Diagnostic_ERROR,
-					Summary:  "Provider UpgradeResourceIdentity Not Implemented",
-					Detail: "A UpgradeResourceIdentity call was received by the provider, however the provider does not implement the call. " +
-						"Either upgrade the provider to a version that implements resource identity support or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return protoResp, nil
-	}
-
-	// TODO: Update this to call downstream once optional interface is removed
-	// resp, err := s.downstream.UpgradeResourceIdentity(ctx, req)
-	resp, err := resourceIdentityProviderServer.UpgradeResourceIdentity(ctx, req)
+	resp, err := s.downstream.UpgradeResourceIdentity(ctx, req)
 
 	if err != nil {
 		logging.ProtocolError(ctx, "Error from downstream", map[string]interface{}{logging.KeyError: err})

--- a/tfprotov6/provider.go
+++ b/tfprotov6/provider.go
@@ -22,6 +22,10 @@ type ProviderServer interface {
 	// and data sources.
 	GetProviderSchema(context.Context, *GetProviderSchemaRequest) (*GetProviderSchemaResponse, error)
 
+	// GetResourceIdentitySchemas is called when Terraform needs to know
+	// what the provider's resource identity schemas are.
+	GetResourceIdentitySchemas(context.Context, *GetResourceIdentitySchemasRequest) (*GetResourceIdentitySchemasResponse, error)
+
 	// ValidateProviderConfig is called to give a provider a chance to
 	// validate the configuration the user specified.
 	ValidateProviderConfig(context.Context, *ValidateProviderConfigRequest) (*ValidateProviderConfigResponse, error)
@@ -61,29 +65,6 @@ type ProviderServer interface {
 	// ephemeral resource is to terraform-plugin-go, so they're their own
 	// interface that is composed into ProviderServer.
 	EphemeralResourceServer
-}
-
-// ProviderServerWithResourceIdentity is a temporary interface for servers
-// to implement Resource Identity RPC handling with:
-//
-// - GetResourceIdentitySchemas
-// - UpgradeResourceIdentity
-//
-// Deprecated: All methods will be moved into the
-// ProviderServer and ResourceServer interfaces and this interface will be removed in a future
-// version.
-type ProviderServerWithResourceIdentity interface {
-	ProviderServer
-
-	// GetResourceIdentitySchemas is called when Terraform needs to know
-	// what the provider's resource identity schemas are.
-	GetResourceIdentitySchemas(context.Context, *GetResourceIdentitySchemasRequest) (*GetResourceIdentitySchemasResponse, error) // This will go into the ProviderServer interface
-
-	// UpgradeResourceIdentity is called when Terraform has encountered a
-	// resource with an identity state in a schema that doesn't match the schema's
-	// current version. It is the provider's responsibility to modify the
-	// identity state to upgrade it to the latest state schema.
-	UpgradeResourceIdentity(context.Context, *UpgradeResourceIdentityRequest) (*UpgradeResourceIdentityResponse, error) // This will go into the ResourceServer interface
 }
 
 // GetMetadataRequest represents a GetMetadata RPC request.

--- a/tfprotov6/resource.go
+++ b/tfprotov6/resource.go
@@ -63,6 +63,12 @@ type ResourceServer interface {
 	// provider must have enabled the MoveResourceState server capability to
 	// enable these requests.
 	MoveResourceState(context.Context, *MoveResourceStateRequest) (*MoveResourceStateResponse, error)
+
+	// UpgradeResourceIdentity is called when Terraform has encountered a
+	// resource with an identity state in a schema that doesn't match the schema's
+	// current version. It is the provider's responsibility to modify the
+	// identity state to upgrade it to the latest state schema.
+	UpgradeResourceIdentity(context.Context, *UpgradeResourceIdentityRequest) (*UpgradeResourceIdentityResponse, error)
 }
 
 // ValidateResourceConfigRequest is the request Terraform sends when it

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -572,31 +572,7 @@ func (s *server) GetResourceIdentitySchemas(ctx context.Context, protoReq *tfplu
 
 	ctx = tf6serverlogging.DownstreamRequest(ctx)
 
-	// TODO: Remove this check and error in preference of
-	// s.downstream.GetResourceIdentitySchemas below once ProviderServer interface
-	// implements this RPC method.
-	// nolint:staticcheck
-	resourceIdentityProviderServer, ok := s.downstream.(tfprotov6.ProviderServerWithResourceIdentity)
-	if !ok {
-		logging.ProtocolError(ctx, "ProviderServer does not implement GetResourceIdentitySchemas")
-
-		protoResp := &tfplugin6.GetResourceIdentitySchemas_Response{
-			Diagnostics: []*tfplugin6.Diagnostic{
-				{
-					Severity: tfplugin6.Diagnostic_ERROR,
-					Summary:  "Provider GetResourceIdentitySchemas Not Implemented",
-					Detail: "A GetResourceIdentitySchemas call was received by the provider, however the provider does not implement the call. " +
-						"Either upgrade the provider to a version that implements resource identity support or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return protoResp, nil
-	}
-
-	// TODO: Update this to call downstream once optional interface is removed
-	// resp, err := s.downstream.GetResourceIdentitySchemas(ctx, req)
-	resp, err := resourceIdentityProviderServer.GetResourceIdentitySchemas(ctx, req)
+	resp, err := s.downstream.GetResourceIdentitySchemas(ctx, req)
 
 	if err != nil {
 		logging.ProtocolError(ctx, "Error from downstream", map[string]interface{}{logging.KeyError: err})
@@ -846,31 +822,7 @@ func (s *server) UpgradeResourceIdentity(ctx context.Context, protoReq *tfplugin
 
 	ctx = tf6serverlogging.DownstreamRequest(ctx)
 
-	// TODO: Remove this check and error in preference of
-	// s.downstream.UpgradeResourceIdentity below once ProviderServer interface
-	// implements this RPC method.
-	// nolint:staticcheck
-	resourceIdentityProviderServer, ok := s.downstream.(tfprotov6.ProviderServerWithResourceIdentity)
-	if !ok {
-		logging.ProtocolError(ctx, "ProviderServer does not implement UpgradeResourceIdentity")
-
-		protoResp := &tfplugin6.UpgradeResourceIdentity_Response{
-			Diagnostics: []*tfplugin6.Diagnostic{
-				{
-					Severity: tfplugin6.Diagnostic_ERROR,
-					Summary:  "Provider UpgradeResourceIdentity Not Implemented",
-					Detail: "A UpgradeResourceIdentity call was received by the provider, however the provider does not implement the call. " +
-						"Either upgrade the provider to a version that implements resource identity support or this is a bug in Terraform that should be reported to the Terraform maintainers.",
-				},
-			},
-		}
-
-		return protoResp, nil
-	}
-
-	// TODO: Update this to call downstream once optional interface is removed
-	// resp, err := s.downstream.UpgradeResourceIdentity(ctx, req)
-	resp, err := resourceIdentityProviderServer.UpgradeResourceIdentity(ctx, req)
+	resp, err := s.downstream.UpgradeResourceIdentity(ctx, req)
 
 	if err != nil {
 		logging.ProtocolError(ctx, "Error from downstream", map[string]interface{}{logging.KeyError: err})


### PR DESCRIPTION
## Related Issue

Closes https://github.com/hashicorp/terraform-plugin-go/issues/478

## Description

This PR removes the `ProviderServerWithResourceIdentity` temporary interface, which was causing issues with providers not implementing it fully via muxed providers or when implementing a plugin-go server, since Terraform v1.12.1 will call `GetResourceIdentitySchemas` even if the provider doesn't support identity (GRPC unimplemented codes keep older providers from failing)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

N/A
