### PR TITLE
Revert "Update CHANGELOG.md"

### DIFF
--- a/.changes/0.29.0-alpha.1.md
+++ b/.changes/0.29.0-alpha.1.md
@@ -1,9 +1,0 @@
-## 0.29.0-alpha.1 (July 08, 2025)
-
-NOTES:
-
-* This alpha pre-release contains the protocol definitions and Go type definitions for list resources, which are a new type of resource. ([#512](https://github.com/hashicorp/terraform-plugin-go/issues/512))
-* A `ProviderServerWithListResource` can be used with the `terraform query` subcommand in Terraform 1.13.0-alpha20250708 and later to search unmanaged infrastructure. ([#512](https://github.com/hashicorp/terraform-plugin-go/issues/512))
-* The list resource protocol definitions are considered experimental and may change up until general availability. ([#512](https://github.com/hashicorp/terraform-plugin-go/issues/512))
-* tfprotov5+tfprotov6: An upcoming release will require the `ValidateListResourceConfig` and `ListResource` implementations as part of `ProviderServer`. ([#514](https://github.com/hashicorp/terraform-plugin-go/issues/514))
-

--- a/.changes/unreleased/NOTES-20250703-163629.yaml
+++ b/.changes/unreleased/NOTES-20250703-163629.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: This alpha pre-release contains the protocol definitions and Go type definitions for list resources, which are a new type of resource.
+time: 2025-07-03T16:36:29.624307-04:00
+custom:
+    Issue: "512"

--- a/.changes/unreleased/NOTES-20250703-163637.yaml
+++ b/.changes/unreleased/NOTES-20250703-163637.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: A `ProviderServerWithListResource` can be used with the `terraform query` subcommand in Terraform 1.13.0-alpha20250708 and later to search unmanaged infrastructure.
+time: 2025-07-03T16:36:37.158621-04:00
+custom:
+    Issue: "512"

--- a/.changes/unreleased/NOTES-20250703-163653.yaml
+++ b/.changes/unreleased/NOTES-20250703-163653.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: The list resource protocol definitions are considered experimental and may change up until general availability.
+time: 2025-07-03T16:36:53.905091-04:00
+custom:
+    Issue: "512"

--- a/.changes/unreleased/NOTES-20250703-163708.yaml
+++ b/.changes/unreleased/NOTES-20250703-163708.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: 'tfprotov5+tfprotov6: An upcoming release will require the `ValidateListResourceConfig` and `ListResource` implementations as part of `ProviderServer`.'
+time: 2025-07-03T16:37:08.835514-04:00
+custom:
+    Issue: "514"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,3 @@
-## 0.29.0-alpha.1 (July 08, 2025)
-
-NOTES:
-
-* This alpha pre-release contains the protocol definitions and Go type definitions for list resources, which are a new type of resource. ([#512](https://github.com/hashicorp/terraform-plugin-go/issues/512))
-* A `ProviderServerWithListResource` can be used with the `terraform query` subcommand in Terraform 1.13.0-alpha20250708 and later to search unmanaged infrastructure. ([#512](https://github.com/hashicorp/terraform-plugin-go/issues/512))
-* The list resource protocol definitions are considered experimental and may change up until general availability. ([#512](https://github.com/hashicorp/terraform-plugin-go/issues/512))
-* tfprotov5+tfprotov6: An upcoming release will require the `ValidateListResourceConfig` and `ListResource` implementations as part of `ProviderServer`. ([#514](https://github.com/hashicorp/terraform-plugin-go/issues/514))
-
 ## 0.28.0 (May 21, 2025)
 
 BREAKING CHANGES:


### PR DESCRIPTION
Reverts hashicorp/terraform-plugin-go#535, because the Release action wants to run `changie batch` for us.