### PR TITLE
Add `tfprotov{5,6}.NoListResults` for convenience

### DIFF
--- a/tfprotov5/list_resource.go
+++ b/tfprotov5/list_resource.go
@@ -53,6 +53,9 @@ type ListResourceServerStream struct {
 	Results iter.Seq[ListResourceResult]
 }
 
+// NoListResults is a convenient value to return when there are no list results.
+var NoListResults = func(func(ListResourceResult) bool) {}
+
 type ListResourceResult struct { // TODO: propose rename in protocol: ListResource_Event -> ListResource_Result
 	// DisplayName is the display name of the resource. This is a ...
 	DisplayName string

--- a/tfprotov5/tf5server/server.go
+++ b/tfprotov5/tf5server/server.go
@@ -1210,8 +1210,7 @@ func (s *server) ValidateListResourceConfig(ctx context.Context, protoReq *tfplu
 
 	ctx = tf5serverlogging.DownstreamRequest(ctx)
 
-	// TODO: Remove this check and error in preference of
-	// s.downstream.ValidateListResourceConfig below once ProviderServer interface
+	// TODO: Remove this check and error once ProviderServer interface
 	// implements this RPC method.
 	// nolint:staticcheck
 	listResourceServer, ok := s.downstream.(tfprotov5.ProviderServerWithListResource)

--- a/tfprotov6/list_resource.go
+++ b/tfprotov6/list_resource.go
@@ -53,6 +53,9 @@ type ListResourceServerStream struct {
 	Results iter.Seq[ListResourceResult]
 }
 
+// NoListResults is a convenient value to return when there are no list results.
+var NoListResults = func(func(ListResourceResult) bool) {}
+
 type ListResourceResult struct { // TODO: propose rename in protocol: ListResource_Event -> ListResource_Result
 	// DisplayName is the display name of the resource. This is a ...
 	DisplayName string

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -1264,8 +1264,7 @@ func (s *server) ListResource(protoReq *tfplugin6.ListResource_Request, protoStr
 
 	ctx = tf6serverlogging.DownstreamRequest(ctx)
 
-	// TODO: Remove this check and error in preference of
-	// s.downstream.ValidateListResourceConfig below once ProviderServer interface
+	// TODO: Remove this check and error once ProviderServer interface
 	// implements this RPC method.
 	// nolint:staticcheck
 	downstream, ok := s.downstream.(tfprotov6.ProviderServerWithListResource)


### PR DESCRIPTION
## Description

This change adds an exported `NoListResults` variable to the `tfprotov5` and `tfprotov6` packages. This is a syntactic convenience to be used by SDKs as a default value.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No