### PR TITLE
Update Go version in go.mod to 1.25.0

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.25.8
+go 1.25.0
 
 require (
 	github.com/hashicorp/copywrite v0.25.3


### PR DESCRIPTION
## Related Issue

Fixes # 

## Description

Making this a major go version required instead of a minor

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
