### PR TITLE
Sarah's updates to f-pluggable-state-store

### DIFF
--- a/tfprotov6/state_store.go
+++ b/tfprotov6/state_store.go
@@ -57,7 +57,16 @@ type ReadStateBytesStream struct {
 }
 
 type WriteStateBytesStream struct {
-	Chunks iter.Seq2[WriteStateByteChunk, error]
+	Messages iter.Seq[WriteStateBytesStreamMsg]
+}
+
+// WriteStateBytesStreamMsg contains paired data:
+//  1. A chunk of state data, received from Terraform core to be persisted.
+//  2. Any gRPC-related errors the provider server encountered when
+//     receiving data from Terraform core.
+type WriteStateBytesStreamMsg struct {
+	Chunk WriteStateByteChunk
+	Err   error
 }
 
 type WriteStateBytesResponse struct {

--- a/tfprotov6/state_store.go
+++ b/tfprotov6/state_store.go
@@ -57,7 +57,7 @@ type ReadStateBytesStream struct {
 }
 
 type WriteStateBytesStream struct {
-	Chunks iter.Seq[WriteStateByteChunk]
+	Chunks iter.Seq2[WriteStateByteChunk, error]
 }
 
 type WriteStateBytesResponse struct {

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -1655,8 +1655,7 @@ func (s *server) WriteStateBytes(srv grpc.ClientStreamingServer[tfplugin6.WriteS
 				logging.ProtocolError(ctx, fmt.Sprintf(
 					"WriteStateBytes experienced an error when receiving state data from Terraform: %s",
 					err,
-				),
-				)
+				))
 			}
 
 			ok := yield(tfprotov6.WriteStateByteChunk{

--- a/tfprotov6/tf6server/server.go
+++ b/tfprotov6/tf6server/server.go
@@ -1649,7 +1649,7 @@ func (s *server) WriteStateBytes(srv grpc.ClientStreamingServer[tfplugin6.WriteS
 		for {
 			chunk, err := srv.Recv()
 			if err == io.EOF {
-				break
+				return
 			}
 			if err != nil {
 				logging.ProtocolError(ctx, fmt.Sprintf(


### PR DESCRIPTION
## Related Issue

N/A

## Description

This PR updates `WriteStateBytes`'s implementation so that users can receive any gRPC errors that arose when receiving state data from Terraform core. This allows provider implementations to have custom logic for handling errors that might happen partway though streaming in state data (clean up, etc).

Alternative solutions can be seen in the commit history - we explored using iter.Seq2 but instead decided to use iter.Seq with a struct that contains multiple pieces of information. This follows a pattern already used in terraform-exec and means consumers of terraform-plugin-go benefit from the named fields and any associated go doc comments when understanding the contents of the streamed message.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
